### PR TITLE
Add support for Union type in structured configs.

### DIFF
--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -15,6 +15,7 @@ from .nodes import (
     FloatNode,
     IntegerNode,
     StringNode,
+    UnionNode,
     ValueNode,
 )
 from .omegaconf import (
@@ -46,6 +47,7 @@ __all__ = [
     "open_dict",
     "Node",
     "ValueNode",
+    "UnionNode",
     "AnyNode",
     "IntegerNode",
     "StringNode",

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -8,7 +8,12 @@ from typing import Any, Dict, List, Match, Optional, Tuple, Type, Union, get_typ
 
 import yaml
 
-from .errors import ConfigIndexError, ConfigTypeError, OmegaConfBaseException
+from .errors import (
+    ConfigIndexError,
+    ConfigTypeError,
+    OmegaConfBaseException,
+    UnsupportedValueType,
+)
 
 try:
     import dataclasses
@@ -445,7 +450,11 @@ def get_union_types(ref_type: Optional[Any]) -> Union[List[Any], Any]:
     if args is not None and Any not in args:
         element_types = list(args)
     else:
-        element_types = Any
+        if args is None:
+            msg = "{} is not a valid Union type, it should include more than 1 type."
+        elif Any in args:
+            msg = "{} is not a valid Union type, Any is not a valid union element type."
+        raise UnsupportedValueType(msg.format(ref_type))
 
     return element_types
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -447,8 +447,7 @@ def get_union_types(ref_type: Optional[Any]) -> List[Any]:
     element_types: List[Any]
     if ref_type is not Union and args is not None and args[0] is not Any:
         element_types = list(args)
-    else:
-        element_types = None  # type: ignore
+    assert element_types is not None
 
     return element_types
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -446,23 +446,18 @@ def is_primitive_container(obj: Any) -> bool:
 
 def get_union_types(ref_type: Optional[Any]) -> Union[List[Any], Any]:
     args = getattr(ref_type, "__args__", None)
-    element_types: Union[List[Any], Any]
+    args = getattr(ref_type, "__args__", None)
     error_msg = ""
-    if args is None:
+    if args is None or len(args) < 2:
         error_msg = "{} is not a valid Union type, it should include more than 1 type."
     elif Any in args:
         error_msg = (
             "{} is not a valid Union type, Any is not a valid union element type."
         )
     elif type(None) in args and len(args) == 2:
-        error_msg = "{} is not a valid Union type, we recomend using Optional instead."
+        error_msg = "{} is not a valid Union type, we recommend using Optional instead."
     if error_msg:
         raise UnsupportedValueType(error_msg.format(ref_type))
-
-    if args is not None and Any not in args:
-        element_types = list(args)
-
-    return element_types
 
 
 def get_list_element_type(ref_type: Optional[Type[Any]]) -> Any:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -444,10 +444,10 @@ def is_primitive_container(obj: Any) -> bool:
     return is_primitive_list(obj) or is_primitive_dict(obj)
 
 
-def get_union_types(ref_type: Optional[Any]) -> Union[List[Any], Any]:
-    args = getattr(ref_type, "__args__", None)
+def get_union_types(ref_type: Optional[Any]) -> List[Any]:
     args = getattr(ref_type, "__args__", None)
     error_msg = ""
+    element_types: List[Any]
     if args is None or len(args) < 2:
         error_msg = "{} is not a valid Union type, it should include more than 1 type."
     elif Any in args:
@@ -458,6 +458,8 @@ def get_union_types(ref_type: Optional[Any]) -> Union[List[Any], Any]:
         error_msg = "{} is not a valid Union type, we recommend using Optional instead."
     if error_msg:
         raise UnsupportedValueType(error_msg.format(ref_type))
+    element_types = list(args)
+    return element_types
 
 
 def get_list_element_type(ref_type: Optional[Type[Any]]) -> Any:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -472,7 +472,7 @@ def get_dict_key_value_types(ref_type: Any) -> Tuple[Any, Any]:
 
     key_type: Any
     element_type: Any
-    if ref_type is None:
+    if ref_type is None or ref_type == Dict:
         key_type = Any
         element_type = Any
     else:
@@ -491,7 +491,7 @@ def valid_value_annotation_type(type_: Any) -> bool:
 
 
 def _valid_dict_key_annotation_type(type_: Any) -> bool:
-    return type_ is Any or issubclass(type_, (str, Enum))
+    return type_ is None or type_ is Any or issubclass(type_, (str, Enum))
 
 
 def is_primitive_type(type_: Any) -> bool:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -772,7 +772,6 @@ def validate_value_in_annotation(value: Any, ref_type: Any) -> bool:
 
     valid_type = False
     input_type: Any = type(value)
-    print(value, ref_type, input_type)
     if isinstance(value, Node):
         input_type = value._metadata.ref_type
     if is_list_annotation(ref_type):
@@ -819,10 +818,8 @@ def validate_value_in_dict_annotation(value: Any, dict_type: Dict[Any, Any]) -> 
         return False
     for key in value:
         item = value[key]
-        print(key, key_type, element_type)
         if not isinstance(key, key_type):
             valid_value = False
-            print("xd")
             break
         elif is_nested_type(element_type):
             valid_value = validate_value_in_annotation(item, element_type)

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -452,6 +452,31 @@ def get_union_types(ref_type: Optional[Any]) -> List[Any]:
     return element_types
 
 
+def is_valid_value_list_annotation(value: Any, list_type: List[Any]) -> bool:
+    element_type = get_list_element_type(list_type)  # type: ignore
+    valid_value = True
+    if not isinstance(value, list):
+        return False
+    for item in value:
+        if not isinstance(item, element_type):
+            valid_value = False
+            break
+    return valid_value
+
+
+def is_valid_value_dict_annotation(value: Any, dict_type: Dict[Any, Any]) -> bool:
+    key_type, element_type = get_dict_key_value_types(dict_type)
+    valid_value = True
+    if not isinstance(value, dict):
+        return False
+    for key in value:
+        item = value[key]
+        if not isinstance(key, key_type) or not isinstance(item, element_type):
+            valid_value = False
+            break
+    return valid_value
+
+
 def get_list_element_type(ref_type: Optional[Type[Any]]) -> Any:
     args = getattr(ref_type, "__args__", None)
     if ref_type is not List and args is not None and args[0]:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -235,7 +235,6 @@ def get_dataclass_data(
                 value = MISSING
             else:
                 value = field.default_factory()  # type: ignore
-
         d[name] = _maybe_wrap(
             ref_type=type_,
             is_optional=is_optional,

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -8,12 +8,7 @@ from typing import Any, Dict, List, Match, Optional, Tuple, Type, Union, get_typ
 
 import yaml
 
-from .errors import (
-    ConfigIndexError,
-    ConfigTypeError,
-    ConfigValueError,
-    OmegaConfBaseException,
-)
+from .errors import ConfigIndexError, ConfigTypeError, OmegaConfBaseException
 
 try:
     import dataclasses
@@ -199,12 +194,10 @@ def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, A
         else:
             value = attrib.default
             if value == attr.NOTHING:
-                value = MISSING
-        if _is_union(type_):
-            e = ConfigValueError(
-                f"Union types are not supported:\n{name}: {type_str(type_)}"
-            )
-            format_and_raise(node=None, key=None, value=value, cause=e, msg=str(e))
+                if is_nested:
+                    value = type_
+                else:
+                    value = MISSING
 
         d[name] = _maybe_wrap(
             ref_type=type_,
@@ -241,11 +234,6 @@ def get_dataclass_data(
             else:
                 value = field.default_factory()  # type: ignore
 
-        if _is_union(type_):
-            e = ConfigValueError(
-                f"Union types are not supported:\n{name}: {type_str(type_)}"
-            )
-            format_and_raise(node=None, key=None, value=value, cause=e, msg=str(e))
         d[name] = _maybe_wrap(
             ref_type=type_,
             is_optional=is_optional,
@@ -452,6 +440,17 @@ def is_dict(obj: Any) -> bool:
 
 def is_primitive_container(obj: Any) -> bool:
     return is_primitive_list(obj) or is_primitive_dict(obj)
+
+
+def get_union_types(ref_type: Optional[Any]) -> List[Any]:
+    args = getattr(ref_type, "__args__", None)
+    element_types: List[Any]
+    if ref_type is not Union and args is not None and args[0] is not Any:
+        element_types = list(args)
+    else:
+        element_types = None  # type: ignore
+
+    return element_types
 
 
 def get_list_element_type(ref_type: Optional[Type[Any]]) -> Any:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -439,12 +439,13 @@ def is_primitive_container(obj: Any) -> bool:
     return is_primitive_list(obj) or is_primitive_dict(obj)
 
 
-def get_union_types(ref_type: Optional[Any]) -> List[Any]:
+def get_union_types(ref_type: Optional[Any]) -> Union[List[Any], Any]:
     args = getattr(ref_type, "__args__", None)
-    element_types: List[Any]
-    if ref_type is not Union and args is not None and args[0] is not Any:
+    element_types: Union[List[Any], Any]
+    if args is not None and Any not in args:
         element_types = list(args)
-    assert element_types is not None
+    else:
+        element_types = Any
 
     return element_types
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -447,14 +447,20 @@ def is_primitive_container(obj: Any) -> bool:
 def get_union_types(ref_type: Optional[Any]) -> Union[List[Any], Any]:
     args = getattr(ref_type, "__args__", None)
     element_types: Union[List[Any], Any]
+    error_msg = ""
+    if args is None:
+        error_msg = "{} is not a valid Union type, it should include more than 1 type."
+    elif Any in args:
+        error_msg = (
+            "{} is not a valid Union type, Any is not a valid union element type."
+        )
+    elif type(None) in args and len(args) == 2:
+        error_msg = "{} is not a valid Union type, we recomend using Optional instead."
+    if error_msg:
+        raise UnsupportedValueType(error_msg.format(ref_type))
+
     if args is not None and Any not in args:
         element_types = list(args)
-    else:
-        if args is None:
-            msg = "{} is not a valid Union type, it should include more than 1 type."
-        elif Any in args:
-            msg = "{} is not a valid Union type, Any is not a valid union element type."
-        raise UnsupportedValueType(msg.format(ref_type))
 
     return element_types
 

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, Iterator, Optional, Tuple, Type, Union
 
-from ._utils import ValueKind, _get_value, format_and_raise, get_value_kind
+from ._utils import ValueKind, _get_value, _is_union, format_and_raise, get_value_kind
 from .errors import ConfigKeyError, MissingMandatoryValue, UnsupportedInterpolationType
 
 
@@ -39,7 +39,11 @@ class ContainerMetadata(Metadata):
     def __post_init__(self) -> None:
         assert self.key_type is Any or isinstance(self.key_type, type)
         if self.element_type is not None:
-            assert self.element_type is Any or isinstance(self.element_type, type)
+            assert (
+                self.element_type is Any
+                or isinstance(self.element_type, type)
+                or _is_union(self.element_type)
+            )
 
         if self.flags is None:
             self.flags = {}

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -449,7 +449,6 @@ class BaseContainer(Container, ABC):
         input_config = isinstance(value, Container)
         target_node_ref = self._get_node(key)
         special_value = value is None or value == "???"
-
         input_node = isinstance(value, ValueNode)
         if isinstance(self.__dict__["_content"], dict):
             target_node = key in self.__dict__["_content"] and isinstance(

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -118,7 +118,6 @@ class BaseContainer(Container, ABC):
                 d["_metadata"].ref_type = List[element_type]  # type: ignore
             else:
                 assert False
-
         self.__dict__.update(d)
 
     @abstractmethod

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -117,12 +117,9 @@ class BaseContainer(Container, ABC):
             key_type = d["_metadata"].key_type
         element_type = d["_metadata"].element_type
         if isinstance(element_type, list):
-            union = Union[element_type[0]]  # type: ignore
-            for type_ in element_type:
-                union = Union[union, type_]  # type: ignore
-            d["_metadata"].element_type = union
+            d["_metadata"].element_type = Union[tuple(element_type)]
+            element_type = d["_metadata"].element_type
 
-        element_type = d["_metadata"].element_type
         ref_type = d["_metadata"].ref_type
         if is_container_annotation(ref_type):
             if is_generic_dict(ref_type):

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -116,6 +116,13 @@ class BaseContainer(Container, ABC):
         if isinstance(self, DictConfig):
             key_type = d["_metadata"].key_type
         element_type = d["_metadata"].element_type
+        if isinstance(element_type, list):
+            union = Union[element_type[0]]  # type: ignore
+            for type_ in element_type:
+                union = Union[union, type_]  # type: ignore
+            d["_metadata"].element_type = union
+
+        element_type = d["_metadata"].element_type
         ref_type = d["_metadata"].ref_type
         if is_container_annotation(ref_type):
             if is_generic_dict(ref_type):
@@ -124,12 +131,6 @@ class BaseContainer(Container, ABC):
                 d["_metadata"].ref_type = List[element_type]  # type: ignore
             else:
                 assert False
-
-        if isinstance(element_type, list):
-            union = Union[element_type[0]]  # type: ignore
-            for type_ in element_type:
-                union = Union[union, type_]  # type: ignore
-            d["_metadata"].element_type = union
 
         self.__dict__.update(d)
 

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -157,7 +157,6 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
             return
 
         target = self._get_node(key) if key is not None else self
-
         target_has_ref_type = isinstance(
             target, DictConfig
         ) and target._metadata.ref_type not in (Any, dict)

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -217,6 +217,9 @@ class UnionNode(ValueNode):
         else:
             return self._value()._value() == other  # type: ignore
 
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
+
     def __deepcopy__(self, memo: Dict[int, Any] = {}) -> "UnionNode":
         res = UnionNode(
             ref_type=self._metadata.ref_type,

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -202,40 +202,14 @@ class UnionNode(ValueNode):
             )
 
     def validate_and_convert(self, value: Any) -> Optional[Any]:
+        from omegaconf._utils import validate_value_in_union_annotation
+
         if value is None:
             return None
-        if not self._validate_value(value):
+        if not validate_value_in_union_annotation(value, self.element_types):
             msg = f"invalid value {value} should be {self.element_types}"
             raise ValidationError(msg)
         return value
-
-    def _validate_value(self, value: Any) -> bool:
-        from omegaconf import DictConfig, ListConfig
-        from omegaconf._utils import (
-            is_dict_annotation,
-            is_list_annotation,
-            is_valid_value_dict_annotation,
-            is_valid_value_list_annotation,
-        )
-
-        valid_type = False
-        for element_type in self.element_types:
-            type_: Any = type(value)
-            if isinstance(value, Node):
-                type_ = value._metadata.ref_type
-            if is_list_annotation(element_type):
-                valid_type = is_valid_value_list_annotation(value, element_type)
-            elif is_dict_annotation(element_type):
-                valid_type = is_valid_value_dict_annotation(value, element_type)
-            elif element_type == ListConfig and type_ == list:
-                valid_type = True
-            elif element_type == DictConfig and type_ == dict:
-                valid_type = True
-            elif element_type == type_:
-                valid_type = True
-            if valid_type:
-                break
-        return valid_type
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, AnyNode):

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -211,13 +211,23 @@ class UnionNode(ValueNode):
 
     def _validate_value(self, value: Any) -> bool:
         from omegaconf import DictConfig, ListConfig
+        from omegaconf._utils import (
+            is_dict_annotation,
+            is_list_annotation,
+            is_valid_value_dict_annotation,
+            is_valid_value_list_annotation,
+        )
 
         valid_type = False
         for element_type in self.element_types:
             type_: Any = type(value)
             if isinstance(value, Node):
                 type_ = value._metadata.ref_type
-            if element_type == ListConfig and type_ == list:
+            if is_list_annotation(element_type):
+                valid_type = is_valid_value_list_annotation(value, element_type)
+            elif is_dict_annotation(element_type):
+                valid_type = is_valid_value_dict_annotation(value, element_type)
+            elif element_type == ListConfig and type_ == list:
                 valid_type = True
             elif element_type == DictConfig and type_ == dict:
                 valid_type = True

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -234,7 +234,6 @@ class UnionNode(ValueNode):
             return self._value()._value() == other  # type: ignore
 
     def __deepcopy__(self, memo: Dict[int, Any] = {}) -> "UnionNode":
-        # TODO missing in case container for self._val
         res = UnionNode(
             ref_type=self._metadata.ref_type,
             value=self._val,

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -171,7 +171,7 @@ class UnionNode(ValueNode):
         parent: Optional[Container] = None,
         is_optional: bool = True,
         ref_type: Any = Union[Any],
-        element_types: List[Any] = [],
+        element_types: List[Any] = None,  # type: ignore
     ):
         self.element_types = element_types
         super().__init__(

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -226,6 +226,7 @@ class UnionNode(ValueNode):
             self._bring_type_to_front(value_type)
         for union_type in self.element_types:
             try:
+                print(union_type, value)
                 value_node = self._wrap_node(
                     value=value, ref_type=union_type, use_type=True
                 )

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -221,8 +221,6 @@ class UnionNode(ValueNode):
             ref_type = value._metadata.ref_type
             if is_structured_config(ref_type):
                 value_type = ref_type
-            else:
-                value_type = type(value)
             if any(
                 issubclass(value_type, union_type) for union_type in self.element_types
             ):

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -249,8 +249,7 @@ class UnionNode(ValueNode):
 
     def _raise_invalid_value(self, value: Any, value_type: Any) -> None:
         raise ValidationError(
-            "Value '%s' with value_type '%s' is not in '%s'"
-            % (value, value_type, self.element_types)
+            f"Value '{value}' with value_type '{value_type}' is not in '{self.element_types}'"
         )
 
     def _get_element_types_lead_by(self, type_: Any) -> List[Any]:

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -251,8 +251,11 @@ class UnionNode(ValueNode):
         )
 
     def _get_element_types_lead_by(self, type_: Any) -> List[Any]:
+        pos = self.element_types.index(type_)
+        if pos == 0:
+            return self.element_types
         element_types = copy.copy(self.element_types)
-        element_types.insert(0, element_types.pop(element_types.index(type_)))
+        element_types[0], element_types[pos] = element_types[pos], element_types[0]
         return element_types
 
     def __eq__(self, other: Any) -> bool:

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -214,8 +214,6 @@ class UnionNode(ValueNode):
             )
 
     def validate_and_convert(self, value: Any) -> Optional[Any]:
-        if value is None:
-            return None
         value_node = None
         valid_value = False
         for union_type in self.element_types:
@@ -234,10 +232,10 @@ class UnionNode(ValueNode):
         return value_node
 
     def __eq__(self, other: Any) -> bool:
-        if isinstance(other, AnyNode):
-            return self._value() == other._value()  # type: ignore
-        else:
+        if isinstance(other, ValueNode):
             return self._value()._value() == other  # type: ignore
+        else:
+            return self._value() == other  # type: ignore
 
     def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -196,15 +196,11 @@ class UnionNode(ValueNode):
     ) -> Optional[Node]:
         from omegaconf.omegaconf import _maybe_wrap
 
-        if ref_type is None:
-            type_ = type(value)
-        else:
-            type_ = ref_type
         if value is None:
             return None
         else:
             return _maybe_wrap(
-                ref_type=type_,
+                ref_type=ref_type,
                 key=key,
                 value=value,
                 is_optional=is_optional,

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -217,16 +217,20 @@ class UnionNode(ValueNode):
         value_node = None
         valid_value = False
         value_type: Any = type(value)
-        if isinstance(value, BaseContainer) and is_structured_config(
-            value._metadata.ref_type
-        ):
-            value_type = value._metadata.ref_type
+        if isinstance(value, BaseContainer):
+            ref_type = value._metadata.ref_type
+            if is_structured_config(ref_type):
+                value_type = ref_type
+            else:
+                value_type = type(value)
             if any(
                 issubclass(value_type, union_type) for union_type in self.element_types
             ):
                 return value
             else:
                 self._raise_invalid_value(value, value._metadata.ref_type)
+        if isinstance(value, ValueNode):
+            value = value._value()
         element_types = self.element_types
         if value_type in self.element_types:
             element_types = self._get_element_types_lead_by(value_type)

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -172,7 +172,8 @@ class UnionNode(ValueNode):
         parent: Optional[Container] = None,
         is_optional: bool = True,
         ref_type: Any = Union[Any],
-        element_types: List[Any] = None,  # type: ignore
+        *,
+        element_types: List[Any],
     ):
         self.element_types = element_types
         super().__init__(

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -268,6 +268,19 @@ class UnionNode(ValueNode):
     def __hash__(self) -> int:
         return hash(self._val)
 
+    def __getstate__(self) -> Dict[str, Any]:
+        node = copy.copy(self.__dict__)
+        node["_metadata"].ref_type = Union
+        return node
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        element_types = state["element_types"]
+        union = Union[element_types[0]]  # type: ignore
+        for element_type in element_types:
+            union = Union[union, element_type]  # type: ignore
+        state["_metadata"].ref_type = union
+        self.__dict__.update(state)
+
 
 class StringNode(ValueNode):
     def __init__(

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -852,7 +852,7 @@ def _maybe_wrap(
 ) -> Node:
     # if already a node, update key and parent and return as is.
     # NOTE: that this mutate the input node!
-    if isinstance(value, Node):
+    if isinstance(value, Node) and ref_type is Any:
         value._set_key(key)
         value._set_parent(parent)
         return value

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -794,7 +794,7 @@ def _node_wrap(
         element_types = get_union_types(type_)
         if type(None) in element_types:
             is_optional = True
-            element_types.pop()
+            element_types.remove(type(None))
         else:
             is_optional = False
         node = UnionNode(

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -258,6 +258,7 @@ class OmegaConf:
                     element_type = get_list_element_type(ref_type)
                     return ListConfig(
                         element_type=element_type,
+                        ref_type=ref_type,
                         content=obj,
                         parent=parent,
                         flags=flags,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -32,12 +32,14 @@ from . import DictConfig, ListConfig
 from ._utils import (
     _ensure_container,
     _get_value,
+    _is_union,
     decode_primitive,
     format_and_raise,
     get_dict_key_value_types,
     get_list_element_type,
     get_omega_conf_dumper,
     get_type_of,
+    get_union_types,
     is_attr_class,
     is_dataclass,
     is_dict_annotation,
@@ -66,6 +68,7 @@ from .nodes import (
     FloatNode,
     IntegerNode,
     StringNode,
+    UnionNode,
     ValueNode,
 )
 
@@ -786,6 +789,16 @@ def _node_wrap(
             is_optional=is_optional,
             element_type=element_type,
             ref_type=ref_type,
+        )
+    elif _is_union(type_):
+        element_types = get_union_types(type_)
+        node = UnionNode(
+            ref_type=type_,
+            element_types=element_types,
+            value=value,
+            key=key,
+            parent=parent,
+            is_optional=is_optional,
         )
     elif is_structured_config(type_) or is_structured_config(value):
         key_type, element_type = get_dict_key_value_types(type_)

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -792,6 +792,11 @@ def _node_wrap(
         )
     elif _is_union(type_):
         element_types = get_union_types(type_)
+        if type(None) in element_types:
+            is_optional = True
+            element_types.pop()
+        else:
+            is_optional = False
         node = UnionNode(
             ref_type=type_,
             element_types=element_types,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -761,14 +761,14 @@ def _node_wrap(
     value: Any,
     key: Any,
     ref_type: Any = None,
+    use_type: bool = False,
 ) -> Node:
     node: Node
-    is_dict = type(value) is dict or is_dict_annotation(type_)
-    is_list = (
-        type(value) in (list, tuple)
-        or is_list_annotation(type_)
-        or is_tuple_annotation(type_)
-    )
+    is_dict = is_dict_annotation(type_)
+    is_list = is_list_annotation(type_) or is_tuple_annotation(type_)
+    if not use_type:
+        is_dict = is_dict or type(value) is dict
+        is_list = is_list or type(value) in (list, tuple)
     if is_dict:
         key_type, element_type = get_dict_key_value_types(type_)
         node = DictConfig(
@@ -843,6 +843,7 @@ def _maybe_wrap(
     value: Any,
     is_optional: bool,
     parent: Optional[BaseContainer],
+    use_type: bool = False,
 ) -> Node:
     # if already a node, update key and parent and return as is.
     # NOTE: that this mutate the input node!
@@ -858,6 +859,7 @@ def _maybe_wrap(
             value=value,
             key=key,
             ref_type=ref_type,
+            use_type=use_type,
         )
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -88,11 +88,6 @@ class StructuredWithMissing:
 
 
 @dataclass
-class UnionError:
-    x: Union[int, str] = 10
-
-
-@dataclass
 class MissingList:
     list: List[str] = MISSING
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -175,3 +175,13 @@ class InterpolationDict:
 
 class UnionClass:
     foo: Union[str, int] = 1
+
+
+@dataclass
+class DictUnion:
+    dict: Dict[str, Union[int, bool]] = field(default_factory=lambda: {"a": 1})
+
+
+@dataclass
+class ListUnion:
+    list: List[Union[int, bool]] = field(default_factory=lambda: [1])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -147,8 +147,20 @@ class Package:
 
 
 @dataclass
+class UntypedList:
+    list: List = field(default_factory=lambda: [1, 2])  # type: ignore
+    opt_list: Optional[List] = None  # type: ignore
+
+
+@dataclass
 class SubscriptedList:
     list: List[int] = field(default_factory=lambda: [1, 2])
+
+
+@dataclass
+class UntypedDict:
+    dict: Dict = field(default_factory=lambda: {"foo": "var"})  # type: ignore
+    opt_dict: Optional[Dict] = None  # type: ignore
 
 
 @dataclass

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -180,9 +180,9 @@ class UnionClass:
 
 @dataclass
 class DictUnion:
-    dict: Dict[str, Union[int, bool]] = field(default_factory=lambda: {"a": 1})
+    dict: Dict[str, Union[int, float]] = field(default_factory=lambda: {"a": 1})
 
 
 @dataclass
 class ListUnion:
-    list: List[Union[int, bool]] = field(default_factory=lambda: [1])
+    list: List[Union[int, float]] = field(default_factory=lambda: [1])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -173,6 +173,7 @@ class InterpolationDict:
     dict: Dict[str, int] = II("optimization.lr")
 
 
+@dataclass
 class UnionClass:
     foo: Union[str, int] = 1
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -176,3 +176,7 @@ class InterpolationList:
 @dataclass
 class InterpolationDict:
     dict: Dict[str, int] = II("optimization.lr")
+
+
+class UnionClass:
+    foo: Union[str, int] = 1

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -506,7 +506,7 @@ class Shelf2:
 
 @attr.s(auto_attribs=True)
 class OptionalBook:
-    author: Optional[Union[str, int]] = "author"
+    author: Optional[Union[str, List[str]]] = "author"
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import attr
 import pytest
 
-from omegaconf import II, MISSING, SI
+from omegaconf import II, MISSING, SI, ListConfig
 from tests import Color
 
 # attr is a dependency of pytest which means it's always available when testing with pytest.
@@ -462,11 +462,6 @@ class NestedWithNone:
 
 
 @attr.s(auto_attribs=True)
-class UnionError:
-    x: Union[int, str] = 10
-
-
-@attr.s(auto_attribs=True)
 class WithNativeMISSING:
     num: int = attr.NOTHING  # type: ignore
 
@@ -492,3 +487,13 @@ class UntypedList:
 class UntypedDict:
     dict: Dict = {"foo": "var"}  # type: ignore
     opt_dict: Optional[Dict] = None  # type: ignore
+    
+
+@attr.s(auto_attribs=True)
+class Book:
+    author: Union[str, ListConfig] = "dude"
+
+
+@attr.s(auto_attribs=True)
+class Shelf:
+    content: Union[Book, int] = 1

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -502,3 +502,8 @@ class Shelf:
 @attr.s(auto_attribs=True)
 class Shelf2:
     content: Union[Book, List[Book]] = Book()
+
+
+@attr.s(auto_attribs=True)
+class OptionalBook:
+    author: Optional[Union[str, int]] = "author"

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import attr
 import pytest
 
-from omegaconf import II, MISSING, SI
+from omegaconf import II, MISSING, SI, DictConfig, ListConfig
 from tests import Color
 
 # attr is a dependency of pytest which means it's always available when testing with pytest.
@@ -517,3 +517,9 @@ class ListUnion:
 @attr.s(auto_attribs=True)
 class DictUnion:
     dict: Dict[str, Union[float, int]] = {"foo": 1}
+
+
+@attr.s(auto_attribs=True)
+class UnionWithContainer:
+    union_dict: Union[DictConfig, int] = DictConfig({"foo": 1})
+    union_list: Union[ListConfig, int] = ListConfig([1, 2])

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -523,3 +523,28 @@ class DictUnion:
 class UnionWithContainer:
     union_dict: Union[DictConfig, int] = DictConfig({"foo": 1})
     union_list: Union[ListConfig, int] = ListConfig([1, 2])
+
+
+@attr.s(auto_attribs=True)
+class Base:
+    foo: int = 1
+
+
+@attr.s(auto_attribs=True)
+class Subclass1(Base):
+    pass
+
+
+@attr.s(auto_attribs=True)
+class Subclass2(Base):
+    pass
+
+
+@attr.s(auto_attribs=True)
+class UnionWithBaseclass:
+    foo: Union[Base, int]
+
+
+@attr.s(auto_attribs=True)
+class UnionOfSubclasses:
+    foo: Union[Subclass1, Subclass2]

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -66,7 +66,6 @@ class AnyTypeConfig:
 
 @attr.s(auto_attribs=True)
 class BoolConfig:
-
     # with default value
     with_default: bool = True
 
@@ -82,7 +81,6 @@ class BoolConfig:
 
 @attr.s(auto_attribs=True)
 class IntegersConfig:
-
     # with default value
     with_default: int = 10
 
@@ -98,7 +96,6 @@ class IntegersConfig:
 
 @attr.s(auto_attribs=True)
 class StringConfig:
-
     # with default value
     with_default: str = "foo"
 
@@ -114,7 +111,6 @@ class StringConfig:
 
 @attr.s(auto_attribs=True)
 class FloatConfig:
-
     # with default value
     with_default: float = 0.10
 
@@ -130,7 +126,6 @@ class FloatConfig:
 
 @attr.s(auto_attribs=True)
 class EnumConfig:
-
     # with default value
     with_default: Color = Color.BLUE
 
@@ -485,3 +480,15 @@ class MissingStructuredConfigField:
 class ListClass:
     list: List[int] = []
     tuple: Tuple[int, int] = (1, 2)
+
+
+@attr.s(auto_attribs=True)
+class UntypedList:
+    list: List = [1, 2]  # type: ignore
+    opt_list: Optional[List] = None  # type: ignore
+
+
+@attr.s(auto_attribs=True)
+class UntypedDict:
+    dict: Dict = {"foo": "var"}  # type: ignore
+    opt_dict: Optional[Dict] = None  # type: ignore

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -487,7 +487,7 @@ class UntypedList:
 class UntypedDict:
     dict: Dict = {"foo": "var"}  # type: ignore
     opt_dict: Optional[Dict] = None  # type: ignore
-    
+
 
 @attr.s(auto_attribs=True)
 class Book:

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import attr
 import pytest
 
-from omegaconf import II, MISSING, SI, ListConfig
+from omegaconf import II, MISSING, SI
 from tests import Color
 
 # attr is a dependency of pytest which means it's always available when testing with pytest.
@@ -491,7 +491,7 @@ class UntypedDict:
 
 @attr.s(auto_attribs=True)
 class Book:
-    author: Union[str, ListConfig] = "dude"
+    author: Union[str, List[str]] = "dude"
 
 
 @attr.s(auto_attribs=True)
@@ -502,8 +502,3 @@ class Shelf:
 @attr.s(auto_attribs=True)
 class Shelf2:
     content: Union[Book, List[Book]] = Book()
-
-
-@attr.s(auto_attribs=True)
-class Shelf3:
-    content: Union[Book, Dict[str, Book]] = Book()

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -497,3 +497,13 @@ class Book:
 @attr.s(auto_attribs=True)
 class Shelf:
     content: Union[Book, int] = 1
+
+
+@attr.s(auto_attribs=True)
+class Shelf2:
+    content: Union[Book, List[Book]] = Book()
+
+
+@attr.s(auto_attribs=True)
+class Shelf3:
+    content: Union[Book, Dict[str, Book]] = Book()

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -507,3 +507,13 @@ class Shelf2:
 @attr.s(auto_attribs=True)
 class OptionalBook:
     author: Optional[Union[str, int]] = "author"
+
+
+@attr.s(auto_attribs=True)
+class ListUnion:
+    list: List[Union[float, int]] = [1, 3.14]
+
+
+@attr.s(auto_attribs=True)
+class DictUnion:
+    dict: Dict[str, Union[float, int]] = {"foo": 1}

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -497,3 +497,15 @@ class MissingStructuredConfigField:
 class ListClass:
     list: List[int] = field(default_factory=lambda: [])
     tuple: Tuple[int, int] = field(default_factory=lambda: (1, 2))
+
+
+@dataclass
+class UntypedList:
+    list: List = field(default_factory=lambda: [1, 2])  # type: ignore
+    opt_list: Optional[List] = None  # type: ignore
+
+
+@dataclass
+class UntypedDict:
+    dict: Dict = field(default_factory=lambda: {"foo": "var"})  # type: ignore
+    opt_dict: Optional[Dict] = None  # type: ignore

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -514,3 +514,13 @@ class Book:
 @dataclass
 class Shelf:
     content: Union[Book, int] = 1
+
+
+@dataclass
+class Shelf2:
+    content: Union[Book, List[Book]] = Book()
+
+
+@dataclass
+class Shelf3:
+    content: Union[Book, Dict[str, Book]] = Book()

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
 
-from omegaconf import II, MISSING, SI
+from omegaconf import II, MISSING, SI, ListConfig
 from tests import Color
 
 # skip test if dataclasses are not available
@@ -479,11 +479,6 @@ class NestedWithNone:
 
 
 @dataclass
-class UnionError:
-    x: Union[int, str] = 10
-
-
-@dataclass
 class WithNativeMISSING:
     num: int = dataclasses.MISSING  # type: ignore
 
@@ -509,3 +504,13 @@ class UntypedList:
 class UntypedDict:
     dict: Dict = field(default_factory=lambda: {"foo": "var"})  # type: ignore
     opt_dict: Optional[Dict] = None  # type: ignore
+
+
+@dataclass
+class Book:
+    author: Union[str, ListConfig] = "dude"
+
+
+@dataclass
+class Shelf:
+    content: Union[Book, int] = 1

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -519,3 +519,8 @@ class Shelf:
 @dataclass
 class Shelf2:
     content: Union[Book, List[Book]] = Book()
+
+
+@dataclass
+class OptionalBook:
+    author: Optional[Union[str, List[str]]] = "foo"

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
 
-from omegaconf import II, MISSING, SI, ListConfig
+from omegaconf import II, MISSING, SI
 from tests import Color
 
 # skip test if dataclasses are not available
@@ -508,7 +508,7 @@ class UntypedDict:
 
 @dataclass
 class Book:
-    author: Union[str, ListConfig] = "dude"
+    author: Union[str, List[str]] = "dude"
 
 
 @dataclass
@@ -519,8 +519,3 @@ class Shelf:
 @dataclass
 class Shelf2:
     content: Union[Book, List[Book]] = Book()
-
-
-@dataclass
-class Shelf3:
-    content: Union[Book, Dict[str, Book]] = Book()

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -524,3 +524,13 @@ class Shelf2:
 @dataclass
 class OptionalBook:
     author: Optional[Union[str, List[str]]] = "foo"
+
+
+@dataclass
+class ListUnion:
+    list: List[Union[float, int]] = field(default_factory=lambda: [1, 3.14])
+
+
+@dataclass
+class DictUnion:
+    dict: Dict[str, Union[float, int]] = field(default_factory=lambda: {"foo": 1})

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -544,3 +544,28 @@ class UnionWithContainer:
     union_list: Union[ListConfig, int] = field(
         default_factory=lambda: ListConfig([1, 2])
     )
+
+
+@dataclass
+class Base:
+    foo: int = 1
+
+
+@dataclass
+class Subclass1(Base):
+    pass
+
+
+@dataclass
+class Subclass2(Base):
+    pass
+
+
+@dataclass
+class UnionWithBaseclass:
+    foo: Union[Base, int]
+
+
+@dataclass
+class UnionOfSubclasses:
+    foo: Union[Subclass1, Subclass2]

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
 
-from omegaconf import II, MISSING, SI
+from omegaconf import II, MISSING, SI, DictConfig, ListConfig
 from tests import Color
 
 # skip test if dataclasses are not available
@@ -534,3 +534,13 @@ class ListUnion:
 @dataclass
 class DictUnion:
     dict: Dict[str, Union[float, int]] = field(default_factory=lambda: {"foo": 1})
+
+
+@dataclass
+class UnionWithContainer:
+    union_dict: Union[DictConfig, int] = field(
+        default_factory=lambda: DictConfig({"foo": 1})
+    )
+    union_list: Union[ListConfig, int] = field(
+        default_factory=lambda: ListConfig([1, 2])
+    )

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1160,3 +1160,17 @@ class TestDictSubclass:
         cfg[node] = value
         assert cfg[node] == value
         assert isinstance(cfg._get_node(node), UnionNode)
+
+    def test_union_with_baseclass(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.UnionWithBaseclass)
+        cfg.foo = module.Subclass1()
+        assert cfg.foo == module.Subclass1()
+        assert isinstance(cfg._get_node("foo"), UnionNode)
+
+    def test_union_with_subclasses(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.UnionOfSubclasses)
+        cfg.foo = module.Subclass1
+        assert cfg.foo == module.Subclass1()
+        assert isinstance(cfg._get_node("foo"), UnionNode)

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1087,7 +1087,7 @@ class TestDictSubclass:
             cfg._get_node("author")._metadata.ref_type
             == Union[str, List[str], type(None)]
         )
-        assert cfg._get_node("author")._metadata.optional is True
+        assert cfg._get_node("author")._is_optional()
 
     def test_non_optional_union_create(self, class_type: str) -> None:
         module: Any = import_module(class_type)

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1078,3 +1078,23 @@ class TestDictSubclass:
         value = module.Book()
         with pytest.raises(ValidationError):
             cfg.author = value
+
+    def test_optional_union_create(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        OmegaConf.structured(module.OptionalBook(author=None))
+
+    def test_non_optional_union_create(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        with pytest.raises(ValidationError):
+            OmegaConf.structured(module.Book(author=None))
+
+    def test_optional_union_set_none(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.OptionalBook)
+        cfg.author = None
+
+    def test_non_optional_union_set_none(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.Book)
+        with pytest.raises(ValidationError):
+            cfg.author = None

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1144,3 +1144,19 @@ class TestDictSubclass:
         cfg = OmegaConf.structured(class_)
         with pytest.raises(ValidationError):
             cfg[node] = value
+
+    @pytest.mark.parametrize(  # type: ignore
+        "value,node",
+        [
+            (DictConfig({"foo": False}), "union_dict"),
+            (ListConfig([1, 2, False]), "union_list"),
+        ],
+    )
+    def test_cfg_set_container_in_union(
+        self, class_type: str, node: str, value: Any
+    ) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.UnionWithContainer)
+        cfg[node] = value
+        assert cfg[node] == value
+        assert isinstance(cfg._get_node(node), UnionNode)

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1098,3 +1098,43 @@ class TestDictSubclass:
         cfg = OmegaConf.structured(module.Book)
         with pytest.raises(ValidationError):
             cfg.author = None
+
+    @pytest.mark.parametrize(  # type: ignore
+        "obj,value,node",
+        [
+            ("DictUnion", {"foo": 0.33, "foo2": 10}, "dict"),
+            ("ListUnion", [1, 2, 0.33], "list"),
+        ],
+    )
+    def test_cfg_set_valid_union_value(
+        self, class_type: str, obj: str, value: Any, node: str
+    ) -> None:
+        module: Any = import_module(class_type)
+        class_ = getattr(module, obj)
+        cfg = OmegaConf.structured(class_)
+        cfg[node] = value
+        assert cfg[node] == value
+
+    @pytest.mark.parametrize(  # type: ignore
+        "obj,value,node",
+        [
+            ("DictUnion", {"foo": False}, "dict"),
+            ("DictUnion", {"foo": "invalid"}, "dict"),
+            ("DictUnion", {"foo": Color.BLUE}, "dict"),
+            ("DictUnion", {"foo": User()}, "dict"),
+            ("DictUnion", {"foo": None}, "dict"),
+            ("ListUnion", [1, 2, False], "list"),
+            ("ListUnion", [1, 2, "invalid"], "list"),
+            ("ListUnion", [1, 2, Color.BLUE], "list"),
+            ("ListUnion", [1, 2, User()], "list"),
+            ("ListUnion", [1, 2, None], "list"),
+        ],
+    )
+    def test_cfg_set_invalid_union_value(
+        self, class_type: str, obj: str, value: Any, node: str
+    ) -> None:
+        module: Any = import_module(class_type)
+        class_ = getattr(module, obj)
+        cfg = OmegaConf.structured(class_)
+        with pytest.raises(ValidationError):
+            cfg[node] = value

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1064,6 +1064,22 @@ class TestDictSubclass:
         assert cfg.content == value
         assert isinstance(cfg._get_node("content"), UnionNode)
 
+    def test_union_set_valid_value_nested_list(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.Shelf2)
+        value = [module.Book(), module.Book()]
+        cfg.content = value
+        assert cfg.content == value
+        assert isinstance(cfg._get_node("content"), UnionNode)
+
+    def test_union_set_valid_value_nested_dict(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.Shelf3)
+        value = {"book1": module.Book(), "book2": module.Book()}
+        cfg.content = value
+        assert cfg.content == value
+        assert isinstance(cfg._get_node("content"), UnionNode)
+
     def test_union_set_invalid_value(self, class_type: str) -> None:
         module: Any = import_module(class_type)
         cfg = OmegaConf.structured(module.Book)

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1,5 +1,6 @@
+from enum import Enum
 from importlib import import_module
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import pytest
 
@@ -810,6 +811,23 @@ class TestConfigs:
         o = rl(d=[rl(), rl()])
         cfg = OmegaConf.structured(o)
         assert cfg == {"d": [{"d": "???"}, {"d": "???"}]}
+
+    def test_create_untyped_dict(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.UntypedDict)
+        dt = Dict[Union[str, Enum], Any]
+        assert _utils.get_ref_type(cfg, "dict") == dt
+        assert _utils.get_ref_type(cfg, "opt_dict") == Optional[dt]
+        assert cfg.dict == {"foo": "var"}
+        assert cfg.opt_dict is None
+
+    def test_create_untyped_list(self, class_type: str) -> None:
+        module: Any = import_module(class_type)
+        cfg = OmegaConf.structured(module.UntypedList)
+        assert _utils.get_ref_type(cfg, "list") == List[Any]
+        assert _utils.get_ref_type(cfg, "opt_list") == Optional[List[Any]]
+        assert cfg.list == [1, 2]
+        assert cfg.opt_list is None
 
 
 def validate_frozen_impl(conf: DictConfig) -> None:

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1081,7 +1081,13 @@ class TestDictSubclass:
 
     def test_optional_union_create(self, class_type: str) -> None:
         module: Any = import_module(class_type)
-        OmegaConf.structured(module.OptionalBook(author=None))
+        cfg = OmegaConf.structured(module.OptionalBook(author=None))
+        assert isinstance(cfg._get_node("author"), UnionNode)
+        assert (
+            cfg._get_node("author")._metadata.ref_type
+            == Union[str, List[str], type(None)]
+        )
+        assert cfg._get_node("author")._metadata.optional is True
 
     def test_non_optional_union_create(self, class_type: str) -> None:
         module: Any = import_module(class_type)

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -17,8 +17,8 @@ from omegaconf import (
     _utils,
 )
 from omegaconf.errors import ConfigKeyError
-from tests import Color, User
 from omegaconf.nodes import UnionNode
+from tests import Color, User
 
 
 class EnumConfigAssignments:
@@ -1072,17 +1072,9 @@ class TestDictSubclass:
         assert cfg.content == value
         assert isinstance(cfg._get_node("content"), UnionNode)
 
-    def test_union_set_valid_value_nested_dict(self, class_type: str) -> None:
-        module: Any = import_module(class_type)
-        cfg = OmegaConf.structured(module.Shelf3)
-        value = {"book1": module.Book(), "book2": module.Book()}
-        cfg.content = value
-        assert cfg.content == value
-        assert isinstance(cfg._get_node("content"), UnionNode)
-
     def test_union_set_invalid_value(self, class_type: str) -> None:
         module: Any = import_module(class_type)
         cfg = OmegaConf.structured(module.Book)
-        value = 1
+        value = module.Book()
         with pytest.raises(ValidationError):
             cfg.author = value

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -740,7 +740,6 @@ def test_setdefault() -> None:
 def test_set_valid_union_value() -> None:
     cfg = OmegaConf.structured(DictUnion)
     cfg.dict = {"a": 4, "b": 3.14}
-    assert isinstance(cfg.dict._get_node("a"), UnionNode)  # type: ignore
     assert cfg.dict == {"a": 4, "b": 3.14}
     assert isinstance(cfg.dict._get_node("a"), UnionNode)  # type: ignore
     assert isinstance(cfg.dict._get_node("b"), UnionNode)  # type: ignore

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -739,13 +739,13 @@ def test_setdefault() -> None:
 
 def test_set_valid_union_value() -> None:
     cfg = OmegaConf.structured(DictUnion)
-    cfg.dict = {"a": 4, "b": True}
+    cfg.dict = {"a": 4, "b": 3.14}
     assert isinstance(cfg.dict._get_node("a"), UnionNode)  # type: ignore
-    assert cfg.dict == {"a": 4, "b": True}
+    assert cfg.dict == {"a": 4, "b": 3.14}
     assert isinstance(cfg.dict._get_node("a"), UnionNode)  # type: ignore
     assert isinstance(cfg.dict._get_node("b"), UnionNode)  # type: ignore
     assert cfg.dict.a == 4  # type: ignore
-    assert cfg.dict.b is True  # type: ignore
+    assert cfg.dict.b == 3.14  # type: ignore
 
 
 def test_set_invalid_union_value() -> None:

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -603,7 +603,6 @@ def test_getattr() -> None:
 def test_set_valid_union_value() -> None:
     cfg = OmegaConf.structured(ListUnion)
     cfg.list = [4, 3.14]
-    assert isinstance(cfg.list._get_node(0), UnionNode)  # type: ignore
     assert cfg.list == [4, 3.14]
     assert isinstance(cfg.list._get_node(0), UnionNode)  # type: ignore
     assert isinstance(cfg.list._get_node(1), UnionNode)  # type: ignore

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -602,13 +602,13 @@ def test_getattr() -> None:
 
 def test_set_valid_union_value() -> None:
     cfg = OmegaConf.structured(ListUnion)
-    cfg.list = [4, True]
+    cfg.list = [4, 3.14]
     assert isinstance(cfg.list._get_node(0), UnionNode)  # type: ignore
-    assert cfg.list == [4, True]
+    assert cfg.list == [4, 3.14]
     assert isinstance(cfg.list._get_node(0), UnionNode)  # type: ignore
     assert isinstance(cfg.list._get_node(1), UnionNode)  # type: ignore
     assert cfg.list[0] == 4
-    assert cfg.list[1] is True
+    assert cfg.list[1] == 3.14
 
 
 def test_set_invalid_union_value() -> None:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,7 +1,8 @@
 """Testing for OmegaConf"""
 import re
 import sys
-from typing import Any, Dict, List
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
 
 import pytest
 import yaml
@@ -198,3 +199,17 @@ def test_create_unmodified_loader() -> None:
     yaml_cfg = yaml.load("gitrev: 100e100", Loader=yaml.loader.SafeLoader)
     assert cfg.gitrev == 1e102
     assert yaml_cfg["gitrev"] == "100e100"
+
+
+def test_create_untyped_list() -> None:
+    from omegaconf._utils import get_ref_type
+
+    cfg = ListConfig(ref_type=List, content=[])
+    assert get_ref_type(cfg) == Optional[List[Any]]
+
+
+def test_create_untyped_dict() -> None:
+    from omegaconf._utils import get_ref_type
+
+    cfg = DictConfig(ref_type=Dict, content={})
+    assert get_ref_type(cfg) == Optional[Dict[Union[str, Enum], Any]]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -34,7 +34,6 @@ from . import (
     Plugin,
     StructuredWithMissing,
     SubscriptedDict,
-    UnionError,
     User,
 )
 
@@ -494,18 +493,6 @@ params = [
             ref_type_str=None,
         ),
         id="structured:create_from_unsupported_object",
-    ),
-    pytest.param(
-        Expected(
-            create=lambda: None,
-            op=lambda cfg: OmegaConf.structured(UnionError),
-            exception_type=ValueError,
-            msg="Union types are not supported:\nx: Union[int, str]",
-            object_type_str=None,
-            ref_type_str=None,
-            num_lines=4,
-        ),
-        id="structured:create_with_union_error",
     ),
     # assign
     pytest.param(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -553,20 +553,22 @@ def test_merge_union_node_with_valid_value(obj: Any, expected: Any) -> None:
     [
         (OmegaConf.structured(UnionClass), {"foo": User()}),
         (
-            DictConfig(
-                ref_type=Dict[str, Union[int, bool]],
-                element_type=Union[int, bool],
-                key_type=str,
-                content={"foo": True},
+            OmegaConf.create(
+                DictConfig(
+                    ref_type=Dict[str, Union[int, float]],
+                    element_type=Union[int, float],
+                    key_type=str,
+                    content={"foo": 3.1415},
+                )
             ),
             {"foo": User()},
         ),
         (
             DictConfig(
-                ref_type=Dict[str, Union[int, bool]],
-                element_type=Union[int, bool],
+                ref_type=Dict[str, Union[int, float]],
+                element_type=Union[int, float],
                 key_type=str,
-                content={"foo": True},
+                content={"foo": 3.1415},
             ),
             {"foo": "var"},
         ),

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -582,6 +582,21 @@ def test_allow_objects() -> None:
         (UnionNode(element_types=[List[bool], bool]), [True, False], [True, False]),
         (UnionNode(element_types=[List[float], float]), [3.14, 9.67], [3.14, 9.67]),
         (UnionNode(element_types=[List[str], str]), ["foo", "foo2"], ["foo", "foo2"]),
+        (
+            UnionNode(element_types=[List[Dict[str, int]], str]),
+            [{"nested2": 2}, {"nested": 1}],
+            [{"nested2": 2}, {"nested": 1}],
+        ),
+        (
+            UnionNode(element_types=[List[User], str]),
+            [User(name="user1", age=21), User(name="user2", age=45)],
+            [User(name="user1", age=21), User(name="user2", age=45)],
+        ),
+        (
+            UnionNode(element_types=[List[int], int]),
+            1,
+            1,
+        ),
         (UnionNode(element_types=[Dict[str, int], int]), {"foo": 1}, {"foo": 1}),
         (
             UnionNode(element_types=[Dict[str, str], str]),
@@ -598,6 +613,21 @@ def test_allow_objects() -> None:
             {"foo": 3.14},
             {"foo": 3.14},
         ),
+        (
+            UnionNode(element_types=[Dict[str, List[int]], float]),
+            {"foo": [1, 2]},
+            {"foo": [1, 2]},
+        ),
+        (
+            UnionNode(element_types=[Dict[str, List[User]], float]),
+            3.14,
+            3.14,
+        ),
+        (
+            UnionNode(element_types=[Dict[str, List[User]], float]),
+            {"foo": [User(), User()]},
+            {"foo": [User(), User()]},
+        ),
     ],
 )
 def test_valid_value_union_node(node: ValueNode, value: Any, expected: Any) -> None:
@@ -613,6 +643,27 @@ def test_valid_value_union_node(node: ValueNode, value: Any, expected: Any) -> N
         (UnionNode(element_types=[int, ListConfig]), {"foo": "var"}),
         (UnionNode(element_types=[int, DictConfig]), [1, 2]),
         (UnionNode(element_types=[DictConfig, str]), 3),
+        (
+            UnionNode(element_types=[Dict[str, List[int]], float]),
+            {"foo": [1, "invalid_value"]},
+        ),
+        (UnionNode(element_types=[DictConfig, str]), 3),
+        (
+            UnionNode(element_types=[List[Dict[str, int]], str]),
+            [{"nested2": 2}, {"nested": "invalid_value"}],
+        ),
+        (
+            UnionNode(element_types=[List[Dict[str, int]], str]),
+            [{"nested2": 2}, {"nested": User()}],
+        ),
+        (
+            UnionNode(element_types=[Dict[str, List[int]], float]),
+            {"foo": [1, User()]},
+        ),
+        (
+            UnionNode(element_types=[Dict[str, List[User]], str]),
+            {1: [User(), User()]},
+        ),
     ],
 )
 def test_invalid_value_union_node(node: ValueNode, value: Any) -> None:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,6 +1,6 @@
 import copy
 from enum import Enum
-from typing import Any, Dict, Tuple, Type, Union
+from typing import Any, Dict, List, Tuple, Type, Union
 
 import pytest
 
@@ -578,6 +578,26 @@ def test_allow_objects() -> None:
         (UnionNode(element_types=[DictConfig, str]), {"a": 1}, {"a": 1}),
         (UnionNode(element_types=[ListConfig, int]), [1, 2], [1, 2]),
         (UnionNode(element_types=[ListConfig, int]), [1, 2], [1, 2]),
+        (UnionNode(element_types=[List[int], int]), [1, 2], [1, 2]),
+        (UnionNode(element_types=[List[bool], bool]), [True, False], [True, False]),
+        (UnionNode(element_types=[List[float], float]), [3.14, 9.67], [3.14, 9.67]),
+        (UnionNode(element_types=[List[str], str]), ["foo", "foo2"], ["foo", "foo2"]),
+        (UnionNode(element_types=[Dict[str, int], int]), {"foo": 1}, {"foo": 1}),
+        (
+            UnionNode(element_types=[Dict[str, str], str]),
+            {"foo": "var"},
+            {"foo": "var"},
+        ),
+        (
+            UnionNode(element_types=[Dict[str, bool], bool]),
+            {"foo": True},
+            {"foo": True},
+        ),
+        (
+            UnionNode(element_types=[Dict[str, float], float]),
+            {"foo": 3.14},
+            {"foo": 3.14},
+        ),
     ],
 )
 def test_valid_value_union_node(node: ValueNode, value: Any, expected: Any) -> None:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -505,6 +505,7 @@ def test_deepcopy(obj: Any) -> None:
             True,
         ),
         (UnionNode(element_types=[int, str], value="str"), "str", True),
+        (UnionNode(element_types=[int, str], value="str"), AnyNode(value="str"), True),
     ],
 )
 def test_eq(node: ValueNode, value: Any, expected: Any) -> None:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -576,7 +576,7 @@ def test_allow_objects() -> None:
         (UnionNode(ref_type=Union[int, str], element_types=[int, str], value=1), 1, 1),
         (UnionNode(element_types=[int, str], value="str"), "str", "str"),
         (UnionNode(element_types=[int, str]), "str", "str"),
-        (UnionNode(element_types=[int, str]), None, None),
+        (UnionNode(element_types=[int, str, type(None)]), None, None),
         (
             UnionNode(element_types=[DictConfig, str]),
             DictConfig({"a": 1}),
@@ -617,6 +617,11 @@ def test_allow_objects() -> None:
             {"foo": 3.14},
             {"foo": 3.14},
         ),
+        (
+            UnionNode(element_types=[bool, float], is_optional=True),
+            None,
+            None,
+        ),
     ],
 )
 def test_valid_value_union_node(node: ValueNode, value: Any, expected: Any) -> None:
@@ -633,6 +638,7 @@ def test_valid_value_union_node(node: ValueNode, value: Any, expected: Any) -> N
         (UnionNode(element_types=[int, ListConfig]), {"foo": "var"}),
         (UnionNode(element_types=[int, DictConfig]), {"foo": "var"}),
         (UnionNode(element_types=[int, DictConfig]), [1, 2]),
+        (UnionNode(element_types=[int, str], is_optional=False, value="foo"), None),
         (
             UnionNode(element_types=[Dict[str, List[int]], float]),
             {"foo": [1, "invalid_value"]},

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -571,60 +571,32 @@ def test_allow_objects() -> None:
 
 
 @pytest.mark.parametrize(  # type: ignore
-    "node, value, expected",
+    "node, value",
     [
-        (UnionNode(ref_type=Union[int, str], element_types=[int, str], value=1), 1, 1),
-        (UnionNode(element_types=[int, str], value="str"), "str", "str"),
-        (UnionNode(element_types=[int, str]), "str", "str"),
-        (UnionNode(element_types=[int, str, type(None)]), None, None),
-        (
-            UnionNode(element_types=[DictConfig, str]),
-            DictConfig({"a": 1}),
-            DictConfig({"a": 1}),
-        ),
-        (
-            UnionNode(element_types=[ListConfig, int]),
-            ListConfig([1, 2]),
-            ListConfig([1, 2]),
-        ),
-        (UnionNode(element_types=[List[int], int]), [1, 2], [1, 2]),
-        (UnionNode(element_types=[List[bool], bool]), [True, False], [True, False]),
-        (UnionNode(element_types=[List[float], float]), [3.14, 9.67], [3.14, 9.67]),
-        (UnionNode(element_types=[List[str], str]), ["foo", "foo2"], ["foo", "foo2"]),
+        (UnionNode(ref_type=Union[int, str], element_types=[int, str], value=1), 1),
+        (UnionNode(element_types=[int, str], value="str"), "str"),
+        (UnionNode(element_types=[int, str]), "str"),
+        (UnionNode(element_types=[int, str, type(None)]), None),
+        (UnionNode(element_types=[DictConfig, str]), DictConfig({"a": 1})),
+        (UnionNode(element_types=[ListConfig, int]), ListConfig([1, 2])),
+        (UnionNode(element_types=[List[int], int]), [1, 2]),
+        (UnionNode(element_types=[List[bool], bool]), [True, False]),
+        (UnionNode(element_types=[List[float], float]), [3.14, 9.67]),
+        (UnionNode(element_types=[List[str], str]), ["foo", "foo2"]),
         (
             UnionNode(element_types=[List[User], str]),
             [User(name="user1", age=21), User(name="user2", age=45)],
-            [User(name="user1", age=21), User(name="user2", age=45)],
         ),
-        (
-            UnionNode(element_types=[List[int], int]),
-            1,
-            1,
-        ),
-        (UnionNode(element_types=[Dict[str, int], int]), {"foo": 1}, {"foo": 1}),
-        (
-            UnionNode(element_types=[Dict[str, str], str]),
-            {"foo": "var"},
-            {"foo": "var"},
-        ),
-        (
-            UnionNode(element_types=[Dict[str, bool], bool]),
-            {"foo": True},
-            {"foo": True},
-        ),
-        (
-            UnionNode(element_types=[Dict[str, float], float]),
-            {"foo": 3.14},
-            {"foo": 3.14},
-        ),
-        (
-            UnionNode(element_types=[bool, float], is_optional=True),
-            None,
-            None,
-        ),
+        (UnionNode(element_types=[List[int], int]), 1),
+        (UnionNode(element_types=[Dict[str, int], int]), {"foo": 1}),
+        (UnionNode(element_types=[Dict[str, str], str]), {"foo": "var"}),
+        (UnionNode(element_types=[Dict[str, bool], bool]), {"foo": True}),
+        (UnionNode(element_types=[Dict[str, float], float]), {"foo": 3.14}),
+        (UnionNode(element_types=[bool, float], is_optional=True), None),
     ],
 )
-def test_valid_value_union_node(node: ValueNode, value: Any, expected: Any) -> None:
+def test_valid_value_union_node(node: ValueNode, value: Any) -> None:
+    expected = copy.deepcopy(value)
     node._set_value(value)
     assert node._value() == expected
     assert isinstance(node, UnionNode)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -581,6 +581,7 @@ def test_allow_objects() -> None:
         (UnionNode(element_types=[DictConfig, str]), DictConfig({"a": 1})),
         (UnionNode(element_types=[ListConfig, int]), ListConfig([1, 2])),
         (UnionNode(element_types=[List[int], int]), [1, 2]),
+        (UnionNode(element_types=[List[int], int]), ListConfig(content=[1, 2])),
         (UnionNode(element_types=[List[bool], bool]), [True, False]),
         (UnionNode(element_types=[List[float], float]), [3.14, 9.67]),
         (UnionNode(element_types=[List[str], str]), ["foo", "foo2"]),
@@ -590,6 +591,14 @@ def test_allow_objects() -> None:
         ),
         (UnionNode(element_types=[List[int], int]), 1),
         (UnionNode(element_types=[Dict[str, int], int]), {"foo": 1}),
+        (
+            UnionNode(element_types=[Dict[str, int], int]),
+            DictConfig(content={"foo": 1}),
+        ),
+        (
+            UnionNode(element_types=[Dict[str, int], int]),
+            DictConfig(content={"foo": 1}, ref_type=Dict[str, int]),
+        ),
         (UnionNode(element_types=[Dict[str, str], str]), {"foo": "var"}),
         (UnionNode(element_types=[Dict[str, bool], bool]), {"foo": True}),
         (UnionNode(element_types=[Dict[str, float], float]), {"foo": 3.14}),
@@ -623,6 +632,11 @@ def test_valid_value_union_node(node: ValueNode, value: Any) -> None:
             UnionNode(element_types=[Dict[str, List[int]], float]),
             {"foo": [1, User()]},
         ),
+        (
+            UnionNode(element_types=[Dict[str, int], int]),
+            DictConfig(content={"foo": "invalid"}),
+        ),
+        (UnionNode(element_types=[List[int], int]), ListConfig(content=["invalid", 1])),
     ],
 )
 def test_invalid_value_union_node(node: ValueNode, value: Any) -> None:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -568,6 +568,8 @@ def test_allow_objects() -> None:
     iv = IllegalType()
     c.foo = iv
     assert c.foo == iv
+
+
 @pytest.mark.parametrize(  # type: ignore
     "node, value, expected",
     [
@@ -575,18 +577,20 @@ def test_allow_objects() -> None:
         (UnionNode(element_types=[int, str], value="str"), "str", "str"),
         (UnionNode(element_types=[int, str]), "str", "str"),
         (UnionNode(element_types=[int, str]), None, None),
-        (UnionNode(element_types=[DictConfig, str]), {"a": 1}, {"a": 1}),
-        (UnionNode(element_types=[ListConfig, int]), [1, 2], [1, 2]),
-        (UnionNode(element_types=[ListConfig, int]), [1, 2], [1, 2]),
+        (
+            UnionNode(element_types=[DictConfig, str]),
+            DictConfig({"a": 1}),
+            DictConfig({"a": 1}),
+        ),
+        (
+            UnionNode(element_types=[ListConfig, int]),
+            ListConfig([1, 2]),
+            ListConfig([1, 2]),
+        ),
         (UnionNode(element_types=[List[int], int]), [1, 2], [1, 2]),
         (UnionNode(element_types=[List[bool], bool]), [True, False], [True, False]),
         (UnionNode(element_types=[List[float], float]), [3.14, 9.67], [3.14, 9.67]),
         (UnionNode(element_types=[List[str], str]), ["foo", "foo2"], ["foo", "foo2"]),
-        (
-            UnionNode(element_types=[List[Dict[str, int]], str]),
-            [{"nested2": 2}, {"nested": 1}],
-            [{"nested2": 2}, {"nested": 1}],
-        ),
         (
             UnionNode(element_types=[List[User], str]),
             [User(name="user1", age=21), User(name="user2", age=45)],
@@ -613,21 +617,6 @@ def test_allow_objects() -> None:
             {"foo": 3.14},
             {"foo": 3.14},
         ),
-        (
-            UnionNode(element_types=[Dict[str, List[int]], float]),
-            {"foo": [1, 2]},
-            {"foo": [1, 2]},
-        ),
-        (
-            UnionNode(element_types=[Dict[str, List[User]], float]),
-            3.14,
-            3.14,
-        ),
-        (
-            UnionNode(element_types=[Dict[str, List[User]], float]),
-            {"foo": [User(), User()]},
-            {"foo": [User(), User()]},
-        ),
     ],
 )
 def test_valid_value_union_node(node: ValueNode, value: Any, expected: Any) -> None:
@@ -639,30 +628,18 @@ def test_valid_value_union_node(node: ValueNode, value: Any, expected: Any) -> N
 @pytest.mark.parametrize(  # type: ignore
     "node, value",
     [
-        (UnionNode(element_types=[int, str], value="str"), False),
+        (UnionNode(element_types=[int, str], value="str"), User()),
+        (UnionNode(element_types=[int, ListConfig]), [1, 2]),
         (UnionNode(element_types=[int, ListConfig]), {"foo": "var"}),
+        (UnionNode(element_types=[int, DictConfig]), {"foo": "var"}),
         (UnionNode(element_types=[int, DictConfig]), [1, 2]),
-        (UnionNode(element_types=[DictConfig, str]), 3),
         (
             UnionNode(element_types=[Dict[str, List[int]], float]),
             {"foo": [1, "invalid_value"]},
         ),
-        (UnionNode(element_types=[DictConfig, str]), 3),
-        (
-            UnionNode(element_types=[List[Dict[str, int]], str]),
-            [{"nested2": 2}, {"nested": "invalid_value"}],
-        ),
-        (
-            UnionNode(element_types=[List[Dict[str, int]], str]),
-            [{"nested2": 2}, {"nested": User()}],
-        ),
         (
             UnionNode(element_types=[Dict[str, List[int]], float]),
             {"foo": [1, User()]},
-        ),
-        (
-            UnionNode(element_types=[Dict[str, List[User]], str]),
-            {1: [User(), User()]},
         ),
     ],
 )

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -21,6 +21,7 @@ from . import (
     SubscriptedList,
     UntypedDict,
     UntypedList,
+    UnionClass
 )
 
 
@@ -146,6 +147,18 @@ def test_pickle(obj: Any, ref_type: Any) -> None:
         assert c1._metadata.optional is True
         if isinstance(c, DictConfig):
             assert c1._metadata.key_type is Any
+
+
+def test_pickle_union() -> None:
+    with tempfile.TemporaryFile() as fp:
+        c = OmegaConf.structured(UnionClass)
+        pickle.dump(c, fp)
+        fp.flush()
+        fp.seek(0)
+        c1 = pickle.load(fp)
+        assert c == c1
+        assert c._get_node("foo")._metadata.ref_type == Union[str, int]
+        assert c._get_node("foo").element_types == [str, int]
 
 
 def test_load_duplicate_keys_top() -> None:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -150,6 +150,8 @@ def test_pickle(obj: Any, ref_type: Any) -> None:
 
 
 def test_pickle_union() -> None:
+    import collections
+
     with tempfile.TemporaryFile() as fp:
         c = OmegaConf.structured(UnionClass)
         pickle.dump(c, fp)
@@ -158,7 +160,9 @@ def test_pickle_union() -> None:
         c1 = pickle.load(fp)
         assert c == c1
         assert c._get_node("foo")._metadata.ref_type == Union[str, int]
-        assert c._get_node("foo").element_types == [str, int]
+        assert collections.Counter(
+            c._get_node("foo").element_types
+        ) == collections.Counter([str, int])
 
 
 def test_load_duplicate_keys_top() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -544,3 +544,15 @@ def test_is_list_annotation(type_: Any, expected: Any) -> Any:
 )
 def test_get_ref_type(obj: Any, expected: Any) -> None:
     assert _utils.get_ref_type(obj) == expected
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "obj, expected",
+    [
+        pytest.param(Union[int, str], [int, str]),
+        pytest.param(Union[int, str, ListConfig], [int, str, ListConfig]),
+        pytest.param(Union[Plugin, ListConfig], [Plugin, ListConfig]),
+    ],
+)
+def test_get_union_types(obj: Any, expected: Any) -> None:
+    assert _utils.get_union_types(obj) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -550,6 +550,7 @@ def test_get_ref_type(obj: Any, expected: Any) -> None:
     "obj, expected",
     [
         pytest.param(Union[int, str], [int, str]),
+        pytest.param(Union[int, Any, str], Any),
         pytest.param(Union[int, str, ListConfig], [int, str, ListConfig]),
         pytest.param(Union[Plugin, ListConfig], [Plugin, ListConfig]),
         pytest.param(Union[str, List[str]], [str, List[str]]),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -550,7 +550,6 @@ def test_get_ref_type(obj: Any, expected: Any) -> None:
     "obj, expected",
     [
         pytest.param(Union[int, str], [int, str]),
-        pytest.param(Union[int, Any, str], Any),
         pytest.param(Union[int, str, ListConfig], [int, str, ListConfig]),
         pytest.param(Union[Plugin, ListConfig], [Plugin, ListConfig]),
         pytest.param(Union[str, List[str]], [str, List[str]]),
@@ -559,3 +558,15 @@ def test_get_ref_type(obj: Any, expected: Any) -> None:
 )
 def test_get_union_types(obj: Any, expected: Any) -> None:
     assert _utils.get_union_types(obj) == expected
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "obj",
+    [
+        Union[int, Any, str],
+        Union[int],
+    ],
+)
+def test_get_invalid_union_types(obj: Any) -> None:
+    with pytest.raises(UnsupportedValueType):
+        _utils.get_union_types(obj)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -552,6 +552,8 @@ def test_get_ref_type(obj: Any, expected: Any) -> None:
         pytest.param(Union[int, str], [int, str]),
         pytest.param(Union[int, str, ListConfig], [int, str, ListConfig]),
         pytest.param(Union[Plugin, ListConfig], [Plugin, ListConfig]),
