### PR TITLE
Fix numpy warning if val is numpy array

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -85,7 +85,7 @@ class Config(MutableMapping):
 
     def __getattr__(self, key):
         val = self.content.get(key)
-        if val == '???':
+        if type(val) == str and val == '???':
             raise MissingMandatoryValue(key)
         return self._resolve_single(val) if isinstance(val, str) else val
 


### PR DESCRIPTION
When comparing numpy array to string, numpy throws a warning. See: https://stackoverflow.com/a/46721064/9654319