### PR TITLE
fix merge list of structured class

### DIFF
--- a/news/327.bugfix
+++ b/news/327.bugfix
@@ -1,0 +1,1 @@
+Merging a List of a structured with a different type now raises an error.

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -21,6 +21,7 @@ from ._utils import (
     get_value_kind,
     is_int,
     is_primitive_list,
+    type_str,
 )
 from .base import Container, ContainerMetadata, Node
 from .basecontainer import BaseContainer
@@ -85,6 +86,23 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                     raise ValidationError(
                         "$FULL_KEY is not optional and cannot be assigned None"
                     )
+
+        from omegaconf import OmegaConf
+        from omegaconf._utils import is_attr_class, is_dataclass
+
+        target_type = self._metadata.element_type
+        value_type = OmegaConf.get_type(value)
+        if is_attr_class(target_type) or is_dataclass(target_type):
+            if (
+                target_type is not None
+                and value_type is not None
+                and not issubclass(value_type, target_type)
+            ):
+                msg = (
+                    f"Invalid type assigned : {type_str(value_type)} is not a "
+                    f"subclass of {type_str(target_type)}. value: {value}"
+                )
+                raise ValidationError(msg)
 
     def __deepcopy__(self, memo: Dict[int, Any] = {}) -> "ListConfig":
         res = ListConfig(content=[])

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -14,15 +14,11 @@ from typing import (
     Union,
 )
 
-from omegaconf import OmegaConf
-
 from ._utils import (
     ValueKind,
     _get_value,
     format_and_raise,
     get_value_kind,
-    is_attr_class,
-    is_dataclass,
     is_int,
     is_primitive_list,
     type_str,
@@ -77,6 +73,8 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
             )
 
     def _validate_set(self, key: Any, value: Any) -> None:
+        from omegaconf import OmegaConf
+        from omegaconf._utils import is_attr_class, is_dataclass
 
         self._validate_get(key, value)
 

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -14,11 +14,15 @@ from typing import (
     Union,
 )
 
