### PR TITLE
Fix bug assigning structured classes of different element_type in dictconfigs #386

### DIFF
--- a/news/386.bugfix
+++ b/news/386.bugfix
@@ -1,0 +1,1 @@
+Fix bug that allowed Structured classes to be assigned to DictConfig with different element type.

--- a/news/386.bugfix
+++ b/news/386.bugfix
@@ -1,1 +1,1 @@
-Fix bug that allowed Structured classes to be assigned to DictConfig with different element type.
+Fix bug that allowed instances of Structured Configs to be assigned to DictConfig with different element type.

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -435,7 +435,11 @@ class BaseContainer(Container, ABC):
                 target = self._get_node(key)
                 if target is None:
                     if is_structured_config(val):
-                        ref_type = OmegaConf.get_type(val)
+                        element_type = self._metadata.element_type
+                        if element_type is Any:
+                            ref_type = OmegaConf.get_type(val)
+                        else:
+                            ref_type = element_type
                 else:
                     is_optional = target._is_optional()
                     ref_type = target._metadata.ref_type

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -147,7 +147,25 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
         self._validate_set_merge_impl(key, value, is_assign=False)
 
     def _validate_set(self, key: Any, value: Any) -> None:
+        self._validate_set_value_node(key, value)
         self._validate_set_merge_impl(key, value, is_assign=True)
+
+    def _validate_set_value_node(self, key: Any, value: Any) -> None:
+        from omegaconf.omegaconf import _maybe_wrap
+
+        element_type = self._metadata.element_type
+        dummy_value = copy.deepcopy(value)
+
+        if isinstance(dummy_value, ValueNode) and element_type is not Any:
+            optional = dummy_value._metadata.optional
+            dummy_parent = DictConfig(content={})
+            _maybe_wrap(
+                ref_type=element_type,
+                key=key,
+                value=dummy_value._value(),
+                is_optional=optional,
+                parent=dummy_parent,
+            )
 
     def _validate_set_merge_impl(self, key: Any, value: Any, is_assign: bool) -> None:
         from omegaconf import OmegaConf

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -153,7 +153,6 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
         from omegaconf import OmegaConf
 
         vk = get_value_kind(value)
-
         if vk in (ValueKind.INTERPOLATION, ValueKind.STR_INTERPOLATION):
             return
 

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -147,30 +147,13 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
         self._validate_set_merge_impl(key, value, is_assign=False)
 
     def _validate_set(self, key: Any, value: Any) -> None:
-        self._validate_set_value_node(key, value)
         self._validate_set_merge_impl(key, value, is_assign=True)
-
-    def _validate_set_value_node(self, key: Any, value: Any) -> None:
-        from omegaconf.omegaconf import _maybe_wrap
-
-        element_type = self._metadata.element_type
-        dummy_value = copy.deepcopy(value)
-
-        if isinstance(dummy_value, ValueNode) and element_type is not Any:
-            optional = dummy_value._metadata.optional
-            dummy_parent = DictConfig(content={})
-            _maybe_wrap(
-                ref_type=element_type,
-                key=key,
-                value=dummy_value._value(),
-                is_optional=optional,
-                parent=dummy_parent,
-            )
 
     def _validate_set_merge_impl(self, key: Any, value: Any, is_assign: bool) -> None:
         from omegaconf import OmegaConf
 
         vk = get_value_kind(value)
+
         if vk in (ValueKind.INTERPOLATION, ValueKind.STR_INTERPOLATION):
             return
 
@@ -192,6 +175,10 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
                     )
 
         if value == "???":
+            return
+
+        if is_assign and isinstance(value, ValueNode) and self._has_element_type():
+            self._check_assign_with_wrap_value(key, value)
             return
 
         target: Optional[Node]
@@ -242,6 +229,24 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
                 f"subclass of {type_str(target_type)}. value: {value}"
             )
             raise ValidationError(msg)
+
+    def _check_assign_with_wrap_value(self, key: Any, value: Any) -> None:
+        from omegaconf.omegaconf import _maybe_wrap
+
+        element_type = self._metadata.element_type
+        dummy_value = copy.deepcopy(value)
+        optional = dummy_value._metadata.optional
+        dummy_parent = DictConfig(content={})
+        _maybe_wrap(
+            ref_type=element_type,
+            key=key,
+            value=dummy_value._value(),
+            is_optional=optional,
+            parent=dummy_parent,
+        )
+
+    def _has_element_type(self) -> bool:
+        return self._metadata.element_type is not Any
 
     def _validate_and_normalize_key(self, key: Any) -> Union[str, Enum]:
         return self._s_validate_and_normalize_key(self._metadata.key_type, key)

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -234,7 +234,7 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
 
         element_type = self._metadata.element_type
         value_type = OmegaConf.get_type(value)
