### PR TITLE
Implement nested interpolations

### DIFF
--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -731,7 +731,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can add additional interpolation types using custom resolvers. This example creates a resolver that adds 10 the the given value."
+    "You can add additional interpolation types using custom resolvers, which take strings as inputs. This example creates a resolver that adds 10 to the given value (note the need to cast it to `int`)."
    ]
   },
   {
@@ -761,6 +761,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Nested interpolations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can use interpolations within interpolations, for instance to perform an\n",
+    "operation over config variables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3\n"
+     ]
+    }
+   ],
+   "source": [
+    "OmegaConf.register_resolver(\"plus_int\", lambda x, y: int(x) + int(y))\n",
+    "conf = OmegaConf.create({\"a\": 1, \"b\": 2, \"a_plus_b\": \"${plus_int:${a},${b}}\"})\n",
+    "print(conf.a_plus_b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Merging configurations\n",
     "Merging configurations enables the creation of reusable configuration files for each logical component instead of a single config file for each variation of your task.\n",
     "\n",
@@ -780,7 +814,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -807,7 +841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -831,7 +865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -884,7 +918,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.3"
   },
   "pycharm": {
    "stem_cell": {

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -795,6 +795,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Another typical use case is to to dynamically select a sub-config:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default: cfg.plan = plan A\n",
+      "After selecting plan B: cfg.plan = plan B\n"
+     ]
+    }
+   ],
+   "source": [
+    "cfg = OmegaConf.create(\"\"\"\n",
+    "plans:\n",
+    "    A: plan A\n",
+    "    B: plan B\n",
+    "selected_plan: A\n",
+    "plan: ${plans.${selected_plan}}\n",
+    "\"\"\")\n",
+    "print(f\"Default: cfg.plan = {cfg.plan}\")\n",
+    "cfg.selected_plan = \"B\"\n",
+    "print(f\"After selecting plan B: cfg.plan = {cfg.plan}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Merging configurations\n",
     "Merging configurations enables the creation of reusable configuration files for each logical component instead of a single config file for each variation of your task.\n",
     "\n",
@@ -814,7 +848,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -841,7 +875,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -865,7 +899,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -521,7 +521,7 @@
     "\n",
     "OmegaConf support variable interpolation, Interpolations are evaluated lazily on access.\n",
     "\n",
-    "### Config node interpolation"
+    "## Config node interpolation"
    ]
   },
   {
@@ -620,7 +620,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Environment variable interpolation\n",
+    "Interpolations may be nested, enabling more advanced behavior like dynamically selecting a sub-config:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default: cfg.plan = plan A\n",
+      "After selecting plan B: cfg.plan = plan B\n"
+     ]
+    }
+   ],
+   "source": [
+    "cfg = OmegaConf.create(\"\"\"\n",
+    "plans:\n",
+    "    A: plan A\n",
+    "    B: plan B\n",
+    "selected_plan: A\n",
+    "plan: ${plans.${selected_plan}}\n",
+    "\"\"\")\n",
+    "print(f\"Default: cfg.plan = {cfg.plan}\")\n",
+    "cfg.selected_plan = \"B\"\n",
+    "print(f\"After selecting plan B: cfg.plan = {cfg.plan}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Environment variable interpolation\n",
     "\n",
     "Environment variable interpolation is also supported.\n",
     "\n",
@@ -629,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,7 +681,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -672,7 +706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -704,7 +738,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -736,7 +770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -761,20 +795,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Nested interpolations"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can use interpolations within interpolations, for instance to perform an\n",
-    "operation over config variables:"
+    "You can take advantage of nested interpolations to perform operations over variables:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -789,40 +815,6 @@
     "OmegaConf.register_resolver(\"plus_int\", lambda x, y: int(x) + int(y))\n",
     "conf = OmegaConf.create({\"a\": 1, \"b\": 2, \"a_plus_b\": \"${plus_int:${a},${b}}\"})\n",
     "print(conf.a_plus_b)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Another typical use case is to to dynamically select a sub-config:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Default: cfg.plan = plan A\n",
-      "After selecting plan B: cfg.plan = plan B\n"
-     ]
-    }
-   ],
-   "source": [
-    "cfg = OmegaConf.create(\"\"\"\n",
-    "plans:\n",
-    "    A: plan A\n",
-    "    B: plan B\n",
-    "selected_plan: A\n",
-    "plan: ${plans.${selected_plan}}\n",
-    "\"\"\")\n",
-    "print(f\"Default: cfg.plan = {cfg.plan}\")\n",
-    "cfg.selected_plan = \"B\"\n",
-    "print(f\"After selecting plan B: cfg.plan = {cfg.plan}\")"
    ]
   },
   {

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -369,12 +369,12 @@ Another typical use case is to to dynamically select a sub-config:
 .. doctest::
 
     >>> cfg = OmegaConf.create("""
-        plans:
-            A: plan A
-            B: plan B
-        selected_plan: A
-        plan: ${plans.${selected_plan}}
-        """)
+    ... plans:
+    ...     A: plan A
+    ...     B: plan B
+    ... selected_plan: A
+    ... plan: ${plans.${selected_plan}}
+    ... """)
     >>> print(f"Default: cfg.plan = {cfg.plan}")
     Default: cfg.plan = plan A
     >>> cfg.selected_plan = "B"

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -364,6 +364,23 @@ operation over config variables:
     >>> c.a_plus_b
     3
 
+Another typical use case is to to dynamically select a sub-config:
+
+.. doctest::
+
+    >>> cfg = OmegaConf.create("""
+        plans:
+            A: plan A
+            B: plan B
+        selected_plan: A
+        plan: ${plans.${selected_plan}}
+        """)
+    >>> print(f"Default: cfg.plan = {cfg.plan}")
+    Default: cfg.plan = plan A
+    >>> cfg.selected_plan = "B"
+    >>> print(f"After selecting plan B: cfg.plan = {cfg.plan}")
+    After selecting plan B: cfg.plan = plan B
+
 
 Merging configurations
 ----------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -322,8 +322,8 @@ The following example sets `12345` as the the default value for the `DB_PASSWORD
 
 Custom interpolations
 ^^^^^^^^^^^^^^^^^^^^^
-You can add additional interpolation types using custom resolvers.
-This example creates a resolver that adds 10 the the given value.
+You can add additional interpolation types using custom resolvers, which take strings as inputs.
+This example creates a resolver that adds 10 to the given value (note the need to cast it to `int`).
 
 .. doctest::
 
@@ -351,6 +351,18 @@ You can use literal commas and spaces anywhere by escaping (:code:`\,` and :code
     >>> c.escape_whitespace
     'Hello World'
 
+Nested interpolations
+^^^^^^^^^^^^^^^^^^^^^
+
+You can use interpolations within interpolations, for instance to perform an
+operation over config variables:
+
+.. doctest::
+
+    >>> OmegaConf.register_resolver("plus_int", lambda x, y: int(x) + int(y))
+    >>> c = OmegaConf.create({"a": 1, "b": 2, "a_plus_b": "${plus_int:${a},${b}}"})
+    >>> c.a_plus_b
+    3
 
 
 Merging configurations

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -286,6 +286,23 @@ Example:
     >>> print(type(conf.client.url).__name__)
     str
 
+Interpolations may be nested, enabling more advanced behavior like dynamically selecting a sub-config:
+
+.. doctest::
+
+    >>> cfg = OmegaConf.create("""
+    ... plans:
+    ...     A: plan A
+    ...     B: plan B
+    ... selected_plan: A
+    ... plan: ${plans.${selected_plan}}
+    ... """)
+    >>> print(f"Default: cfg.plan = {cfg.plan}")
+    Default: cfg.plan = plan A
+    >>> cfg.selected_plan = "B"
+    >>> print(f"After selecting plan B: cfg.plan = {cfg.plan}")
+    After selecting plan B: cfg.plan = plan B
+
 
 Environment variable interpolation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -336,6 +353,7 @@ This example creates a resolver that adds 10 to the given value (note the need t
 Custom resolvers support variadic argument lists in the form of a comma separated list of zero or more values.
 Whitespaces are stripped from both ends of each value ("foo,bar" is the same as "foo, bar ").
 You can use literal commas and spaces anywhere by escaping (:code:`\,` and :code:`\ `).
+
 .. doctest::
 
     >>> OmegaConf.register_resolver("concat", lambda x,y: x+y)
@@ -351,11 +369,7 @@ You can use literal commas and spaces anywhere by escaping (:code:`\,` and :code
     >>> c.escape_whitespace
     'Hello World'
 
-Nested interpolations
-^^^^^^^^^^^^^^^^^^^^^
-
-You can use interpolations within interpolations, for instance to perform an
-operation over config variables:
+You can take advantage of nested interpolations to perform operations over variables:
 
 .. doctest::
 
@@ -363,23 +377,6 @@ operation over config variables:
     >>> c = OmegaConf.create({"a": 1, "b": 2, "a_plus_b": "${plus_int:${a},${b}}"})
     >>> c.a_plus_b
     3
-
-Another typical use case is to to dynamically select a sub-config:
-
-.. doctest::
-
-    >>> cfg = OmegaConf.create("""
-    ... plans:
-    ...     A: plan A
-    ...     B: plan B
-    ... selected_plan: A
-    ... plan: ${plans.${selected_plan}}
-    ... """)
-    >>> print(f"Default: cfg.plan = {cfg.plan}")
-    Default: cfg.plan = plan A
-    >>> cfg.selected_plan = "B"
-    >>> print(f"After selecting plan B: cfg.plan = {cfg.plan}")
-    After selecting plan B: cfg.plan = plan B
 
 
 Merging configurations

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -373,8 +373,11 @@ You can take advantage of nested interpolations to perform operations over varia
 
 .. doctest::
 
-    >>> OmegaConf.register_resolver("plus_int", lambda x, y: int(x) + int(y))
-    >>> c = OmegaConf.create({"a": 1, "b": 2, "a_plus_b": "${plus_int:${a},${b}}"})
+    >>> OmegaConf.register_resolver("plus_int",
+    ...                             lambda x, y: int(x) + int(y))
+    >>> c = OmegaConf.create({"a": 1,
+    ...                       "b": 2,
+    ...                       "a_plus_b": "${plus_int:${a},${b}}"})
     >>> c.a_plus_b
     3
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -297,11 +297,11 @@ Interpolations may be nested, enabling more advanced behavior like dynamically s
     ... selected_plan: A
     ... plan: ${plans.${selected_plan}}
     ... """)
