### PR TITLE
If passing an env var value that can be parsed with yaml, pass it through parsed

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -14,7 +14,7 @@ from .config import Config
 def register_default_resolvers():
     def env(key):
         try:
-            return os.environ[key]
+            return yaml.safe_load(os.environ[key])
         except KeyError:
             raise KeyError("Environment variable '{}' not found".format(key))
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -156,6 +156,34 @@ def test_env_interpolation_not_found():
         c.path
 
 
+@pytest.mark.parametrize("value,expected", [
+   ("false", False),
+   ("off", False),
+   ("no", False),
+   ("true", True),
+   ("on", True),
+   ("yes", True),
+   ("10", 10),
+   ("-10", -10),
+   ("10.0", 10.0),
+   ("-10.0", -10.0),
+   ("foo: bar", {'foo': 'bar'}),
+   ("foo: \n - bar\n - baz", {'foo': ['bar', 'baz']}),
+])
+def test_values_from_env_come_parsed(value, expected):
+    try:
+        os.environ["my_key"] = value
+        c = OmegaConf.create(
+            dict(
+                my_key="${env:my_key}",
+            )
+        )
+        assert c.my_key == expected
+    finally:
+        del os.environ["my_key"]
+        OmegaConf.clear_resolvers()
+
+
 def test_register_resolver_twice_error():
     try:
         OmegaConf.register_resolver("foo", lambda: 10)


### PR DESCRIPTION
Really useful project!

This helps keep parity when you merge multiple configs, one that defines
values as bools in YAML and another one that interpolates these boolean
values from the environment

I have noticed that you have added other `NodeTypes` but haven't used them, so please tell me if this is not how you planned this to happen and I'll update accordingly. 