### PR TITLE
1.4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,39 @@
+## 1.4.0 (2019-11-19)
+
+
+Features
+--------
+
+- ListConfig now implements + operator (Allowing concatenation with other ListConfigs) (#36)
+- OmegaConf.save() now takes a resolve flag (defaults False) (#37)
+- Add OmegaConf.masked_copy(keys) function that returns a copy of a config with a subset of the keys (#42)
+- Improve built-in env resolver to return properly typed values ("1" -> int, "1.0" -> float etc) (#44)
+- Resolvers can now accept a list of zero or more arguments, for example: "${foo:a,b,..,n}" (#46)
+- Change semantics of contains check ('x' in conf): Missing mandatory values ('???') are now considered not included and contains test returns false for them (#49)
+- Allow assignment of a tuple value into a Config (#74)
+
+Bug Fixes
+---------
+
+- Read-only list can no longer be replaced with command line override (#39)
+- Fix an error when expanding an empty dictionary in PyCharm debugger (#40)
+- Fix a bug in open_dict causing improper restoration of struct flag in some cases (#47)
+- Fix a bug preventing dotlist values from containing '=' (foo=bar=10 -> key: foo, value: bar=10) (#56)
+- Config.merge_with_dotlist() now throws if input is not a list or tuple of strings (#72)
+- Add copy method for DictConfig and improve shallow copy support (#82)
+
+Deprecations and Removals
+-------------------------
+
+- Deprecated Config.to_container() in favor of OmegaConf.to_container() (#41)
+- Deprecated config.save(file) in favor of OmegaConf.save(config, file) (#66)
+- Remove OmegaConf.{empty(), from_string(), from_dict(), from_list()}. Use OmegaConf.create() (deprecated since 1.1.5) (#67)
+- Remove Config.merge_from(). Use Config.merge_with() (deprecated since 1.1.0) (#67)
+- Remove OmegaConf.from_filename() and OmegaConf.from_file(). Use OmegaConf.load() (deprecated since 1.1.5) (#67)
+
+Miscellaneous changes
+---------------------
+
+- Switch from tox to nox for test automation (#54)
+- Formatting code with Black (#54)
+- Switch from Travis to CircleCI for CI (#54)

--- a/news/36.feature
+++ b/news/36.feature
@@ -1,1 +1,0 @@
-ListConfig now implements + operator (Allowing concatenation with other ListConfigs)

--- a/news/37.feature
+++ b/news/37.feature
@@ -1,1 +1,0 @@
-OmegaConf.save() now takes a resolve flag (defaults False)

--- a/news/39.bugfix
+++ b/news/39.bugfix
@@ -1,1 +1,0 @@
-Read-only list can no longer be replaced with command line override

--- a/news/40.bugfix
+++ b/news/40.bugfix
@@ -1,1 +1,0 @@
-Fix an error when expanding an empty dictionary in PyCharm debugger

--- a/news/41.removal
+++ b/news/41.removal
@@ -1,1 +1,0 @@
-Deprecated Config.to_container() in favor of OmegaConf.to_container()

--- a/news/42.feature
+++ b/news/42.feature
@@ -1,1 +1,0 @@
-Add OmegaConf.masked_copy(keys) function that returns a copy of a config with a subset of the keys

--- a/news/44.feature
+++ b/news/44.feature
@@ -1,1 +1,0 @@
-Improve built-in env resolver to return properly typed values ("1" -> int, "1.0" -> float etc)

--- a/news/46.feature
+++ b/news/46.feature
@@ -1,1 +1,0 @@
-Resolvers can now accept a list of zero or more arguments, for example: "${foo:a,b,..,n}"

--- a/news/47.bugfix
+++ b/news/47.bugfix
@@ -1,1 +1,0 @@
-Fixes a bug in open_dict causing improper restoration of struct flag in some cases

--- a/news/49.feature
+++ b/news/49.feature
@@ -1,1 +1,0 @@
-Change semantics of contains check ('x' in conf): Missing mandatory values ('???') are now considered not included and contains test returns false for them

--- a/news/54.misc.1
+++ b/news/54.misc.1
@@ -1,1 +1,0 @@
-Formatting code with Black

--- a/news/54.misc.2
+++ b/news/54.misc.2
@@ -1,1 +1,0 @@
-Switched from tox to nox for test automation

--- a/news/54.misc.3
+++ b/news/54.misc.3
@@ -1,1 +1,0 @@
-Switched from Travis to CircleCI for CI

--- a/news/56.bugfix
+++ b/news/56.bugfix
@@ -1,1 +1,0 @@
-Fixes a bug preventing dotlist values from containing '=' (foo=bar=10 -> key: foo, value: bar=10)

--- a/news/66.removal
+++ b/news/66.removal
@@ -1,1 +1,0 @@
-Deprecated config.save(file) in favor of OmegaConf.save(config, file)

--- a/news/67.removal.1
+++ b/news/67.removal.1
@@ -1,1 +1,0 @@
-Remove OmegaConf.{empty(), from_string(), from_dict(), from_list()}. Use OmegaConf.create() (deprecated since 1.1.5)

--- a/news/67.removal.2
+++ b/news/67.removal.2
@@ -1,1 +1,0 @@
-Remove OmegaConf.from_filename() and OmegaConf.from_file(). Use OmegaConf.load() (deprecated since 1.1.5)

--- a/news/67.removal.3
+++ b/news/67.removal.3
@@ -1,1 +1,0 @@
-Remove Config.merge_from(). Use Config.merge_with() (deprecated since 1.1.0)

--- a/news/72.bugfix
+++ b/news/72.bugfix
@@ -1,1 +1,0 @@
-Config.merge_with_dotlist() now throws if input is not a list or tuple of strings

--- a/news/74.feature
+++ b/news/74.feature
@@ -1,1 +1,0 @@
-Allow assignment of a tuple value into a Config

--- a/news/82.bugfix
+++ b/news/82.bugfix
@@ -1,1 +1,0 @@
-Add copy method for DictConfig and improve shallow copy support

--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -12,7 +12,7 @@ from .nodes import (
     FloatNode,
 )
 
-__version__ = "1.4.0rc4"
+__version__ = "1.4.0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## 1.4.0 (2019-11-19)


Features
--------

- ListConfig now implements + operator (Allowing concatenation with other ListConfigs) (#36)
- OmegaConf.save() now takes a resolve flag (defaults False) (#37)
- Add OmegaConf.masked_copy(keys) function that returns a copy of a config with a subset of the keys (#42)
- Improve built-in env resolver to return properly typed values ("1" -> int, "1.0" -> float etc) (#44)
- Resolvers can now accept a list of zero or more arguments, for example: "${foo:a,b,..,n}" (#46)
- Change semantics of contains check ('x' in conf): Missing mandatory values ('???') are now considered not included and contains test returns false for them (#49)
- Allow assignment of a tuple value into a Config (#74)

Bug Fixes
---------

- Read-only list can no longer be replaced with command line override (#39)
- Fix an error when expanding an empty dictionary in PyCharm debugger (#40)
- Fix a bug in open_dict causing improper restoration of struct flag in some cases (#47)
- Fix a bug preventing dotlist values from containing '=' (foo=bar=10 -> key: foo, value: bar=10) (#56)
- Config.merge_with_dotlist() now throws if input is not a list or tuple of strings (#72)
- Add copy method for DictConfig and improve shallow copy support (#82)

Deprecations and Removals
-------------------------

- Deprecated Config.to_container() in favor of OmegaConf.to_container() (#41)
- Deprecated config.save(file) in favor of OmegaConf.save(config, file) (#66)
- Remove OmegaConf.{empty(), from_string(), from_dict(), from_list()}. Use OmegaConf.create() (deprecated since 1.1.5) (#67)
- Remove Config.merge_from(). Use Config.merge_with() (deprecated since 1.1.0) (#67)
- Remove OmegaConf.from_filename() and OmegaConf.from_file(). Use OmegaConf.load() (deprecated since 1.1.5) (#67)

Miscellaneous changes
---------------------

- Switch from tox to nox for test automation (#54)
- Formatting code with Black (#54)
- Switch from Travis to CircleCI for CI (#54)