### PR TITLE
Support passing variable number of arguments to resolvers.

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -255,6 +255,26 @@ This example creates a resolver that adds 10 the the given value.
     1000
 
 
+Custom resolvers support variadic argument lists in the form of a comma separated list of zero or more values (coming in OmegaConf 1.3.1).
+Whitespaces are stripped from both ends of each value ("foo,bar" is the same as "foo, bar ").
+You can use literal commas and spaces anywhere by escaping (:code:`\,` and :code:`\ `).
+.. doctest::
+
+    >>> OmegaConf.register_resolver("concat", lambda x,y: x+y)
+    >>> c = OmegaConf.create({
+    ...     'key1': '${concat:Hello,World}',
+    ...     'key_trimmed': '${concat:Hello , World}',
+    ...     'escape_whitespace': '${concat:Hello,\ World}',
+    ... })
+    >>> c.key1
+    'HelloWorld'
+    >>> c.key_trimmed
+    'HelloWorld'
+    >>> c.escape_whitespace
+    'Hello World'
+
+
+
 Merging configurations
 ----------------------
 Merging configurations enables the creation of reusable configuration files for each logical component

--- a/omegaconf/config.py
+++ b/omegaconf/config.py
@@ -416,7 +416,9 @@ class Config(object):
         return ret
 
     def _resolve_single(self, value):
-        match_list = list(re.finditer(r"\${(\w+:)?([\w\.%_-]+?)}", value))
+        key_prefix = r"\${(\w+:)?"
+        legal_characters = r"([\w\.%_ \\,-]*?)}"
+        match_list = list(re.finditer(key_prefix+legal_characters, value))
         if len(match_list) == 0:
             return value
 

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -245,6 +245,23 @@ def test_read_write_override(src, func, expectation):
             func(c)
 
 
+@pytest.mark.parametrize('string, tokenized', [
+    ('dog,cat', ['dog', 'cat']),
+    ('dog\,cat\ ', ['dog,cat ']),
+    ('dog,\ cat', ['dog', ' cat']),
+    ('\ ,cat', [' ', 'cat']),
+    ('dog, cat', ['dog', 'cat']),
+    ('dog, ca t', ['dog', 'ca t']),
+    ('dog, cat', ['dog', 'cat']),
+    ('whitespace\ , before comma', ['whitespace ', 'before comma']),
+    (None, []),
+    ('', []),
+    ('no , escape', ['no', 'escape']),
+])
+def test_tokenize_with_escapes(string, tokenized):
+    assert OmegaConf._tokenize_args(string) == tokenized
+
+
 @pytest.mark.parametrize('src, func, expectation', [
     ({}, lambda c: c.__setattr__('foo', 1), pytest.raises(KeyError)),
 ])

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -233,7 +233,7 @@ def test_resolver_cache_1():
 
 def test_resolver_cache_2():
     """
-    Tests that resolver cache is not shared between different OmegaConf objects 
+    Tests that resolver cache is not shared between different OmegaConf objects
     """
     try:
         OmegaConf.register_resolver("random", lambda _: random.randint(0, 10000000))
@@ -246,6 +246,21 @@ def test_resolver_cache_2():
         assert c1.k != c2.k
         assert c1.k == c1.k
         assert c2.k == c2.k
+    finally:
+        OmegaConf.clear_resolvers()
+
+
+@pytest.mark.parametrize('resolver,name,key,result', [
+    (lambda *args: args, 'arg_list', "${my_resolver:cat, dog}",("cat", "dog")),
+    (lambda *args: args, 'escape_comma',"${my_resolver:cat\, do g}",("cat, do g",)),
+    (lambda *args: args, 'escape_whitespace',"${my_resolver:cat\, do g}",("cat, do g",)),
+    (lambda: 'zero', 'zero_arg',"${my_resolver:}",("zero")),
+])
+def test_resolver_that_allows_a_list_of_arguments(resolver, name, key, result):
+    try:
+        OmegaConf.register_resolver('my_resolver', resolver)
+        c = OmegaConf.create({name: key})
+        assert c[name] == result
     finally:
         OmegaConf.clear_resolvers()
 


### PR DESCRIPTION
This PR adds the ability to pass in 0 or more arguments to resolvers:
```
${foo:}               # zero arguments
${foo:a}              # one argument (currently supported)
${foo:a,b,..,n}       # n arguments
```