### PR TITLE
Merge allow objects

### DIFF
--- a/news/394.bugfix
+++ b/news/394.bugfix
@@ -1,0 +1,1 @@
+Fix exception raised when checking for an existance of a key with an incompatible type in DictConfig

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -728,14 +728,14 @@ def type_str(t: Any) -> str:
         return ret
 
 
-def _ensure_container(target: Any) -> Any:
+def _ensure_container(target: Any, flags: Optional[Dict[str, bool]] = None) -> Any:
     from omegaconf import OmegaConf
 
     if is_primitive_container(target):
         assert isinstance(target, (list, dict))
-        target = OmegaConf.create(target)
+        target = OmegaConf.create(target, flags=flags)
     elif is_structured_config(target):
-        target = OmegaConf.structured(target)
+        target = OmegaConf.structured(target, flags=flags)
     assert OmegaConf.is_config(target)
     return target
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -340,7 +340,12 @@ class BaseContainer(Container, ABC):
         for other in others:
             if other is None:
                 raise ValueError("Cannot merge with a None config")
-            other = _ensure_container(other)
+
+            my_flags = {}
+            if self._get_flag("allow_objects") is True:
+                my_flags = {"allow_objects": True}
+            other = _ensure_container(other, flags=my_flags)
+
             if isinstance(self, DictConfig) and isinstance(other, DictConfig):
                 BaseContainer._map_merge(self, other)
             elif isinstance(self, ListConfig) and isinstance(other, ListConfig):

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -440,7 +440,11 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
         :return:
         """
 
-        key = self._validate_and_normalize_key(key)
+        try:
+            key = self._validate_and_normalize_key(key)
+        except KeyValidationError:
+            return False
+
         try:
             node: Optional[Node] = self._get_node(key)
         except (KeyError, AttributeError):

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -342,6 +342,17 @@ def test_dict_pop_error(cfg: Dict[Any, Any], key: Any, expectation: Any) -> None
         ({"a": None, "b": "${a}"}, "b", True),
         ({"a": "cat", "b": "${a}"}, "b", True),
         ({Enum1.FOO: 1, "b": {}}, Enum1.FOO, True),
+        ({Enum1.FOO: 1, "b": {}}, "aaa", False),
+        (
+            DictConfig(content={Enum1.FOO: "foo"}, key_type=Enum1, element_type=str),
+            Enum1.FOO,
+            True,
+        ),
+        (
+            DictConfig(content={Enum1.FOO: "foo"}, key_type=Enum1, element_type=str),
+            "incompatible_key_type",
+            False,
+        ),
     ],
 )
 def test_in_dict(conf: Any, key: str, expected: Any) -> None:

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -107,10 +107,10 @@ def test_list_pop_on_unexpected_exception_not_modifying() -> None:
 
 
 def test_in_list() -> None:
-    c = OmegaConf.create([10, 11, dict(a=12)])
+    c = OmegaConf.create([10, 11, {"a": 12}])
     assert 10 in c
     assert 11 in c
-    assert dict(a=12) in c
+    assert {"a": 12} in c
     assert "blah" not in c
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -13,7 +13,7 @@ from omegaconf import (
     nodes,
 )
 from omegaconf._utils import is_structured_config
-from omegaconf.errors import ConfigKeyError
+from omegaconf.errors import ConfigKeyError, UnsupportedValueType
 
 from . import (
     A,
@@ -22,6 +22,7 @@ from . import (
     ConcretePlugin,
     ConfWithMissingDict,
     Group,
+    IllegalType,
     MissingDict,
     MissingList,
     Package,
@@ -472,3 +473,14 @@ def test_merge_with_dotlist_errors(dotlist: List[str]) -> None:
     c = OmegaConf.create()
     with pytest.raises(ValueError):
         c.merge_with_dotlist(dotlist)
+
+
+def test_merge_allow_objects() -> None:
+    iv = IllegalType()
+    cfg = OmegaConf.create({"a": 10})
+    with pytest.raises(UnsupportedValueType):
+        OmegaConf.merge(cfg, {"foo": iv})
+
+    cfg._set_flag("allow_objects", True)
+    ret = OmegaConf.merge(cfg, {"foo": iv})
+    assert ret == {"a": 10, "foo": iv}


### PR DESCRIPTION
1. fixes new bug with allow_objects not being respected in merge.
2. closes #394 