### PR TITLE
Loading an empty YAML file now returns an empty DictConfig

### DIFF
--- a/news/297.bugfix
+++ b/news/297.bugfix
@@ -1,0 +1,1 @@
+Loading an empty YAML file now returns an empty DictConfig

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -246,7 +246,10 @@ class OmegaConf:
         if isinstance(file_, (str, pathlib.Path)):
             with io.open(os.path.abspath(file_), "r", encoding="utf-8") as f:
                 obj = yaml.load(f, Loader=get_yaml_loader())
-                res = OmegaConf.create(obj)
+                if obj is None:
+                    res = OmegaConf.create()
+                else:
+                    res = OmegaConf.create(obj)
                 assert isinstance(res, (ListConfig, DictConfig))
                 return res
         elif getattr(file_, "read", None):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -3,6 +3,7 @@ import io
 import os
 import pathlib
 import tempfile
+from pathlib import Path
 from typing import Any, Dict, Type
 
 import pytest
@@ -141,3 +142,10 @@ a:
             OmegaConf.load(fp.name)
     finally:
         os.unlink(fp.name)
+
+
+def test_load_empty_file(tmpdir: str) -> None:
+    empty = Path(tmpdir) / "test.yaml"
+    empty.touch()
+
+    assert OmegaConf.load(empty) == {}


### PR DESCRIPTION
closes #297 