### PR TITLE
make is_float return False for float(st) == float("inf")

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -368,8 +368,7 @@ def is_bool(st: str) -> bool:
 
 def is_float(st: str) -> bool:
     try:
-        float(st)
-        return True
+        return float(st) != float("inf")
     except ValueError:
         return False
 


### PR DESCRIPTION
use case:

`key: /path/to/data-${env:identifier}`

where identifier might be a combination of 6 chars and digits, e.g.
`identifier=2e1354`

Currently the variable interpolation will create this:
`key: /path/to/data-inf`

This commit causes `is_float` to return False here, so that the identifier is inserted as string:
`key: /path/to/data-2e1354`