-        if value_type is not Any and element_type != value_type:
+        if value_type is not Any and not issubclass(value_type, element_type):  # type: ignore
             msg = (
                 f"Invalid type assigned : {type_str(value_type)} is not a "
                 f"subclass of {type_str(element_type)}. value: {value}"

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -393,13 +393,13 @@ class DictSubclass:
     class Str2StrWithField(Dict[str, str]):
         foo: str = "bar"
 
-    @attr.s(auto_attribs=True)
-    class Str2IntWithStrField(Dict[str, int]):
-        foo: str = "bar"
-
     class Error:
         @attr.s(auto_attribs=True)
         class User2Str(Dict[User, str]):
+            pass
+
+        @attr.s(auto_attribs=True)
+        class Str2IntWithStrField(Dict[str, int]):
             pass
 
 

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -393,14 +393,14 @@ class DictSubclass:
     class Str2StrWithField(Dict[str, str]):
         foo: str = "bar"
 
+    @attr.s(auto_attribs=True)
+    class Str2IntWithStrField(Dict[str, int]):
+        foo: int = 1
+
     class Error:
         @attr.s(auto_attribs=True)
         class User2Str(Dict[User, str]):
             pass
-
-        @attr.s(auto_attribs=True)
-        class Str2IntWithStrField(Dict[str, int]):
-            foo: int = 1
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -400,7 +400,7 @@ class DictSubclass:
 
         @attr.s(auto_attribs=True)
         class Str2IntWithStrField(Dict[str, int]):
-            pass
+            foo: int = 1
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -405,14 +405,14 @@ class DictSubclass:
     class Str2StrWithField(Dict[str, str]):
         foo: str = "bar"
 
+    @dataclass
+    class Str2IntWithStrField(Dict[str, int]):
+        foo: int = 1
+
     class Error:
         @dataclass
         class User2Str(Dict[User, str]):
             pass
-
-        @dataclass
-        class Str2IntWithStrField(Dict[str, int]):
-            foo: int = 1
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -412,7 +412,7 @@ class DictSubclass:
 
         @dataclass
         class Str2IntWithStrField(Dict[str, int]):
-            pass
+            foo: int = 1
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -405,13 +405,13 @@ class DictSubclass:
     class Str2StrWithField(Dict[str, str]):
         foo: str = "bar"
 
-    @dataclass
-    class Str2IntWithStrField(Dict[str, int]):
-        foo: str = "bar"
-
     class Error:
         @dataclass
         class User2Str(Dict[User, str]):
+            pass
+
+        @dataclass
+        class Str2IntWithStrField(Dict[str, int]):
             pass
 
 

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -905,16 +905,17 @@ class TestDictSubclass:
         with pytest.raises(KeyValidationError):
             cfg[Color.RED] = "fail"
 
-    def test_str2int_with_field_of_different_type(self, class_type: str) -> None:
-        module: Any = import_module(class_type)
-        with pytest.raises(ValidationError):
-            OmegaConf.structured(module.DictSubclass.Str2IntWithStrField())
-
     class TestErrors:
         def test_usr2str(self, class_type: str) -> None:
             module: Any = import_module(class_type)
             with pytest.raises(KeyValidationError):
                 OmegaConf.structured(module.DictSubclass.Error.User2Str())
+
+        def test_str2int_with_field_of_different_type(self, class_type: str) -> None:
+            module: Any = import_module(class_type)
+            cfg = OmegaConf.structured(module.DictSubclass.Error.Str2IntWithStrField())
+            with pytest.raises(ValidationError):
+                cfg.foo = "str"
 
     def test_construct_from_another_retain_node_types(self, class_type: str) -> None:
         module: Any = import_module(class_type)

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -752,7 +752,7 @@ class TestConfigs:
             ["foo", True, 1.2],
             {"foo": True},
             User(age=1, name="foo"),
-            {"xd": User(age=1, name="foo")},
+            {"user": User(age=1, name="foo")},
         ],
     )
     def test_assign_wrong_type_to_dict(self, class_type: str, value: Any) -> None:

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -16,7 +16,7 @@ from omegaconf import (
     _utils,
 )
 from omegaconf.errors import ConfigKeyError
-from tests import Color
+from tests import Color, User
 
 
 class EnumConfigAssignments:
@@ -743,7 +743,17 @@ class TestConfigs:
             cfg.tuple = value
 
     @pytest.mark.parametrize(  # type: ignore
-        "value", [1, True, "str", 3.1415, ["foo", True, 1.2], {"foo": True}]
+        "value",
+        [
+            1,
+            True,
+            "str",
+            3.1415,
+            ["foo", True, 1.2],
+            {"foo": True},
+            User(age=1, name="foo"),
+            {"xd": User(age=1, name="foo")},
+        ],
     )
     def test_assign_wrong_type_to_dict(self, class_type: str, value: Any) -> None:
         module: Any = import_module(class_type)
@@ -897,15 +907,8 @@ class TestDictSubclass:
 
     def test_str2int_with_field_of_different_type(self, class_type: str) -> None:
         module: Any = import_module(class_type)
-        cfg = OmegaConf.structured(module.DictSubclass.Str2IntWithStrField())
-        assert cfg.foo == "bar"
-
-        cfg.one = 1
-        assert cfg.one == 1
-
         with pytest.raises(ValidationError):
-            # bad
-            cfg.hello = "world"
+            OmegaConf.structured(module.DictSubclass.Str2IntWithStrField())
 
     class TestErrors:
         def test_usr2str(self, class_type: str) -> None:

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -913,7 +913,7 @@ class TestDictSubclass:
 
         def test_str2int_with_field_of_different_type(self, class_type: str) -> None:
             module: Any = import_module(class_type)
-            cfg = OmegaConf.structured(module.DictSubclass.Error.Str2IntWithStrField())
+            cfg = OmegaConf.structured(module.DictSubclass.Str2IntWithStrField())
             with pytest.raises(ValidationError):
                 cfg.foo = "str"
 


### PR DESCRIPTION
When a ValueNode was being assigned to a DictConfig it was never check if it was a valid type(if DictConfig had an element_type). Moreover looking at the bug I replaced the test for Str2IntWithStrField because it should raise an error. 
Closes #386 .