### PR TITLE
Report errors when loading YAML files with duplicate keys

### DIFF
--- a/news/257.bugfix
+++ b/news/257.bugfix
@@ -1,0 +1,1 @@
+Report errors when loading YAML files with duplicate keys

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -41,8 +41,10 @@ def isint(s: str) -> bool:
 def get_yaml_loader() -> Any:
     # Custom constructor that checks for duplicate keys
     # (from https://gist.github.com/pypt/94d747fe5180851196eb)
-    def no_duplicates_constructor(loader, node, deep=False):
-        mapping = {}
+    def no_duplicates_constructor(
+        loader: yaml.Loader, node: yaml.Node, deep: bool = False
+    ) -> Any:
+        mapping: Dict[str, Any] = {}
         for key_node, value_node in node.value:
             key = loader.construct_object(key_node, deep=deep)
             value = loader.construct_object(value_node, deep=deep)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -105,3 +105,26 @@ def test_pickle_list() -> None:
         fp.seek(0)
         c1 = pickle.load(fp)
         assert c == c1
+
+
+def test_load_duplicate_keys_top() -> None:
+    from yaml.constructor import ConstructorError
+
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            fp.write("a:\n  b: 1\na:\n  b: 2\n".encode("utf-8"))
+        with pytest.raises(ConstructorError):
+            OmegaConf.load(fp.name)
+    finally:
+        os.unlink(fp.name)
+
+def test_load_duplicate_keys_sub() -> None:
+    from yaml.constructor import ConstructorError
+
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            fp.write("a:\n  b: 1\n  c: 2\n  b: 3".encode("utf-8"))
+        with pytest.raises(ConstructorError):
+            OmegaConf.load(fp.name)
+    finally:
+        os.unlink(fp.name)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -112,18 +112,31 @@ def test_load_duplicate_keys_top() -> None:
 
     try:
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            fp.write("a:\n  b: 1\na:\n  b: 2\n".encode("utf-8"))
+            content = """
+a:
+  b: 1
+a:
+  b: 2
+"""
+            fp.write(content.encode("utf-8"))
         with pytest.raises(ConstructorError):
             OmegaConf.load(fp.name)
     finally:
         os.unlink(fp.name)
+
 
 def test_load_duplicate_keys_sub() -> None:
     from yaml.constructor import ConstructorError
 
     try:
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            fp.write("a:\n  b: 1\n  c: 2\n  b: 3".encode("utf-8"))
+            content = """
+a:
+  b: 1
+  c: 2
+  b: 3
+"""
+            fp.write(content.encode("utf-8"))
         with pytest.raises(ConstructorError):
             OmegaConf.load(fp.name)
     finally:


### PR DESCRIPTION
This adds a custom constructor to the YAML loader created in
get_yaml_loader() so that duplicate keys in the YAML file result in a
PyYAML ConstructorError.

Duplicate keys are not allowed as per the YAML spec but are silently
ignored by PyYAML. This is a potential source of hard-to-detect errors
due to misconfigurations. It has been reported several times in the
PyYAML issues, e.g. https://github.com/yaml/pyyaml/issues/165. The
specific fix here was proposed at https://gist.github.com/pypt/94d747fe5180851196eb.