### PR TITLE
Merge respects node interpolation

### DIFF
--- a/news/184.feature
+++ b/news/184.feature
@@ -1,0 +1,1 @@
+Merge into node interpolation is now by value (copying target node)

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -446,7 +446,8 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):  # type: ignore
         if other is None:
             return self.__dict__["_content"] is None
         if is_primitive_dict(other) or is_structured_config(other):
-            return DictConfig._dict_conf_eq(self, DictConfig(other))
+            other = DictConfig(other)
+            return DictConfig._dict_conf_eq(self, other)
         if isinstance(other, DictConfig):
             return DictConfig._dict_conf_eq(self, other)
         return NotImplemented

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -328,7 +328,8 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, (list, tuple)) or other is None:
-            return ListConfig._list_eq(self, ListConfig(other))
+            other = ListConfig(other)
+            return ListConfig._list_eq(self, other)
         if other is None or isinstance(other, ListConfig):
             return ListConfig._list_eq(self, other)
         return NotImplemented

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -71,15 +71,18 @@ class ValueNode(Node):
 
     def _is_none(self) -> bool:
         node = self._dereference_node()
+        assert node is not None
         return node._value() is None
 
     def _is_optional(self) -> bool:
         node = self._dereference_node()
+        assert node is not None
         return node._metadata.optional
 
     def _is_missing(self) -> bool:
         try:
             node = self._dereference_node(throw_on_missing=True)
+            assert node is not None
             if isinstance(node, Container):
                 ret = node._is_missing()
             else:

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -491,7 +491,10 @@ class OmegaConf:
     @staticmethod
     def select(cfg: Container, key: str, throw_on_missing: bool = False) -> Any:
         try:
-            _root, _last_key, value = cfg._select_impl(key, throw_on_missing=False)
+            # TODO: should be throw_on_missing=throw_on_missing ?
+            _root, _last_key, value = cfg._select_impl(
+                key, throw_on_missing=False, throw_on_resolution_failure=True
+            )
             if value is not None and value._is_missing():
                 if throw_on_missing:
                     raise MissingMandatoryValue("missing node selected")

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -434,7 +434,10 @@ def test_resolve_str_interpolation(query: str, result: Any) -> None:
     cfg = OmegaConf.create({"foo": 10, "bar": "${foo}"})
     assert (
         cfg._resolve_str_interpolation(
-            key=None, value=StringNode(value=query), throw_on_missing=False
+            key=None,
+            value=StringNode(value=query),
+            throw_on_missing=False,
+            throw_on_resolution_failure=True,
         )
         == result
     )

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -88,6 +88,11 @@ from . import ConcretePlugin, ConfWithMissingDict, Group, Plugin, User, Users
             {"v": {"a": 20}, "n": {"a": 20}},
             id="inter:node_inter_over_data",
         ),
+        pytest.param(
+            ({"n": {"a": 10}, "i": "${n}"}, {"i": {"b": 20}}),
+            {"n": {"a": 10}, "i": {"a": 10, "b": 20}},
+            id="inter:node_over_node_interpolation",
+        ),
         # Structured configs
         (({"user": User}, {}), {"user": User(name=MISSING, age=MISSING)}),
         (({"user": User}, {"user": {}}), {"user": User(name=MISSING, age=MISSING)}),

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -36,14 +36,57 @@ from . import ConcretePlugin, ConfWithMissingDict, Group, Plugin, User, Users
         (([[1, 2, 3]], [[4, 5, 6]]), [[4, 5, 6]]),
         (([1, 2, {"a": 10}], [4, 5, {"b": 20}]), [4, 5, {"b": 20}]),
         # Interpolations
-        (
-            ({"data": 123, "reference": "${data}"}, {"data": 456}),
-            {"data": 456, "reference": 456},
+        # value interpolation
+        pytest.param(
+            ({"d1": 1, "inter": "${d1}"}, {"d1": 2}),
+            {"d1": 2, "inter": 2},
+            id="inter:updating_data",
         ),
-        (({"missing": "${data}"}, {"missing": 123}), {"missing": 123}),
-        (
-            ({"missing": 123}, {"missing": "${data}"}, {"missing": 456}),
-            {"missing": 456},
+        pytest.param(
+            ({"d1": 1, "d2": 2, "inter": "${d1}"}, {"inter": "${d2}"}),
+            {"d1": 1, "d2": 2, "inter": 2},
+            id="inter:value_inter_over_value_inter",
+        ),
+        pytest.param(
+            ({"inter": "${d1}"}, {"inter": 123}),
+            {"inter": 123},
+            id="inter:data_over_value_inter",
+        ),
+        pytest.param(
+            ({"inter": "${d1}", "d1": 1, "n1": {"foo": "bar"}}, {"inter": "${n1}"}),
+            {"inter": {"foo": "bar"}, "d1": 1, "n1": {"foo": "bar"}},
+            id="inter:node_inter_over_value_inter",
+        ),
+        pytest.param(
+            ({"inter": 123}, {"inter": "${data}"}),
+            {"inter": "${data}"},
+            id="inter:inter_over_data",
+        ),
+        # node interpolation
+        pytest.param(
+            ({"n": {"a": 10}, "i": "${n}"}, {"n": {"a": 20}}),
+            {"n": {"a": 20}, "i": {"a": 20}},
+            id="node_inter:node_update",
+        ),
+        pytest.param(
+            ({"d": 20, "n": {"a": 10}, "i": "${n}"}, {"i": "${d}"}),
+            {"d": 20, "n": {"a": 10}, "i": 20},
+            id="node_inter:value_inter_over_node_inter",
+        ),
+        pytest.param(
+            ({"n": {"a": 10}, "i": "${n}"}, {"i": 30}),
+            {"n": {"a": 10}, "i": 30},
+            id="node_inter:data_over_node_inter",
+        ),
+        pytest.param(
+            ({"n1": {"a": 10}, "n2": {"b": 20}, "i": "${n1}"}, {"i": "${n2}"}),
+            {"n1": {"a": 10}, "n2": {"b": 20}, "i": {"b": 20}},
+            id="node_inter:node_inter_over_node_inter",
+        ),
+        pytest.param(
+            ({"v": 10, "n": {"a": 20}}, {"v": "${n}"}),
+            {"v": {"a": 20}, "n": {"a": 20}},
+            id="inter:node_inter_over_data",
         ),
         # Structured configs
         (({"user": User}, {}), {"user": User(name=MISSING, age=MISSING)}),

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -120,7 +120,11 @@ from . import ConcretePlugin, ConfWithMissingDict, Group, Plugin, User, Users
             {"name2user": {"joe": {"name": "joe", "age": MISSING}}},
         ),
         ([ConfWithMissingDict, {"dict": {"foo": "bar"}}], {"dict": {"foo": "bar"}}),
-        ([{}, ConfWithMissingDict], {"dict": "???"}),
+        pytest.param(
+            [{}, ConfWithMissingDict],
+            {"dict": "???"},
+            id="merge_missing_dict_into_missing_dict",
+        ),
         ([{"user": User}, {"user": Group}], pytest.raises(ValidationError)),
         (
             [{"user": DictConfig(ref_type=User, content=User)}, {"user": Group}],


### PR DESCRIPTION
This changes the semantics of merging into node interpolation, enabling a node we are interpolating into to act as a "by value" template.
```python
c1 = {"n": {"a": 10}, "i": "${n}"}
c2 = {"i": {"b": 20}}
c3 = {"n": {"a": 10}, "i": {"a": 10, "b": 20}}
assert OmegaConf.merge(c1, c2) == c3
```
fixes #184 