+        pytest.param(Union[str, List[str]], [str, List[str]]),
+        pytest.param(Union[str, Dict[str, Any]], [str, Dict[str, Any]]),
     ],
 )
 def test_get_union_types(obj: Any, expected: Any) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -565,6 +565,7 @@ def test_get_union_types(obj: Any, expected: Any) -> None:
     [
         Union[int, Any, str],
         Union[int],
+        Union[type(None), str],
     ],
 )
 def test_get_invalid_union_types(obj: Any) -> None:


### PR DESCRIPTION
To add support for UnionTypes a new type of node is created `UnionNode`. This node holds a value which is another node so it's easier to check values. I plan to modify `_validate_value` which validates that the input is correct with the values implementation of `validate_and_convert` because UnionNode should not know what a ListConfig or DictConfig is. 

I added some tests to check the behaviour. At this time I don't know which ones I missed, I'll check later.

Still have to check optional unions like `Optional[Union[str, int]]` and I will change when pickling unions on 3.6 still fails.

## Tests list
A list of use cases to cover with tests, add more here if you think of more.
- [x] Unions with optional:
```
Optional[Union[int, str]]
Union[int,str,None] # I think this is legal to define Optional
```
- [x] Union with containers, Lists, Dicts
Union[str, List[str]]
- [x] Containers with Unions:
List[Union[int, str]]
- [x] Assignment to union fields, make sure it respects the type and that the field is still a UnionNode
- [x] Merging into Union fields, , make sure it respects the type and that the field is still a UnionNode
- [x] As you pointed out, pickling with Union nodes.

Closes #144 .
    