### PR TITLE
env resolver no longer parsing yaml strings 

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -15,7 +15,7 @@ from .config import Config
 def register_default_resolvers():
     def env(key):
         try:
-            return yaml.safe_load(os.environ[key])
+            return decode_primitive(os.environ[key])
         except KeyError:
             raise KeyError("Environment variable '{}' not found".format(key))
 
@@ -251,3 +251,34 @@ def open_dict(config):
         yield config
     finally:
         OmegaConf.set_struct(config, prev_state)
+
+
+def decode_primitive(s):
+    def is_bool(st):
+        st = str.lower(st)
+        return st == "true" or st == "false"
+
+    def is_float(st):
+        try:
+            float(st)
+            return True
+        except ValueError:
+            return False
+
+    def is_int(s):
+        try:
+            int(s)
+            return True
+        except ValueError:
+            return False
+
+    if is_bool(s):
+        return str.lower(s) == "true"
+
+    if is_int(s):
+        return int(s)
+
+    if is_float(s):
+        return float(s)
+
+    return s

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -140,21 +140,29 @@ def test_env_interpolation_not_found():
 @pytest.mark.parametrize(
     "value,expected",
     [
+        # bool
         ("false", False),
-        ("off", False),
-        ("no", False),
         ("true", True),
-        ("on", True),
-        ("yes", True),
+        # int
         ("10", 10),
         ("-10", -10),
+        # float
         ("10.0", 10.0),
         ("-10.0", -10.0),
-        ("foo: bar", {"foo": "bar"}),
-        ("foo: \n - bar\n - baz", {"foo": ["bar", "baz"]}),
+        # strings
+        ("off", "off"),
+        ("no", "no"),
+        ("on", "on"),
+        ("yes", "yes"),
+        (">1234", ">1234"),
+        (":1234", ":1234"),
+        ("/1234", "/1234"),
+        # yaml strings are not getting parsed by the env resolver
+        ("foo: bar", "foo: bar"),
+        ("foo: \n - bar\n - baz", "foo: \n - bar\n - baz"),
     ],
 )
-def test_values_from_env_come_parsed(value, expected):
+def test_env_values_are_typed(value, expected):
     try:
         os.environ["my_key"] = value
         c = OmegaConf.create(dict(my_key="${env:my_key}",))


### PR DESCRIPTION
No longer using yaml parser to decode environment variables as it causes issues for strings that are not valid yaml.