### PR TITLE
Compact key support

### DIFF
--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -257,6 +257,8 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
             self._format_and_raise(key=key, value=value, cause=e)
 
     def __set_impl(self, key: Union[str, Enum], value: Any) -> None:
+        from omegaconf import ListConfig
+
         if isinstance(key, str):
             sub_keys = key.split(".")
             cur = self
@@ -267,6 +269,10 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
                     # last key
                     if isinstance(cur, DictConfig):
                         cur.__set_single_key_val_impl(key=k, value=value)
+                    elif isinstance(cur, ListConfig):
+                        raise CompactKeyError(
+                            "Compact keys does not support ListConfig"
+                        )
                     else:
                         raise CompactKeyError(
                             f"Conflict detected inserting compact key '{key}'  "

--- a/omegaconf/errors.py
+++ b/omegaconf/errors.py
@@ -103,3 +103,9 @@ class ConfigValueError(OmegaConfBaseException, ValueError):
     """
     Thrown from a config object when a regular access would have caused a ValueError.
     """
+
+
+class CompactKeyError(ValueError):
+    """
+    Thrown when a compact key usage triggers an error
+    """

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -14,7 +14,6 @@ from omegaconf import (
     ValidationError,
 )
 from omegaconf.basecontainer import BaseContainer
-
 from omegaconf.errors import CompactKeyError, KeyValidationError
 
 from . import (
@@ -26,9 +25,6 @@ from . import (
     User,
     does_not_raise,
 )
-
-
-from . import IllegalType, StructuredWithMissing, does_not_raise, Enum1
 
 
 def test_setattr_deep_value() -> None:

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -652,7 +652,13 @@ def test_assign_to_reftype_plugin(
         ({"a.aa": {"aaa": 10, "bbb": 20}}, {"a": {"aa": {"aaa": 10, "bbb": 20}}}),
         ({"a.aa": 10, "a.aa.b": 10}, pytest.raises(CompactKeyError)),
         ({"a": {"aa.aaa": 10, "aa.bbb": 20}}, {"a": {"aa": {"aaa": 10, "bbb": 20}}}),
+        (
+            {"a.bb.ccc": 10, "a.BB": {"ddd": 20, "eee": 30}},
+            {"a": {"bb": {"ccc": 10}, "BB": {"ddd": 20, "eee": 30}}},
+        ),
         ({"a..aa": 10}, pytest.raises(CompactKeyError)),
+        ({"a": [1, 2, 3], "a.1": 10}, pytest.raises(CompactKeyError)),
+        ({"a.1": 10}, {"a": {"1": 10}}),
     ],
 )
 def test_compact_keys(inp: Any, expected: Any) -> None:


### PR DESCRIPTION
TODO:

- [ ] documentation
- [ ] compact pretty print() by default. flag to turn it off.
- [ ] convenience function to convert to standard yaml
- [ ] ability to disable compact keys while creating a config object (including loading).
- [ ] ability to opt file based on a file header (`#omegaconf:compact_keys=false` for example)


closes #152 