### PR TITLE
Fix #296 Float/Boolean/Int represented as string, pretty.

### DIFF
--- a/news/296.bugfix
+++ b/news/296.bugfix
@@ -1,0 +1,1 @@
+bool, ints and floats represented as string are now formatted with surrounding quotes on pretty()

--- a/news/296.bugfix
+++ b/news/296.bugfix
@@ -1,1 +1,1 @@
-bool, ints and floats represented as string are now formatted with surrounding quotes on pretty()
+strings containing valid ints and floats represented are converted to quoted strings instead of the primitives in pretty()

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -57,7 +57,7 @@ YAML_BOOL_TYPES = [
 ]
 
 
-class DumperWrapper(yaml.Dumper):  # type: ignore
+class OmegaConfDumper(yaml.Dumper):  # type: ignore
     pass
 
 
@@ -101,10 +101,10 @@ def get_yaml_loader() -> Any:
             mapping[key] = value
         return loader.construct_mapping(node, deep)
 
-    class SafeLoaderWrapper(yaml.SafeLoader):  # type: ignore
+    class OmegaConfLoader(yaml.SafeLoader):  # type: ignore
         pass
 
-    loader = SafeLoaderWrapper
+    loader = OmegaConfLoader
     loader.add_implicit_resolver(
         "tag:yaml.org,2002:float",
         re.compile(

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -30,6 +30,7 @@ except ImportError:  # pragma: no cover
     attr = None  # type: ignore # pragma: no cover
 
 
+# source: https://yaml.org/type/bool.html
 YAML_BOOL_TYPES = [
     "y",
     "Y",
@@ -54,6 +55,10 @@ YAML_BOOL_TYPES = [
     "Off",
     "OFF",
 ]
+
+
+class DumperWrapper(yaml.Dumper):  # type: ignore
+    pass
 
 
 def isbool(b: str) -> bool:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -58,6 +58,8 @@ YAML_BOOL_TYPES = [
 
 
 class OmegaConfDumper(yaml.Dumper):  # type: ignore
+    str_representer_added = False
+
     def str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
         with_quotes = yaml_is_bool(data) or is_int(data) or is_float(data)
         return dumper.represent_scalar(
@@ -67,7 +69,11 @@ class OmegaConfDumper(yaml.Dumper):  # type: ignore
         )
 
 
-OmegaConfDumper.add_representer(str, OmegaConfDumper.str_representer)
+def get_omega_conf_dumper() -> Type[OmegaConfDumper]:
+    if not OmegaConfDumper.str_representer_added:
+        OmegaConfDumper.add_representer(str, OmegaConfDumper.str_representer)
+        OmegaConfDumper.str_representer_added = True
+    return OmegaConfDumper
 
 
 def yaml_is_bool(b: str) -> bool:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -30,6 +30,44 @@ except ImportError:  # pragma: no cover
     attr = None  # type: ignore # pragma: no cover
 
 
+YAML_BOOL_TYPES = [
+    "y",
+    "Y",
+    "yes",
+    "Yes",
+    "YES",
+    "n",
+    "N",
+    "no",
+    "No",
+    "NO",
+    "true",
+    "True",
+    "TRUE",
+    "false",
+    "False",
+    "FALSE",
+    "on",
+    "On",
+    "ON",
+    "off",
+    "Off",
+    "OFF",
+]
+
+
+def isbool(b: str) -> bool:
+    return b in YAML_BOOL_TYPES
+
+
+def isfloat(f: str) -> bool:
+    try:
+        float(f)
+        return True
+    except ValueError:
+        return False
+
+
 def isint(s: str) -> bool:
     try:
         int(s)

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -60,6 +60,7 @@ YAML_BOOL_TYPES = [
 class OmegaConfDumper(yaml.Dumper):  # type: ignore
     str_representer_added = False
 
+    @staticmethod
     def str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
         with_quotes = yaml_is_bool(data) or is_int(data) or is_float(data)
         return dumper.represent_scalar(

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -20,6 +20,9 @@ from ._utils import (
     is_primitive_container,
     is_primitive_dict,
     is_structured_config,
+    isbool,
+    isfloat,
+    isint,
 )
 from .base import Container, ContainerMetadata, Node
 from .errors import MissingMandatoryValue, ReadonlyConfigError, ValidationError
@@ -227,44 +230,7 @@ class BaseContainer(Container, ABC):
         dumper = yaml.Dumper
 
         def str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
-            def is_bool(data: str) -> bool:
-                return data in [
-                    "yes",
-                    "Yes",
-                    "YES",
-                    "no",
-                    "No",
-                    "NO",
-                    "true",
-                    "True",
-                    "TRUE",
-                    "false",
-                    "False",
-                    "FALSE",
-                    "on",
-                    "On",
-                    "ON",
-                    "off",
-                    "Off",
-                    "OFF",
-                    "y",
-                    "Y",
-                    "n",
-                    "N",
-                ]
-
-            def is_int(data: str) -> bool:
-                return data.isdecimal()
-
-            def is_float(data: str) -> bool:
-                is_float = True
-                try:
-                    float(data)
-                except ValueError:
-                    is_float = False
-                return is_float
-
-            with_quotes = is_bool(data) or is_int(data) or is_float(data)
+            with_quotes = isbool(data) or isint(data) or isfloat(data)
             return dumper.represent_scalar(
                 yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG,
                 data,

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -21,9 +21,6 @@ from ._utils import (
     is_primitive_container,
     is_primitive_dict,
     is_structured_config,
-    isbool,
-    isfloat,
-    isint,
 )
 from .base import Container, ContainerMetadata, Node
 from .errors import MissingMandatoryValue, ReadonlyConfigError, ValidationError
@@ -228,23 +225,13 @@ class BaseContainer(Container, ABC):
         """
         from omegaconf import OmegaConf
 
-        def str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
-            with_quotes = isbool(data) or isint(data) or isfloat(data)
-            return dumper.represent_scalar(
-                yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG,
-                data,
-                style=("'" if with_quotes else None),
-            )
-
-        Dumper = OmegaConfDumper
-        Dumper.add_representer(str, str_representer)
         container = OmegaConf.to_container(self, resolve=resolve, enum_to_str=True)
         return yaml.dump(  # type: ignore
             container,
             default_flow_style=False,
             allow_unicode=True,
             sort_keys=sort_keys,
-            Dumper=Dumper,
+            Dumper=OmegaConfDumper,
         )
 
     @staticmethod

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import yaml
 
 from ._utils import (
-    DumperWrapper,
+    OmegaConfDumper,
     ValueKind,
     _ensure_container,
     _get_value,
@@ -226,10 +226,6 @@ class BaseContainer(Container, ABC):
         :param sort_keys: If True, will print dict keys in sorted order. default False.
         :return: A string containing the yaml representation.
         """
-
-        return self._dump(resolve=resolve, sort_keys=sort_keys)
-
-    def _dump(self, stream=None, Dumper=DumperWrapper, **kwds) -> str:  # type: ignore
         from omegaconf import OmegaConf
 
         def str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
@@ -240,15 +236,14 @@ class BaseContainer(Container, ABC):
                 style=("'" if with_quotes else None),
             )
 
+        Dumper = OmegaConfDumper
         Dumper.add_representer(str, str_representer)
-        container = OmegaConf.to_container(
-            self, resolve=kwds["resolve"], enum_to_str=True
-        )
+        container = OmegaConf.to_container(self, resolve=resolve, enum_to_str=True)
         return yaml.dump(  # type: ignore
             container,
             default_flow_style=False,
             allow_unicode=True,
-            sort_keys=kwds["sort_keys"],
+            sort_keys=sort_keys,
             Dumper=Dumper,
         )
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -228,7 +228,30 @@ class BaseContainer(Container, ABC):
 
         def str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
             def is_bool(data: str) -> bool:
-                return data in ["True", "False"]
+                return data in [
+                    "yes",
+                    "Yes",
+                    "YES",
+                    "no",
+                    "No",
+                    "NO",
+                    "true",
+                    "True",
+                    "TRUE",
+                    "false",
+                    "False",
+                    "FALSE",
+                    "on",
+                    "On",
+                    "ON",
+                    "off",
+                    "Off",
+                    "OFF",
+                    "y",
+                    "Y",
+                    "n",
+                    "N",
+                ]
 
             def is_int(data: str) -> bool:
                 return data.isdecimal()
@@ -245,7 +268,7 @@ class BaseContainer(Container, ABC):
             return dumper.represent_scalar(
                 yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG,
                 data,
-                style=("single-quoted" if with_quotes else None),
+                style=("'" if with_quotes else None),
             )
 
         dumper.add_representer(str, str_representer)

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -8,12 +8,12 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import yaml
 
 from ._utils import (
-    OmegaConfDumper,
     ValueKind,
     _ensure_container,
     _get_value,
     _is_interpolation,
     _resolve_optional,
+    get_omega_conf_dumper,
     get_ref_type,
     get_value_kind,
     get_yaml_loader,
@@ -231,7 +231,7 @@ class BaseContainer(Container, ABC):
             default_flow_style=False,
             allow_unicode=True,
             sort_keys=sort_keys,
-            Dumper=OmegaConfDumper,
+            Dumper=get_omega_conf_dumper(),
         )
 
     @staticmethod

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -19,8 +19,8 @@ from ._utils import (
     _get_value,
     format_and_raise,
     get_value_kind,
+    is_int,
     is_primitive_list,
-    isint,
 )
 from .base import Container, ContainerMetadata, Node
 from .basecontainer import BaseContainer
@@ -115,7 +115,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
         assert False
 
     def __getattr__(self, key: str) -> Any:
-        if isint(key):
+        if is_int(key):
             return self.__getitem__(int(key))
         else:
             self._format_and_raise(

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -36,12 +36,12 @@ from ._utils import (
     get_list_element_type,
     get_type_of,
     is_dict_annotation,
+    is_int,
     is_list_annotation,
     is_primitive_dict,
     is_primitive_list,
     is_structured_config,
     is_tuple_annotation,
-    isint,
     type_str,
 )
 from .base import Container, Node
@@ -711,7 +711,7 @@ def _select_one(
             val = None
     elif isinstance(c, ListConfig):
         assert isinstance(ret_key, str)
-        if not isint(ret_key):
+        if not is_int(ret_key):
             if throw_on_type_error:
                 raise TypeError(
                     f"Index '{ret_key}' ({type(ret_key).__name__}) is not an int"

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -149,6 +149,11 @@ list:
     assert OmegaConf.create(c.pretty()) == c
 
 
+def test_pretty_strings() -> None:
+    c = OmegaConf.create({"b": "10e2", "a": "1", "c": "False"})
+    assert c.pretty() == 'b: "10e2"\na: "1"\nc: "False"\n'
+
+
 def test_default_value() -> None:
     c = OmegaConf.create()
     assert c.missing_key or "a default value" == "a default value"

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -154,36 +154,10 @@ def test_pretty_strings_float() -> None:
     assert c.pretty() == "b: '10e2'\na: '1.0'\nc: 1.0\n"
 
 
-@pytest.mark.parametrize(  # type: ignore
-    "yaml_bool",
-    [
-        "y",
-        "Y",
-        "yes",
-        "Yes",
-        "YES",
-        "n",
-        "N",
-        "no",
-        "No",
-        "NO",
-        "true",
-        "True",
-        "TRUE",
-        "false",
-        "False",
-        "FALSE",
-        "on",
-        "On",
-        "ON",
-        "off",
-        "Off",
-        "OFF",
-    ],
-)
-def test_pretty_string_boolean(yaml_bool: str) -> None:
-    c = OmegaConf.create({"b": yaml_bool, "a": 1})
-    assert c.pretty() == "b: '%s'\na: 1\n" % yaml_bool
+def test_pretty_string_boolean() -> None:
+    for t in _utils.YAML_BOOL_TYPES:
+        c = OmegaConf.create({"b": t, "a": 1})
+        assert c.pretty() == "b: '%s'\na: 1\n" % t
 
 
 def test_pretty_string_int() -> None:

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -149,9 +149,46 @@ list:
     assert OmegaConf.create(c.pretty()) == c
 
 
-def test_pretty_strings() -> None:
-    c = OmegaConf.create({"b": "10e2", "a": "1", "c": "False"})
-    assert c.pretty() == 'b: "10e2"\na: "1"\nc: "False"\n'
+def test_pretty_strings_float() -> None:
+    c = OmegaConf.create({"b": "10e2", "a": "1.0", "c": 1.0})
+    assert c.pretty() == "b: '10e2'\na: '1.0'\nc: 1.0\n"
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "yaml_bool",
+    [
+        "y",
+        "Y",
+        "yes",
+        "Yes",
+        "YES",
+        "n",
+        "N",
+        "no",
+        "No",
+        "NO",
+        "true",
+        "True",
+        "TRUE",
+        "false",
+        "False",
+        "FALSE",
+        "on",
+        "On",
+        "ON",
+        "off",
+        "Off",
+        "OFF",
+    ],
+)
+def test_pretty_string_boolean(yaml_bool: str) -> None:
+    c = OmegaConf.create({"b": yaml_bool, "a": 1})
+    assert c.pretty() == "b: '%s'\na: 1\n" % yaml_bool
+
+
+def test_pretty_string_int() -> None:
+    c = OmegaConf.create({"b": "1", "a": 1})
+    assert c.pretty() == "b: '1'\na: 1\n"
 
 
 def test_default_value() -> None:

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -50,11 +50,56 @@ def test_pretty_list_unicode() -> None:
     assert OmegaConf.create(c.pretty()) == c
 
 
-def test_pretty_strings() -> None:
-    c = OmegaConf.create(["10e2", "1", "False"])
-    expected = """- "10e2"
-- "1"
-- "False"
+def test_pretty_strings_float() -> None:
+    c = OmegaConf.create(["10e2", "1.0", 1.0])
+    expected = """- '10e2'
+- '1.0'
+- 1.0
+"""
+    assert c.pretty() == expected
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "yaml_bool",
+    [
+        "y",
+        "Y",
+        "yes",
+        "Yes",
+        "YES",
+        "n",
+        "N",
+        "no",
+        "No",
+        "NO",
+        "true",
+        "True",
+        "TRUE",
+        "false",
+        "False",
+        "FALSE",
+        "on",
+        "On",
+        "ON",
+        "off",
+        "Off",
+        "OFF",
+    ],
+)
+def test_pretty_string_boolean(yaml_bool: str) -> None:
+    c = OmegaConf.create([yaml_bool, 1])
+    expected = """- '{0}'
+- 1
+""".format(
+        yaml_bool
+    )
+    assert c.pretty() == expected
+
+
+def test_pretty_string_int() -> None:
+    c = OmegaConf.create(["1", 1])
+    expected = """- '1'
+- 1
 """
     assert c.pretty() == expected
 

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 
 import pytest
 
-from omegaconf import AnyNode, ListConfig, OmegaConf
+from omegaconf import AnyNode, ListConfig, OmegaConf, _utils
 from omegaconf.errors import (
     ConfigKeyError,
     ConfigTypeError,
@@ -59,48 +59,17 @@ def test_pretty_strings_float() -> None:
     assert c.pretty() == expected
 
 
-@pytest.mark.parametrize(  # type: ignore
-    "yaml_bool",
-    [
-        "y",
-        "Y",
-        "yes",
-        "Yes",
-        "YES",
-        "n",
-        "N",
-        "no",
-        "No",
-        "NO",
-        "true",
-        "True",
-        "TRUE",
-        "false",
-        "False",
-        "FALSE",
-        "on",
-        "On",
-        "ON",
-        "off",
-        "Off",
-        "OFF",
-    ],
-)
-def test_pretty_string_boolean(yaml_bool: str) -> None:
-    c = OmegaConf.create([yaml_bool, 1])
-    expected = """- '{0}'
-- 1
-""".format(
-        yaml_bool
-    )
-    assert c.pretty() == expected
+def test_pretty_string_boolean() -> None:
+    for t in _utils.YAML_BOOL_TYPES:
+        print(t)
+        c = OmegaConf.create([t, 1])
+        expected = "- '%s'\n- 1\n" % t
+        assert c.pretty() == expected
 
 
 def test_pretty_string_int() -> None:
     c = OmegaConf.create(["1", 1])
-    expected = """- '1'
-- 1
-"""
+    expected = "- '1'\n- 1\n"
     assert c.pretty() == expected
 
 

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -50,6 +50,15 @@ def test_pretty_list_unicode() -> None:
     assert OmegaConf.create(c.pretty()) == c
 
 
+def test_pretty_strings() -> None:
+    c = OmegaConf.create(["10e2", "1", "False"])
+    expected = """- "10e2"
+- "1"
+- "False"
+"""
+    assert c.pretty() == expected
+
+
 def test_list_get_with_default() -> None:
     c = OmegaConf.create([None, "???", "found"])
     assert c.get(0, "default_value") == "default_value"


### PR DESCRIPTION
When representing Float/Boolean/Int as string and then printing with pretty causes the string to be printed without quotes which can cause problems.
Added tests in both DictConfig and ListConfig.
Added news file.
Closes #296 .