### PR TITLE
Fix disable automatic conversion of date strings in yaml decoding

### DIFF
--- a/news/95.bugfix
+++ b/news/95.bugfix
@@ -1,0 +1,1 @@
+Disable automatic conversion of date strings in `from_dotlist`

--- a/news/95.bugfix
+++ b/news/95.bugfix
@@ -1,1 +1,1 @@
-Disable automatic conversion of date strings in `from_dotlist`
+Disable automatic conversion of date strings in yaml decoding

--- a/omegaconf/config.py
+++ b/omegaconf/config.py
@@ -39,6 +39,14 @@ def get_yaml_loader():
         ),
         list(u"-+0123456789."),
     )
+    loader.yaml_implicit_resolvers = {
+        key: [
+            (tag, regexp)
+            for tag, regexp in resolvers
+            if tag != u"tag:yaml.org,2002:timestamp"
+        ]
+        for key, resolvers in loader.yaml_implicit_resolvers.items()
+    }
     return loader
 
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -50,7 +50,15 @@ def test_cli_passing():
 
 
 @pytest.mark.parametrize(
-    "input_, expected", [(["a=1", "b.c=2"], dict(a=1, b=dict(c=2)))]
+    "input_, expected",
+    [
+        # simple
+        (["a=1", "b.c=2"], dict(a=1, b=dict(c=2))),
+        # string
+        (["a=hello", "b=world"], dict(a="hello", b="world")),
+        # date-formatted string
+        (["my_date=2019-12-11"], dict(my_date="2019-12-11")),
+    ],
 )
 def test_dotlist(input_, expected):
     c = OmegaConf.from_dotlist(input_)


### PR DESCRIPTION
Fixes #95 by removing timestamp implicit resolver in yaml loader. 
```
In [3]:  OmegaConf.from_dotlist(["my_date=2019-11-11"])
Out[3]: {'my_date': '2019-11-11'}
```