### PR TITLE
`in` operator should only return false if key is actually missing.

### DIFF
--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -142,9 +142,9 @@ def test_dict_keys():
 def test_pickle_get_root():
     # Test that get_root() is reconstructed correctly for pickle loaded files.
     with tempfile.TemporaryFile() as fp:
-        c1 = OmegaConf.create(dict(a=dict(a1=1, a2=2,),))
+        c1 = OmegaConf.create(dict(a=dict(a1=1, a2=2)))
 
-        c2 = OmegaConf.create(dict(b=dict(b1="???", b2=4, bb=dict(bb1=3, bb2=4,),),))
+        c2 = OmegaConf.create(dict(b=dict(b1="???", b2=4, bb=dict(bb1=3, bb2=4))))
         c3 = OmegaConf.merge(c1, c2)
 
         import pickle
@@ -193,6 +193,8 @@ def test_dict_pop():
         ({"a": 1, "b": "???", "c": "${b}"}, "c", False),
         ({"a": 1, "b": "${not_found}"}, "b", False),
         ({"a": "${unknown_resolver:bar}"}, "a", True),
+        ({"a": None, "b": "${a}"}, "b", True),
+        ({"a": "cat", "b": "${a}"}, "b", True),
     ],
 )
 def test_in_dict(conf, key, expected):
@@ -202,15 +204,15 @@ def test_in_dict(conf, key, expected):
 
 
 def test_get_root():
-    c = OmegaConf.create(dict(a=123, b=dict(bb=456, cc=7,),))
+    c = OmegaConf.create(dict(a=123, b=dict(bb=456, cc=7)))
     assert c._get_root() == c
     assert c.b._get_root() == c
 
 
 def test_get_root_of_merged():
-    c1 = OmegaConf.create(dict(a=dict(a1=1, a2=2,),))
+    c1 = OmegaConf.create(dict(a=dict(a1=1, a2=2)))
 
-    c2 = OmegaConf.create(dict(b=dict(b1="???", b2=4, bb=dict(bb1=3, bb2=4,),),))
+    c2 = OmegaConf.create(dict(b=dict(b1="???", b2=4, bb=dict(bb1=3, bb2=4))))
     c3 = OmegaConf.merge(c1, c2)
 
     assert c3._get_root() == c3
@@ -273,7 +275,7 @@ def test_to_container(src):
 
 
 def test_pretty_without_resolve():
-    c = OmegaConf.create(dict(a1="${ref}", ref="bar",))
+    c = OmegaConf.create(dict(a1="${ref}", ref="bar"))
     # without resolve, references are preserved
     c2 = OmegaConf.create(c.pretty(resolve=False))
     assert c2.a1 == "bar"
@@ -282,7 +284,7 @@ def test_pretty_without_resolve():
 
 
 def test_pretty_with_resolve():
-    c = OmegaConf.create(dict(a1="${ref}", ref="bar",))
+    c = OmegaConf.create(dict(a1="${ref}", ref="bar"))
     c2 = OmegaConf.create(c.pretty(resolve=True))
     assert c2.a1 == "bar"
     c2.ref = "changed"
@@ -315,7 +317,7 @@ def test_dir():
         # nested list
         (dict(a=12, b=[1, 2, 3]), dict(a=12, b=[1, 2, 3])),
         # nested list with any
-        (dict(a=12, b=[1, 2, UntypedNode(3)]), dict(a=12, b=[1, 2, UntypedNode(3)]),),
+        (dict(a=12, b=[1, 2, UntypedNode(3)]), dict(a=12, b=[1, 2, UntypedNode(3)])),
         # In python 3.6 insert order changes iteration order. this ensures that equality is preserved.
         (dict(a=1, b=2, c=3, d=4, e=5), dict(e=5, b=2, c=3, d=4, a=1)),
     ],
@@ -360,7 +362,7 @@ def test_dict_eq_with_interpolation(input1, input2):
         (dict(a=12, b=dict()), dict(a=13, b=dict())),
         (dict(a=12, b=dict(c=10)), dict(a=13, b=dict(c=10))),
         (dict(a=12, b=[1, 2, 3]), dict(a=12, b=[10, 2, 3])),
-        (dict(a=12, b=[1, 2, UntypedNode(3)]), dict(a=12, b=[1, 2, UntypedNode(30)]),),
+        (dict(a=12, b=[1, 2, UntypedNode(3)]), dict(a=12, b=[1, 2, UntypedNode(30)])),
     ],
 )
 def test_dict_not_eq(input1, input2):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -2,6 +2,19 @@ from omegaconf import OmegaConf
 from pytest import raises
 
 
+def test_dereference_key():
+    c = OmegaConf.create(
+        {"foo": 10, "bar": "${nested.value}", "nested": {"value": 5}, "list": [1]}
+    )
+    assert c._dereference_key("nested.value") == "nested.value"
+    assert c._dereference_key("foo") == "foo"
+    assert c._dereference_key("bar") == "bar"
+    assert c._dereference_key("list.0") == "list.0"
+    assert c._dereference_key("list.1") is None
+    assert c._dereference_key("not.there") is None
+    assert c._dereference_key("nested.there") is None
+
+
 def test_select_key_from_empty():
     c = OmegaConf.create()
     assert c.select("not_there") is None
@@ -14,7 +27,7 @@ def test_select_dotkey_from_empty():
 
 
 def test_select_from_dict():
-    c = OmegaConf.create(dict(a=dict(v=1), b=dict(v=1),))
+    c = OmegaConf.create(dict(a=dict(v=1), b=dict(v=1)))
 
     assert c.select("a") == {"v": 1}
     assert c.select("a.v") == 1


### PR DESCRIPTION
Addresses #80. I'm not sure if I like the solution with a sentinel, but seems to be in line with your philosophy of doing minimum possible changes

Do you see a better way other than special_casing the `select()` behaviour? It seems like is used in more than one way