### PR TITLE
Fix bug in FloatNode.__eq__

### DIFF
--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -85,7 +85,11 @@ class FloatNode(BaseNode):
         else:
             other_val = other
 
-        return self.val == other_val or (math.isnan(self.val) and math.isnan(other_val))
+        if self.val == other_val:
+            return True
+        if not hasattr(self.val, "__float__") or not hasattr(other_val, "__float__"):
+            return False
+        return math.isnan(self.val) and math.isnan(other_val)
 
 
 class BooleanNode(BaseNode):

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -66,6 +66,10 @@ class IntegerNode(BaseNode):
             )
 
 
+def is_floatlike(x):
+    return hasattr(x, "__float__")
+
+
 class FloatNode(BaseNode):
     def __init__(self, value=None):
         self.val = None
@@ -87,7 +91,7 @@ class FloatNode(BaseNode):
 
         if self.val == other_val:
             return True
-        if not hasattr(self.val, "__float__") or not hasattr(other_val, "__float__"):
+        if not is_floatlike(self.val) or not is_floatlike(other_val):
             return False
         return math.isnan(self.val) and math.isnan(other_val)
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -177,3 +177,18 @@ def test_merge_validation_error(c1, c2):
     # make sure that conf1 and conf2 were not modified
     assert conf1 == OmegaConf.create(c1)
     assert conf2 == OmegaConf.create(c2)
+
+
+@pytest.mark.parametrize(
+    "type_,input_,target,expected",
+    [
+        (FloatNode, None, 1, False),
+        (FloatNode, "1", 1, True),
+        (FloatNode, float("nan"), float("nan"), True),
+        (FloatNode, None, float("nan"), False),
+    ],
+)
+def test_eq(type_, input_, target, expected):
+    node = type_(input_)
+    assert (node == target) == expected
+


### PR DESCRIPTION
from #89 

Before this PR, the following code raises
```python
from omegaconf.nodes import FloatNode

x = FloatNode()
x == 1
```

After this PR, not raise.