+from omegaconf import OmegaConf
+
 from ._utils import (
     ValueKind,
     _get_value,
     format_and_raise,
     get_value_kind,
+    is_attr_class,
+    is_dataclass,
     is_int,
     is_primitive_list,
     type_str,
@@ -86,9 +90,6 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                     raise ValidationError(
                         "$FULL_KEY is not optional and cannot be assigned None"
                     )
-
-        from omegaconf import OmegaConf
-        from omegaconf._utils import is_attr_class, is_dataclass
 
         target_type = self._metadata.element_type
         value_type = OmegaConf.get_type(value)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -133,3 +133,14 @@ class PersonD:
 class PersonA:
     age: int = 18
     registered: bool = True
+
+
+@dataclass
+class Module:
+    name: str = MISSING
+    classes: List[str] = MISSING
+
+
+@dataclass
+class Config:
+    modules: List[Module] = MISSING

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -142,5 +142,5 @@ class Module:
 
 
 @dataclass
-class Config:
+class Package:
     modules: List[Module] = MISSING

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -22,8 +22,18 @@ class StructuredWithInvalidField:
 
 @attr.s(auto_attribs=True)
 class User:
-    name: str
-    age: int
+    name: str = MISSING
+    age: int = MISSING
+
+
+@attr.s(auto_attribs=True)
+class UserList:
+    list: List[User] = MISSING
+
+
+@attr.s(auto_attribs=True)
+class UserDict:
+    dict: Dict[str, User] = MISSING
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -23,8 +23,18 @@ class StructuredWithInvalidField:
 
 @dataclass
 class User:
-    name: str
-    age: int
+    name: str = MISSING
+    age: int = MISSING
+
+
+@dataclass
+class UserList:
+    list: List[User] = MISSING
+
+
+@dataclass
+class UserDict:
+    dict: Dict[str, User] = MISSING
 
 
 @dataclass

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -489,6 +489,32 @@ class TestConfigs:
         res = OmegaConf.merge(cfg, {"strings": {"x": "abc"}})
         assert res.strings == {"a": "foo", "b": "bar", "x": "abc"}
 
+    def test_merge_list_with_wrong_type(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.UserList)
+        with pytest.raises(ValidationError):
+            OmegaConf.merge(cfg, {"list": [{"foo": "var"}]})
+
+    def test_merge_list_with_correct_type(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.UserList)
+        user = module.User(name="John", age=21)
+        res = OmegaConf.merge(cfg, {"list": [user]})
+        assert res.list == [user]
+
+    def test_merge_dict_with_wrong_type(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.UserDict)
+        with pytest.raises(ValidationError):
+            OmegaConf.merge(cfg, {"dict": {"foo": "var"}})
+
+    def test_merge_dict_with_correct_type(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.UserDict)
+        user = module.User(name="John", age=21)
+        res = OmegaConf.merge(cfg, {"dict": {"foo": user}})
+        assert res.dict == {"foo": user}
+
     def test_typed_dict_key_error(self, class_type: str) -> None:
         module: Any = import_module(class_type)
         input_ = module.ErrorDictIntKey

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -28,6 +28,7 @@ from . import (
     A,
     Color,
     ConcretePlugin,
+    Config,
     IllegalType,
     Plugin,
     StructuredWithMissing,
@@ -373,6 +374,19 @@ params = [
             parent_node=lambda cfg: cfg.params,
         ),
         id="structured:merge,adding_an_invalid_key",
+    ),
+    pytest.param(
+        Expected(
+            create=lambda: OmegaConf.structured(Config),
+            op=lambda cfg: OmegaConf.merge(cfg, {"modules": [{"foo": "var"}]}),
+            exception_type=ValidationError,
+            msg="Invalid type assigned : dict is not a subclass of Module. value: {'foo': 'var'}",
+            key=0,
+            full_key="modules[0]",
+            object_type=list,
+            low_level=True,
+        ),
+        id="structured:merge,wrong_element_type",
     ),
     # merge_with
     pytest.param(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -28,8 +28,8 @@ from . import (
     A,
     Color,
     ConcretePlugin,
-    Config,
     IllegalType,
+    Package,
     Plugin,
     StructuredWithMissing,
     UnionError,
@@ -377,7 +377,7 @@ params = [
     ),
     pytest.param(
         Expected(
-            create=lambda: OmegaConf.structured(Config),
+            create=lambda: OmegaConf.structured(Package),
             op=lambda cfg: OmegaConf.merge(cfg, {"modules": [{"foo": "var"}]}),
             exception_type=ValidationError,
             msg="Invalid type assigned : dict is not a subclass of Module. value: {'foo': 'var'}",

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -18,6 +18,7 @@ from . import (
     B,
     C,
     ConcretePlugin,
+    Config,
     ConfWithMissingDict,
     Group,
     MissingDict,
@@ -314,6 +315,7 @@ def test_merge_list_list() -> None:
         ([], {}, TypeError),
         ([1, 2, 3], None, ValueError),
         ({"a": 10}, None, ValueError),
+        (Config, {"modules": [{"foo": "var"}]}, ValidationError),
     ],
 )
 def test_merge_error(base: Any, merge: Any, exception: Any) -> None:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -18,11 +18,11 @@ from . import (
     B,
     C,
     ConcretePlugin,
-    Config,
     ConfWithMissingDict,
     Group,
     MissingDict,
     MissingList,
+    Package,
     Plugin,
     User,
     Users,
@@ -315,7 +315,7 @@ def test_merge_list_list() -> None:
         ([], {}, TypeError),
         ([1, 2, 3], None, ValueError),
         ({"a": 10}, None, ValueError),
-        (Config, {"modules": [{"foo": "var"}]}, ValidationError),
+        (Package, {"modules": [{"foo": "var"}]}, ValidationError),
     ],
 )
 def test_merge_error(base: Any, merge: Any, exception: Any) -> None:


### PR DESCRIPTION
Closes #327 .
I added test for testing ListConfig and DictConfig(only ListConfig failed). Also added a test for test_merge and one for test_error with the introduced new error to fix this issue.

I followed the same strategy to validate_set as dictconfig.py config with `issubclass(value_type, target_type)`.