### PR TITLE
Read-only list can no longer be replaced with command line override 

### DIFF
--- a/news/39.bugfix
+++ b/news/39.bugfix
@@ -1,0 +1,1 @@
+Read-only list can no longer be replaced with command line override

--- a/news/72.bugfix
+++ b/news/72.bugfix
@@ -1,0 +1,1 @@
+Config.merge_with_dotlist() now throws if input is not a list or tuple of strings

--- a/omegaconf/config.py
+++ b/omegaconf/config.py
@@ -166,7 +166,10 @@ class Config(object):
                             break
             elif isinstance(parent, ListConfig):
                 if child is None:
-                    full_key = "[{}]".format(key)
+                    if key == "":
+                        full_key = key
+                    else:
+                        full_key = "[{}]".format(key)
                 else:
                     for idx, v in enumerate(parent):
                         if id(v) == id(child):
@@ -415,6 +418,9 @@ class Config(object):
             if isinstance(self, DictConfig) and isinstance(other, DictConfig):
                 Config._map_merge(self, other)
             elif isinstance(self, ListConfig) and isinstance(other, ListConfig):
+                if self._get_flag("readonly"):
+                    raise ReadonlyConfigError(self.get_full_key(""))
+
                 self.__dict__["content"] = copy.deepcopy(other.content)
             else:
                 raise TypeError("Merging DictConfig with ListConfig is not supported")

--- a/omegaconf/config.py
+++ b/omegaconf/config.py
@@ -245,7 +245,16 @@ class Config(object):
         self.merge_with_dotlist(args_list)
 
     def merge_with_dotlist(self, dotlist):
+        def fail():
+            raise ValueError("Input list must be a list or a tuple of strings")
+
+        if not isinstance(dotlist, (list, tuple)):
+            fail()
+
         for arg in dotlist:
+            if not isinstance(arg, str):
+                fail()
+
             idx = arg.find("=")
             if idx == -1:
                 key = arg

--- a/tests/test_readonly.py
+++ b/tests/test_readonly.py
@@ -133,3 +133,11 @@ def test_readonly_list_sort():
     with pytest.raises(ReadonlyConfigError):
         c.sort()
     assert c == [3, 1, 2]
+
+
+def test_readonly_from_cli():
+    c = OmegaConf.create({"foo": {"bar": [1]}})
+    OmegaConf.set_readonly(c, True)
+    cli = OmegaConf.from_dotlist(["foo.bar=[2]"])
+    with pytest.raises(ReadonlyConfigError, match="foo.bar"):
+        OmegaConf.merge(c, cli)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -174,3 +174,9 @@ def test_merge_with_cli():
     sys.argv = ["app.py", "0=bar", "2.a=100"]
     c.merge_with_cli()
     assert c == ["bar", 2, dict(a=100)]
+
+
+def test_merge_with_dotlist_list_only():
+    c = OmegaConf.create({})
+    with pytest.raises(ValueError):
+        c.merge_with_dotlist("foo=10")


### PR DESCRIPTION
* Read-only list can no longer be replaced with command line override 
* Config.merge_with_dotlist() now throws if input is not a list or tuple of strings 