### PR TITLE
To container fixes

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -592,6 +592,8 @@ def format_and_raise(
 
 def type_str(t: Any) -> str:
     is_optional, t = _resolve_optional(t)
+    if t is None:
+        return type(t).__name__
     if t is Any:
         return "Any"
     if sys.version_info < (3, 7, 0):  # pragma: no cover

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -247,7 +247,6 @@ class OmegaConf:
         if isinstance(file_, (str, pathlib.Path)):
             with io.open(os.path.abspath(file_), "r", encoding="utf-8") as f:
                 obj = yaml.load(f, Loader=get_yaml_loader())
-                assert isinstance(obj, (list, dict, str))
                 return OmegaConf.create(obj)
         elif getattr(file_, "read", None):
             obj = yaml.load(file_, Loader=get_yaml_loader())

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -248,8 +248,7 @@ class OmegaConf:
             with io.open(os.path.abspath(file_), "r", encoding="utf-8") as f:
                 obj = yaml.load(f, Loader=get_yaml_loader())
                 res = OmegaConf.create(obj)
-                if not isinstance(res, (ListConfig, DictConfig)):
-                    raise ValueError(f"Unexpected config type {type_str(res)}")
+                assert isinstance(res, (ListConfig, DictConfig))
                 return res
         elif getattr(file_, "read", None):
             obj = yaml.load(file_, Loader=get_yaml_loader())

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -247,7 +247,10 @@ class OmegaConf:
         if isinstance(file_, (str, pathlib.Path)):
             with io.open(os.path.abspath(file_), "r", encoding="utf-8") as f:
                 obj = yaml.load(f, Loader=get_yaml_loader())
-                return OmegaConf.create(obj)
+                res = OmegaConf.create(obj)
+                if not isinstance(res, (ListConfig, DictConfig)):
+                    raise ValueError(f"Unexpected config type {type_str(res)}")
+                return res
         elif getattr(file_, "read", None):
             obj = yaml.load(file_, Loader=get_yaml_loader())
             assert isinstance(obj, (list, dict, str))
@@ -413,7 +416,7 @@ class OmegaConf:
     @staticmethod
     def to_container(
         cfg: Container, resolve: bool = False, enum_to_str: bool = False
-    ) -> Union[Dict[str, Any], List[Any]]:
+    ) -> Union[Dict[str, Any], List[Any], None, str]:
         """
         Resursively converts an OmegaConf config to a primitive container (dict or list).
         :param cfg: the config to convert

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -88,3 +88,9 @@ class StructuredWithMissing:
 @dataclass
 class UnionError:
     x: Union[int, str] = 10
+
+
+@dataclass
+class MissingUser:
+    user1: User = MISSING
+    user2: Any = MISSING

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -88,9 +88,3 @@ class StructuredWithMissing:
 @dataclass
 class UnionError:
     x: Union[int, str] = 10
-
-
-@dataclass
-class MissingUser:
-    user1: User = MISSING
-    user2: Any = MISSING

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -506,21 +506,6 @@ def test_assign_dict_in_dict() -> None:
     assert isinstance(c.foo, DictConfig)
 
 
-@pytest.mark.parametrize(  # type: ignore
-    "src",
-    [
-        {"a": 1, "b": 2, "c": {"aa": 10}},
-        [1, 2, 3],
-        {"a": 1, "b": 2, "c": {"aa": 10, "lst": [1, 2, 3]}},
-    ],
-)
-def test_to_container(src: Any) -> None:
-    c = OmegaConf.create(src)
-    result = OmegaConf.to_container(c)
-    assert type(result) == type(src)
-    assert result == src
-
-
 def test_pretty_without_resolve() -> None:
     c = OmegaConf.create(dict(a1="${ref}", ref="bar"))
     # without resolve, references are preserved

--- a/tests/test_config_eq.py
+++ b/tests/test_config_eq.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from omegaconf import AnyNode, DictConfig, OmegaConf
+from omegaconf import AnyNode, DictConfig, ListConfig, OmegaConf
 
 from . import Group, User
 
@@ -63,6 +63,31 @@ from . import Group, User
             {"i1": "${n1}", "n1": {"a": 10}},
             {"i1": "${n1}", "n1": {"a": 10}},
             id="node_interpolation",
+        ),
+        # Inter containers
+        pytest.param(
+            {"foo": DictConfig(content="${bar}"), "bar": 10},
+            {"foo": 10, "bar": 10},
+            id="dictconfig_inter",
+        ),
+        pytest.param(
+            {"foo": ListConfig(content="${bar}"), "bar": 10},
+            {"foo": 10, "bar": 10},
+            id="listconfig_inter",
+        ),
+        # None containers
+        pytest.param(
+            {"foo": DictConfig(content=None)}, {"foo": None}, id="dictconfig_none",
+        ),
+        pytest.param(
+            {"foo": ListConfig(content=None)}, {"foo": None}, id="listconfig_none",
+        ),
+        # Missing containers
+        pytest.param(
+            {"foo": DictConfig(content="???")}, {"foo": "???"}, id="dictconfig_missing",
+        ),
+        pytest.param(
+            {"foo": ListConfig(content="???")}, {"foo": "???"}, id="listconfig_missing",
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -328,7 +328,6 @@ def test_is_primitive_type(type_: Any, is_primitive: bool) -> None:
 @pytest.mark.parametrize(  # type: ignore
     "type_, expected",
     [
-        (None, "None"),
         (int, "int"),
         (bool, "bool"),
         (float, "float"),
@@ -350,6 +349,10 @@ def test_type_str(type_: Any, expected: str, optional: bool) -> None:
         assert _utils.type_str(Optional[type_]) == f"Optional[{expected}]"
     else:
         assert _utils.type_str(type_) == expected
+
+
+def test_type_str_none() -> None:
+    assert _utils.type_str(None) == "NoneType"
 
 
 @pytest.mark.parametrize(  # type: ignore

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -328,6 +328,7 @@ def test_is_primitive_type(type_: Any, is_primitive: bool) -> None:
 @pytest.mark.parametrize(  # type: ignore
     "type_, expected",
     [
+        (None, "None"),
         (int, "int"),
         (bool, "bool"),
         (float, "float"),


### PR DESCRIPTION
to_container now properly handles DictConfig and ListConfig that represents a missing value, a None value or an interpolation.