### PR TITLE
merge_with_dotlist now throws AttributeError

### DIFF
--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -183,7 +183,7 @@ class BaseContainer(Container, ABC):
         ), f"Unexpected type for root : {type(root).__name__}"
 
         if isinstance(root, DictConfig):
-            root[last] = value
+            setattr(root, last, value)
         elif isinstance(root, ListConfig):
             idx = int(last)
             root[idx] = value

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -38,7 +38,7 @@ def test_struct_set_on_nested_dict() -> None:
 def test_merge_dotlist_into_struct() -> None:
     c = OmegaConf.create(dict(a=dict(b=10)))
     OmegaConf.set_struct(c, True)
-    with pytest.raises(KeyError, match=re.escape("foo")):
+    with pytest.raises(AttributeError, match=re.escape("foo")):
         c.merge_with_dotlist(["foo=1"])
 
 


### PR DESCRIPTION
merge_with_dotlist now throws AttributeError if in struct mode and key is not found