-    >>> print(f"Default: cfg.plan = {cfg.plan}")
-    Default: cfg.plan = plan A
+    >>> print(cfg.plan) # default plan
+    plan A
     >>> cfg.selected_plan = "B"
-    >>> print(f"After selecting plan B: cfg.plan = {cfg.plan}")
-    After selecting plan B: cfg.plan = plan B
+    >>> print(cfg.plan) # new plan
+    plan B
 
 
 Environment variable interpolation

--- a/news/308.feature
+++ b/news/308.feature
@@ -1,0 +1,1 @@
+Add ability to nest interpolations, e.g. ${env:{$var}} or ${foo.${bar}.${baz}}

--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -1,6 +1,7 @@
 from .base import Container, Node
 from .dictconfig import DictConfig
 from .errors import (
+    InterpolationParseError,
     KeyValidationError,
     MissingMandatoryValue,
     ReadonlyConfigError,
@@ -36,6 +37,7 @@ __all__ = [
     "ReadonlyConfigError",
     "UnsupportedValueType",
     "KeyValidationError",
+    "InterpolationParseError",
     "Container",
     "ListConfig",
     "DictConfig",

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -709,17 +709,6 @@ def type_str(t: Any) -> str:
         return ret
 
 
-def update_string(to_s: str, start: int, stop: int, from_s: str) -> Optional[str]:
-    """
-    Update `to_s`, replacing its content from `start` to `stop` (excluded) with `from_s`.
-
-    Return `None` if input indices are invalid (negative indices are *not* allowed).
-    """
-    if start < 0 or start > len(to_s) or stop < 0 or stop > len(to_s) or stop < start:
-        return None
-    return "".join([to_s[0:start], from_s, to_s[stop:]])
-
-
 def _ensure_container(target: Any) -> Any:
     from omegaconf import OmegaConf
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -319,7 +319,7 @@ def get_value_kind(value: Any, return_match_list: bool = False) -> Any:
     MANDATORY_MISSING : "???
     VALUE : "10", "20", True,
     INTERPOLATION: "${foo}", "${foo.bar}"
-    STR_INTERPOLATION: "ftp://${host}/path"
+    STR_INTERPOLATION: "ftp://${host}/path", ${foo.${bar}}
 
     :param value: input string to classify
     :param return_match_list: True to return the match list as well
@@ -707,6 +707,17 @@ def type_str(t: Any) -> str:
         return f"Optional[{ret}]"
     else:
         return ret
+
+
+def update_string(to_s: str, start: int, stop: int, from_s: str) -> Optional[str]:
+    """
+    Update `to_s`, replacing its content from `start` to `stop` (excluded) with `from_s`.
+
+    Return `None` if input indices are invalid.
+    """
+    if start < 0 or start > len(to_s) or stop < 0 or stop > len(to_s) or stop < start:
+        return None
+    return "".join([to_s[0:start], from_s, to_s[stop:]])
 
 
 def _ensure_container(target: Any) -> Any:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -316,7 +316,7 @@ def get_value_kind(value: Any, return_match_list: bool = False) -> Any:
     """
     Determine the kind of a value
     Examples:
-    MANDATORY_MISSING : "???
+    MANDATORY_MISSING : "???"
     VALUE : "10", "20", True,
     INTERPOLATION: "${foo}", "${foo.bar}"
     STR_INTERPOLATION: "ftp://${host}/path", ${foo.${bar}}
@@ -713,7 +713,7 @@ def update_string(to_s: str, start: int, stop: int, from_s: str) -> Optional[str
     """
     Update `to_s`, replacing its content from `start` to `stop` (excluded) with `from_s`.
 
-    Return `None` if input indices are invalid.
+    Return `None` if input indices are invalid (negative indices are *not* allowed).
     """
     if start < 0 or start > len(to_s) or stop < 0 or stop > len(to_s) or stop < start:
         return None

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -319,7 +319,12 @@ def get_value_kind(value: Any, return_match_list: bool = False) -> Any:
     MANDATORY_MISSING : "???"
     VALUE : "10", "20", True,
     INTERPOLATION: "${foo}", "${foo.bar}"
-    STR_INTERPOLATION: "ftp://${host}/path", ${foo.${bar}}
+    STR_INTERPOLATION: "ftp://${host}/path", "${foo.${bar}}"
+
+    Note in particular that in the current implementation, "${foo.${bar}}" is
+    identified as a string interpolation (`STR_INTERPOLATION`) while it is
+    actually a (nested) simple interpolation. This discrepancy w.r.t naming
+    conventions will be addressed in a future update.
 
     :param value: input string to classify
     :param return_match_list: True to return the match list as well

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -496,7 +496,7 @@ class Container(Node):
                     throw_on_missing=throw_on_missing,
                     throw_on_resolution_failure=throw_on_resolution_failure,
                 )
-                _parse_assert(val is not None, "unexpected error during parsing")
+                _cond_parse_error(val is not None, "unexpected error during parsing")
                 # If this interpolation covers the whole expression we are evaluating,
                 # then `val` is our final result. We should *not* cast it to string!
                 if inter.start == 0 and idx == len(value) - 1:
@@ -504,12 +504,12 @@ class Container(Node):
                 # Update `result` with the evaluation of the interpolation.
                 val_str = str(val)
                 result = update_string(result, inter.start, inter.stop, val_str)  # type: ignore
-                _parse_assert(result is not None, "unexpected error during parsing")
+                _cond_parse_error(result is not None, "unexpected error during parsing")
                 # Update offset based on difference between the length of the definition
                 # of the interpolation vs the length of its evaluation.
                 offset = inter.stop - inter.start - len(val_str)
                 total_offset += offset
-        _parse_assert(not to_eval, "syntax error - maybe no matching braces?")
+        _cond_parse_error(not to_eval, "syntax error - maybe no matching braces?")
         return StringNode(value=result, key=key)
 
     def _re_parent(self) -> None:
@@ -537,7 +537,7 @@ class Container(Node):
                             item._re_parent()
 
 
-def _parse_assert(condition: Any, msg: str = "") -> None:
+def _cond_parse_error(condition: Any, msg: str = "") -> None:
     """
     Raise an `InterpolationParseError` if `condition` evaluates to `False`.
 

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -452,8 +452,7 @@ class Container(Node):
         Evaluate a complex interpolation.
 
         A complex interpolation is more elaborate than "${a}" or "${a:b,c}", e.g.:
-            "I really like ${liked}" (concatenating a string)
-            "${subject} {verb} ${object}" (concatenating multiple strings)
+            "Sentence: ${subject} {verb} ${object}" (string interpolation)
             "${plus:${x},${y}} (calling a custom resolver on config variables)
             "${${op}:${x},${y}} (same as previous but with a dynamic resolver)
             "${${a}}" (fetching the key whose name is stored in `a`)

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -497,7 +497,9 @@ class Container(Node):
                     return val
                 # Update `result` with the evaluation of the interpolation.
                 val_str = str(val)
-                result = _update_string(result, inter.start, inter.stop, val_str)
+                result = "".join(
+                    [result[0 : inter.start], val_str, result[inter.stop :]]
+                )
                 # Update offset based on difference between the length of the definition
                 # of the interpolation vs the length of its evaluation.
                 offset = inter.stop - inter.start - len(val_str)
@@ -539,13 +541,3 @@ def _cond_parse_error(condition: Any, msg: str = "") -> None:
     """
     if not condition:
         raise InterpolationParseError(msg)
-
-
-def _update_string(to_s: str, start: int, stop: int, from_s: str) -> str:
-    """
-    Update `to_s`, replacing its content from `start` to `stop` (excluded) with `from_s`.
-
-    Both `start` and `stop` indices must be between 0 and `len(to_s)` (included).
-    """
-    assert 0 <= start <= len(to_s) and 0 <= stop <= len(to_s)
-    return "".join([to_s[0:start], from_s, to_s[stop:]])

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -440,7 +440,23 @@ class Container(Node):
         throw_on_missing: bool,
         throw_on_resolution_failure: bool,
     ) -> Optional[str]:
-        """Evaluate a complex interpolation (>1, nested, with other strings...)"""
+        """
+        Evaluate a complex interpolation (>1, nested, with other strings...).
+
+        The high-level logic consists in scanning the input string `value` from
+        left to right, keeping track of the tokens signaling the opening and closing
+        of each interpolation in the string. Whenever an interpolation is closed we
+        evaluate it and replace its definition with the result of this evaluation.
+
+        As an example, consider the string `value` set to "${foo.${bar}}":
+            1. We initialized our result with the original string: "${foo.${bar}}"
+            2. Scanning `value` from left to right, the first interpolation to be
+               closed is "${bar}". We evaluate it: if it resolves to "baz", we update
+               the result string to "${foo.baz}".
+            3. The next interpolation to be closed is now "${foo.baz}". We evaluate it:
+               if it resolves to "abc", we update the result accordingly to "abc".
+            4. We are done scanning `value` => the final result is "abc".
+        """
         to_eval = []  # list of ongoing interpolations to be evaluated
         # `result` will be updated iteratively from `value` to final result.
         result = value

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -17,8 +17,8 @@ from .errors import (
 class InterpolationRange:
     """Used to store start/stop indices of interpolations being evaluated"""
 
-    start: int = -1
-    stop: int = -1
+    start: int
+    stop: Optional[int] = None
 
 
 @dataclass

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -13,8 +13,8 @@ from ._utils import (
 )
 from .errors import (
     ConfigKeyError,
+    InterpolationParseError,
     MissingMandatoryValue,
-    ParseError,
     UnsupportedInterpolationType,
 )
 
@@ -404,7 +404,7 @@ class Container(Node):
                     throw_on_missing=throw_on_missing,
                     throw_on_resolution_failure=throw_on_resolution_failure,
                 )
-            except ParseError as e:
+            except InterpolationParseError as e:
                 if throw_on_resolution_failure:
                     self._format_and_raise(key=key, value=value, cause=e)
                 return None
@@ -533,10 +533,10 @@ class Container(Node):
 
 def _parse_assert(condition: Any, msg: str = "") -> None:
     """
-    Raise a `ParseError` if `condition` evaluates to `False`.
+    Raise an `InterpolationParseError` if `condition` evaluates to `False`.
 
     `msg` is an optional message that may give additional information about
     the error.
     """
     if not condition:
-        raise ParseError(msg)
+        raise InterpolationParseError(msg)

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -4,13 +4,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, Iterator, Optional, Tuple, Type, Union
 
-from ._utils import (
-    ValueKind,
-    _get_value,
-    format_and_raise,
-    get_value_kind,
-    update_string,
-)
+from ._utils import ValueKind, _get_value, format_and_raise, get_value_kind
 from .errors import (
     ConfigKeyError,
     InterpolationParseError,
@@ -503,8 +497,7 @@ class Container(Node):
                     return val
                 # Update `result` with the evaluation of the interpolation.
                 val_str = str(val)
-                result = update_string(result, inter.start, inter.stop, val_str)  # type: ignore
-                _cond_parse_error(result is not None, "unexpected error during parsing")
+                result = _update_string(result, inter.start, inter.stop, val_str)
                 # Update offset based on difference between the length of the definition
                 # of the interpolation vs the length of its evaluation.
                 offset = inter.stop - inter.start - len(val_str)
@@ -546,3 +539,13 @@ def _cond_parse_error(condition: Any, msg: str = "") -> None:
     """
     if not condition:
         raise InterpolationParseError(msg)
+
+
+def _update_string(to_s: str, start: int, stop: int, from_s: str) -> str:
+    """
+    Update `to_s`, replacing its content from `start` to `stop` (excluded) with `from_s`.
+
+    Both `start` and `stop` indices must be between 0 and `len(to_s)` (included).
+    """
+    assert 0 <= start <= len(to_s) and 0 <= stop <= len(to_s)
+    return "".join([to_s[0:start], from_s, to_s[stop:]])

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -396,7 +396,7 @@ class Container(Node):
             value = _get_value(value)
             assert isinstance(value, str)
             try:
-                # NB: `match_list` is ignored here as complex interpolations may be
+                # Note: `match_list` is ignored here as complex interpolations may be
                 # nested, the string will be re-parsed within `_evaluate_complex()`.
                 return self._evaluate_complex(
                     value,
@@ -457,7 +457,7 @@ class Container(Node):
         evaluate it and replace its definition with the result of this evaluation.
 
         As an example, consider the string `value` set to "${foo.${bar}}":
-            1. We initialized our result with the original string: "${foo.${bar}}"
+            1. We initialize our result with the original string: "${foo.${bar}}"
             2. Scanning `value` from left to right, the first interpolation to be
                closed is "${bar}". We evaluate it: if it resolves to "baz", we update
                the result string to "${foo.baz}".

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -413,17 +413,33 @@ class Container(Node):
         else:
             assert False
 
-    def _evaluate_simple(self, value: str, **kw: Any) -> Optional["Node"]:
+    def _evaluate_simple(
+        self,
+        value: str,
+        key: Any,
+        throw_on_missing: bool,
+        throw_on_resolution_failure: bool,
+    ) -> Optional["Node"]:
         """Evaluate a simple interpolation"""
         value_kind, match_list = get_value_kind(value=value, return_match_list=True)
         assert value_kind == ValueKind.INTERPOLATION and len(match_list) == 1
         match = match_list[0]
         node = self._resolve_simple_interpolation(
-            inter_type=match.group(1), inter_key=match.group(2), **kw,
+            inter_type=match.group(1),
+            inter_key=match.group(2),
+            key=key,
+            throw_on_missing=throw_on_missing,
+            throw_on_resolution_failure=throw_on_resolution_failure,
         )
         return node
 
-    def _evaluate_complex(self, value: str, **kw: Any) -> Optional[str]:
+    def _evaluate_complex(
+        self,
+        value: str,
+        key: Any,
+        throw_on_missing: bool,
+        throw_on_resolution_failure: bool,
+    ) -> Optional[str]:
         """Evaluate a complex interpolation (>1, nested, with other strings...)"""
         to_eval = []  # list of ongoing interpolations to be evaluated
         # `result` will be updated iteratively from `value` to final result.
@@ -442,7 +458,12 @@ class Container(Node):
                 inter = to_eval.pop()
                 inter.stop = idx + 1 - total_offset
                 # Evaluate this interpolation.
-                val = self._evaluate_simple(result[inter.start : inter.stop], **kw)
+                val = self._evaluate_simple(
+                    value=result[inter.start : inter.stop],
+                    key=key,
+                    throw_on_missing=throw_on_missing,
+                    throw_on_resolution_failure=throw_on_resolution_failure,
+                )
                 _parse_assert(val is not None, "unexpected error during parsing")
                 # Update `result` with the evaluation of the interpolation.
                 val_str = str(val)

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -449,7 +449,14 @@ class Container(Node):
         throw_on_resolution_failure: bool,
     ) -> Optional["Node"]:
         """
-        Evaluate a complex interpolation (>1, nested, with other strings...).
+        Evaluate a complex interpolation.
+
+        A complex interpolation is more elaborate than "${a}" or "${a:b,c}", e.g.:
+            "I really like ${liked}" (concatenating a string)
+            "${subject} {verb} ${object}" (concatenating multiple strings)
+            "${plus:${x},${y}} (calling a custom resolver on config variables)
+            "${${op}:${x},${y}} (same as previous but with a dynamic resolver)
+            "${${a}}" (fetching the key whose name is stored in `a`)
 
         The high-level logic consists in scanning the input string `value` from
         left to right, keeping track of the tokens signaling the opening and closing

--- a/omegaconf/errors.py
+++ b/omegaconf/errors.py
@@ -103,3 +103,9 @@ class ConfigValueError(OmegaConfBaseException, ValueError):
     """
     Thrown from a config object when a regular access would have caused a ValueError.
     """
+
+
+class ParseError(OmegaConfBaseException):
+    """
+    Thrown when unable to parse a complex interpolation.
+    """

--- a/omegaconf/errors.py
+++ b/omegaconf/errors.py
@@ -105,7 +105,7 @@ class ConfigValueError(OmegaConfBaseException, ValueError):
     """
 
 
-class ParseError(OmegaConfBaseException):
+class InterpolationParseError(OmegaConfBaseException):
     """
     Thrown when unable to parse a complex interpolation.
     """

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -356,23 +356,25 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
 @pytest.mark.parametrize(  # type: ignore
     "cfg,expected_dict",
     [
-        (
+        pytest.param(
             """
             a: 1
             b: a
             c: ${${b}}
             """,
-            {"c": 1},  # basic nesting
+            {"c": 1},
+            id="basic nesting",
         ),
-        (
+        pytest.param(
             """
             a: OMEGACONF
             b: NESTED_INTERPOLATIONS_TEST
             c: ${env:${a}_${b}}
             """,
-            {"c": "test123"},  # nesting with key
+            {"c": "test123"},
+            id="nesting with key",
         ),
-        (
+        pytest.param(
             """
             x: 1
             y: 2
@@ -380,9 +382,10 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
             z: ${plus:${x},${y}}
             t: ${${op}:${x},${y}}
             """,
-            {"z": 3, "t": 3},  # nesting with (possibly dynamic) resolver
+            {"z": 3, "t": 3},
+            id="nesting with (possibly dynamic) resolver",
         ),
-        (
+        pytest.param(
             """
             a:
                 b: 1
@@ -394,16 +397,18 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
             e: .d
             f: ${a${e}}
             """,
-            {"c": 2, "d": 2, "f": 1},  # member access
+            {"c": 2, "d": 2, "f": 1},
+            id="member access",
         ),
-        (
+        pytest.param(
             """
             a: def
             b: abc_{${a}}
             """,
-            {"b": "abc_{def}"},  # braces in string
+            {"b": "abc_{def}"},
+            id="braces in string",
         ),
-        (
+        pytest.param(
             """
             a: A
             b: ${env:x=A}
@@ -413,6 +418,7 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
             # it changes in the future we should ensure that both `b` and `c` yield
             # the same result.
             {"b": "${env:x=A}", "c": "${env:x=A}"},
+            id="illegal character in interpolation",
         ),
     ],
 )

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -363,7 +363,7 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
             c: ${${b}}
             """,
             {"c": 1},
-            id="basic nesting",
+            id="basic_nesting",
         ),
         pytest.param(
             """
@@ -372,7 +372,7 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
             c: ${env:${a}_${b}}
             """,
             {"c": "test123"},
-            id="nesting with key",
+            id="nesting_with_key",
         ),
         pytest.param(
             """
@@ -383,7 +383,7 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
             t: ${${op}:${x},${y}}
             """,
             {"z": 3, "t": 3},
-            id="nesting with (possibly dynamic) resolver",
+            id="nesting_with_resolver",
         ),
         pytest.param(
             """
@@ -398,7 +398,7 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
             f: ${a${e}}
             """,
             {"c": 2, "d": 2, "f": 1},
-            id="member access",
+            id="member_access",
         ),
         pytest.param(
             """
@@ -406,7 +406,7 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
             b: abc_{${a}}
             """,
             {"b": "abc_{def}"},
-            id="braces in string",
+            id="braces_in_string",
         ),
         pytest.param(
             """
@@ -418,7 +418,7 @@ def test_interpolations(cfg: Dict[str, Any], key: str, expected: Any) -> None:
             # it changes in the future we should ensure that both `b` and `c` yield
             # the same result.
             {"b": "${env:x=A}", "c": "${env:x=A}"},
-            id="illegal character in interpolation",
+            id="illegal_character_in_interpolation",
         ),
     ],
 )
@@ -437,9 +437,9 @@ def test_nested_interpolations(cfg: str, expected_dict: Dict[str, Any]) -> None:
     "cfg,key",
     [
         # All these examples have non-matching braces.
-        ({"a": "PATH", "b": "${env:${a}"}, "b"),
-        ({"a": 1, "b": 2, "c": "${a ${b}"}, "c"),
-        ({"a": 1, "b": 2, "c": "${a} ${b"}, "c"),
+        pytest.param({"a": "PATH", "b": "${env:${a}"}, "b", id="env_not_closed"),
+        pytest.param({"a": 1, "b": 2, "c": "${a ${b}"}, "c", id="a_not_closed"),
+        pytest.param({"a": 1, "b": 2, "c": "${a} ${b"}, "c", id="b_not_closed"),
     ],
 )
 def test_nested_interpolation_errors(cfg: Dict[str, Any], key: str) -> None:

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -430,6 +430,7 @@ def test_nested_interpolations(cfg: str, expected_dict: Dict[str, Any]) -> None:
 @pytest.mark.parametrize(  # type: ignore
     "cfg,key",
     [
+        # All these examples have non-matching braces.
         ({"a": "PATH", "b": "${env:${a}"}, "b"),
         ({"a": 1, "b": 2, "c": "${a ${b}"}, "c"),
         ({"a": 1, "b": 2, "c": "${a} ${b"}, "c"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -485,3 +485,21 @@ def test_is_list_annotation(type_: Any, expected: Any) -> Any:
 )
 def test_get_ref_type(obj: Any, expected: Any) -> None:
     assert _utils.get_ref_type(obj) == expected
+
+
+def test_update_string() -> None:
+    assert _utils.update_string("hello world", 1, 5, "i") == "hi world"
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "start, stop",
+    [
+        (-1, 1),
+        (1, -1),
+        (2, 1),
+        (len("hello world") + 1, 100),
+        (0, len("hello world") + 1),
+    ],
+)
+def test_update_string_error(start: int, stop: int) -> None:
+    assert _utils.update_string("hello world", start, stop, "i") is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -485,21 +485,3 @@ def test_is_list_annotation(type_: Any, expected: Any) -> Any:
 )
 def test_get_ref_type(obj: Any, expected: Any) -> None:
     assert _utils.get_ref_type(obj) == expected
-
-
-def test_update_string() -> None:
-    assert _utils.update_string("hello world", 1, 5, "i") == "hi world"
-
-
-@pytest.mark.parametrize(  # type: ignore
-    "start, stop",
-    [
-        (-1, 1),
-        (1, -1),
-        (2, 1),
-        (len("hello world") + 1, 100),
-        (0, len("hello world") + 1),
-    ],
-)
-def test_update_string_error(start: int, stop: int) -> None:
-    assert _utils.update_string("hello world", start, stop, "i") is None


### PR DESCRIPTION
This is to fix #100 

Doc and tests are missing, I'm aware of it, I wanted to first get feedback on the implementation itself, in case there'd be any major concern.

The main parsing logic is in `_evaluate_complex()`, it's actually not too complex since we can sequentially iterate on all characters in the string and evaluate interpolations in the order we encounter their end `}`. So the core logic is simple but there are still "details" to be addressed (see concerns below).

This is not a super efficient implementation: (i) there are many string copies in the process, and (ii) the worst case complexity is quadratic in case of deep nesting (Edit: not anymore, see comment below). That being said, I don't expect it to be a real issue in the large majority of practical use cases.

A few potential concerns:
1. Although all tests currently pass, this can actually break backward compatibility since for instance if you had `a: 1` as config, then `${${a}}` used to evaluate to the string`"${1}"`, when now it would crash when trying to resolve this new interpolation. Hopefully people were not relying on this!
2. My current implementation returns a `None` value instead of crashing in case of syntax error. This isn't good, but right now the only two flags to trigger a crash are `throw_on_missing` and `throw_on_resolution_failure`, because there could be no syntax error in the previous code (for instance `${a}_${a` would be resolved into `"1_${a"`). Should I add a `throw_on_parsing_failure` flag?
3. With my current implementation `${a` resolves to `"${a"` while `${a}_${a` triggers a parsing failure. This inconsistency isn't good => I was thinking of using my new interpolation logic whenever it's not a simple interpolation but there is still a `${` in the string to be parsed, which should address this issue. Thoughts?
4. I'm not planning to allow escaping of the special `${` and `}` tokens, although it probably wouldn't be that hard. Let me know if you think this is important.