### PR TITLE
Bugfix/sometimes envvars begin with yaml special chars

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -15,9 +15,13 @@ from .config import Config
 def register_default_resolvers():
     def env(key):
         try:
-            return yaml.safe_load(os.environ[key])
+            value = os.environ[key]
         except KeyError:
             raise KeyError("Environment variable '{}' not found".format(key))
+        try:
+            return yaml.safe_load(value)
+        except yaml.scanner.ScannerError:
+            return value
 
     OmegaConf.register_resolver('env', env)
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -147,6 +147,22 @@ def test_env_interpolation1():
         del os.environ['foobar']
         OmegaConf.clear_resolvers()
 
+@pytest.mark.parametrize('value', [
+    '>1234',
+    ':1234',
+    '/1234',
+])
+def test_env_string_val_but_invalid_yaml(value):
+    try:
+        os.environ['foobar'] = value
+        c = OmegaConf.create(dict(
+            path='${env:foobar}',
+        ))
+        assert c.path == value
+    finally:
+        del os.environ['foobar']
+        OmegaConf.clear_resolvers()
+
 
 def test_env_interpolation_not_found():
     c = OmegaConf.create(dict(
@@ -154,6 +170,7 @@ def test_env_interpolation_not_found():
     ))
     with pytest.raises(KeyError):
         c.path
+
 
 
 @pytest.mark.parametrize("value,expected", [


### PR DESCRIPTION
If your secrets begin with characters like :, >, / and you use
the env resolver, it can cause quite a lot of havoc. This is one
pass at a solution for it