### PR TITLE
Fixes #289 Omegaconf chaging SafeLoader

### DIFF
--- a/news/289.bugfix
+++ b/news/289.bugfix
@@ -1,0 +1,1 @@
+OmegaConf.create() doesn't modify yaml.loader.SafeLoader

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -58,7 +58,11 @@ def get_yaml_loader() -> Any:
             mapping[key] = value
         return loader.construct_mapping(node, deep)
 
-    loader = yaml.SafeLoader
+    class SafeLoaderWrapper(yaml.SafeLoader):  # type: ignore
+        pass
+
+    loader = SafeLoaderWrapper
+    assert id(loader) != id(yaml.SafeLoader)
     loader.add_implicit_resolver(
         "tag:yaml.org,2002:float",
         re.compile(

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -62,7 +62,6 @@ def get_yaml_loader() -> Any:
         pass
 
     loader = SafeLoaderWrapper
-    assert id(loader) != id(yaml.SafeLoader)
     loader.add_implicit_resolver(
         "tag:yaml.org,2002:float",
         re.compile(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 
 import pytest
 
+import yaml
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from omegaconf.errors import UnsupportedValueType
 
@@ -140,3 +141,10 @@ def test_create_node_parent_retained_on_create(node: Any) -> None:
     cfg2 = OmegaConf.create({"zonk": cfg1.foo})
     assert cfg2 == {"zonk": node}
     assert cfg1.foo._get_parent() == cfg1
+
+
+def test_create_unmodified_loader() -> None:
+    cfg = OmegaConf.create("gitrev: 100e100")
+    yaml_cfg = yaml.load("gitrev: 100e100", Loader=yaml.loader.SafeLoader)
+    assert cfg.gitrev == 1e102
+    assert yaml_cfg["gitrev"] == "100e100"

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -4,8 +4,8 @@ import sys
 from typing import Any, Dict, List
 
 import pytest
-
 import yaml
+
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from omegaconf.errors import UnsupportedValueType
 


### PR DESCRIPTION
Closes #289
By adding a class wrapper for yaml.SafeLoader it solves the problem.
Added test and news report.