### PR TITLE
Allow bracketed lists as arguments to resolvers

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -327,7 +327,7 @@ def get_value_kind(value: Any, return_match_list: bool = False) -> Any:
     """
 
     key_prefix = r"\${(\w+:)?"
-    legal_characters = r"([\w\.%_ \\/:,-]*?)}"
+    legal_characters = r"([\w\.%_ \\/:,-\[\]]*?)}"
     match_list: Optional[List[Match[str]]] = None
 
     def ret(

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -264,6 +264,12 @@ def test_resolver_cache_2(restore_resolvers: Any) -> None:
             "${my_resolver:cat\\, do g}",
             ("cat, do g",),
         ),
+        (
+            lambda *args: args,
+            "bracketed_list",
+            "${my_resolver:[cat\\, dog], unicorn}",
+            ("[cat, dog]", "unicorn"),
+        ),
         (lambda: "zero", "zero_arg", "${my_resolver:}", "zero"),
     ],
 )


### PR DESCRIPTION
This fixes #318 

This is needed if we want to be able to apply a resolver on a config variable which is a list (using nested interpolations).

Note that doing so is a bit cumbersome though, as we need to do something like:
```
my_list: [0, 1, 2]
my_function_of_list: ${my_function:${escape_commas:${my_list}},other_arg}
```
where `escape_commas` is a resolver that escapes the commas in the string representation of a list.

It may not look great but at least it works, enabling use cases that were not possible before (to the best of my knowledge).