### PR TITLE
Fix quoting of keys.

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -62,11 +62,17 @@ class OmegaConfDumper(yaml.Dumper):  # type: ignore
 
     @staticmethod
     def str_representer(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
-        with_quotes = yaml_is_bool(data) or is_int(data) or is_float(data)
+        is_key = True if len(data) and data[0] == "_" else False
+        with_quotes = not is_key and (
+            yaml_is_bool(data) or is_int(data) or is_float(data)
+        )
+        if is_key:
+            data = data[1:]
+        style = ""
+        if with_quotes:
+            style = "'"
         return dumper.represent_scalar(
-            yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG,
-            data,
-            style=("'" if with_quotes else None),
+            yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG, data, style=style
         )
 
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -80,7 +80,9 @@ class OmegaConfDumper(yaml.Dumper):  # type: ignore
 
     # Copied method from https://github.com/yaml/pyyaml/blob/master/lib3/yaml/representer.py
     # Added prefix to keys before representing it so we can identify it's a key.
-    def represent_mapping(self, tag: str, mapping: Any, flow_style: bool = None) -> MappingNode:  # type: ignore
+    def represent_mapping(
+        self, tag: str, mapping: Any, flow_style: Optional[bool] = None
+    ) -> MappingNode:  # pragma: no cover
 
         value: List[Any] = []
         node = MappingNode(tag, value, flow_style=flow_style)

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -572,22 +572,6 @@ class OmegaConf:
             root[idx] = value
 
     @staticmethod
-    def _tag_keys(cfg: DictConfig) -> Container:
-        new_cfg = DictConfig(content={})
-        for key in cfg.keys():
-            new_key = key
-            if OmegaConf.is_missing(cfg, key):
-                value = "???"
-            else:
-                value = cfg[key]
-            if isinstance(value, DictConfig):
-                OmegaConf._tag_keys(value)
-            if type(key) == str:
-                new_key = "_" + key
-            new_cfg[new_key] = value
-        return new_cfg
-
-    @staticmethod
     def to_yaml(
         cfg: Container, *, resolve: bool = False, sort_keys: bool = False
     ) -> str:
@@ -598,12 +582,7 @@ class OmegaConf:
         :param sort_keys: If True, will print dict keys in sorted order. default False.
         :return: A string containing the yaml representation.
         """
-        modified_config = cfg
-        if isinstance(cfg, DictConfig):
-            modified_config = OmegaConf._tag_keys(copy.deepcopy(cfg))
-        container = OmegaConf.to_container(
-            modified_config, resolve=resolve, enum_to_str=True
-        )
+        container = OmegaConf.to_container(cfg, resolve=resolve, enum_to_str=True)
         return yaml.dump(  # type: ignore
             container,
             default_flow_style=False,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -572,6 +572,22 @@ class OmegaConf:
             root[idx] = value
 
     @staticmethod
+    def _tag_keys(cfg: DictConfig) -> Container:
+        new_cfg = DictConfig(content={})
+        for key in cfg.keys():
+            new_key = key
+            if OmegaConf.is_missing(cfg, key):
+                value = "???"
+            else:
+                value = cfg[key]
+            if isinstance(value, DictConfig):
+                OmegaConf._tag_keys(value)
+            if type(key) == str:
+                new_key = "_" + key
+            new_cfg[new_key] = value
+        return new_cfg
+
+    @staticmethod
     def to_yaml(
         cfg: Container, *, resolve: bool = False, sort_keys: bool = False
     ) -> str:
@@ -582,7 +598,12 @@ class OmegaConf:
         :param sort_keys: If True, will print dict keys in sorted order. default False.
         :return: A string containing the yaml representation.
         """
-        container = OmegaConf.to_container(cfg, resolve=resolve, enum_to_str=True)
+        modified_config = cfg
+        if isinstance(cfg, DictConfig):
+            modified_config = OmegaConf._tag_keys(copy.deepcopy(cfg))
+        container = OmegaConf.to_container(
+            modified_config, resolve=resolve, enum_to_str=True
+        )
         return yaml.dump(  # type: ignore
             container,
             default_flow_style=False,

--- a/tests/test_to_yaml.py
+++ b/tests/test_to_yaml.py
@@ -57,7 +57,7 @@ def test_to_yaml_string_primitive_types_list(
 
 
 def test_to_yaml_bool_type_as_key() -> None:
-    for t in _utils.YAML_BOOL_TYPES:
+    for t in ["y", "n", "Y", "N"]:
         c = OmegaConf.create({t: "var"})
         assert OmegaConf.to_yaml(c) == "%s: var\n" % t
 

--- a/tests/test_to_yaml.py
+++ b/tests/test_to_yaml.py
@@ -56,6 +56,12 @@ def test_to_yaml_string_primitive_types_list(
         assert OmegaConf.to_yaml(c) == expected
 
 
+def test_to_yaml_bool_type_as_key() -> None:
+    for t in _utils.YAML_BOOL_TYPES:
+        c = OmegaConf.create({t: "var"})
+        assert OmegaConf.to_yaml(c) == "%s: var\n" % t
+
+
 @pytest.mark.parametrize(  # type: ignore
     "input_, expected, type_",
     [


### PR DESCRIPTION
For some reason 'yes' as key gets quoted as opposed to every other yaml_bool_type. I don't know which prefix would be better instead of '\_'.