### PR TITLE
Reverts mac specific coverage hacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ TODO
 /pip-wheel-metadata
 /.pyre
 .dmypy.json
+.python-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,15 @@ Optionally install commit hooks: `pre-commit install`
 
 pre-commit will verify your code lints cleanly when you commit. You can use `git commit -n` to skip the pre-commit hook for a specific commit.
 
+##### Mac
+OmegaConf is compatible with Python 3.6.4 and newer. Unfortunately Mac comes with older versions.
+
+One way to install multiple Python versions on Mac to to use pyenv.
+The instructions [here](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/MAC_SETUP.md) 
+will provide full details. It shows how to use pyenv on mac to install multiple versions of Python and have 
+pyenv make specific versions available in specific directories automatically.
+This plays well with Conda, which supports a single Python version. Pyenv will provide the versions not installed by Conda (which are used when running nox).
+
 #### Testing
 Run tests directly with `pytest`.
 

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -1,5 +1,4 @@
 import copy
-import sys
 from enum import Enum
 from typing import Any, Dict, List, Union
 
@@ -478,11 +477,6 @@ def test_open_dict_restore(flag_name: str, ctx: Any) -> None:
     assert not cfg.foo._get_node_flag(flag_name)
 
 
-# There is an issue in Python <= 3.6.3 related to copying instances of generic classes,
-# that makes many of the copy tests fail.
-@pytest.mark.skipif(
-    sys.version_info <= (3, 6, 3), reason="Requires Python 3.6.4 or newer"
-)
 @pytest.mark.parametrize("copy_method", [lambda x: copy.copy(x), lambda x: x.copy()])
 class TestCopy:
     @pytest.mark.parametrize(  # type: ignore
@@ -521,17 +515,6 @@ class TestCopy:
         cp = copy_method(cfg)
         assert id(cfg) != id(cp)
         assert id(cfg[0]) == id(cp[0])
-
-
-# This test is to ensure 100% coverage with Python <= 3.6.3, even when the
-# above tests are skipped.
-@pytest.mark.skipif(  # type: ignore
-    sys.version_info >= (3, 6, 4), reason="Copy is tested in `TestCopy`"
-)
-def test_enforce_copy_coverage() -> None:
-    cfg = OmegaConf.create([])
-    with raises(TypeError):
-        cfg.copy()
 
 
 def test_not_implemented() -> None:


### PR DESCRIPTION
Reverts mac specific hacks to tests and adds instructions on how to install supported Python versions on Mac.
cc @odelalleau - Please try to follow the instructions and make sure you can make it work before I land this.

I got it to work and it's actually quiet nice.