### PR TITLE
Fix #407 Subscripted Dict and List unable to be pickled on python 3.6.

### DIFF
--- a/news/407.bugfix
+++ b/news/407.bugfix
@@ -1,0 +1,1 @@
+Fixes bug where subscripted Dict and List couldn't be pickled on python 3.6.

--- a/news/407.bugfix
+++ b/news/407.bugfix
@@ -1,1 +1,1 @@
-Fixes bug where subscripted Dict and List couldn't be pickled on python 3.6.
+Fix Structured Configs with subscripted Dict and List fields failed pickling on python 3.6.

--- a/news/407.bugfix
+++ b/news/407.bugfix
@@ -1,1 +1,1 @@
-Fix Structured Configs with subscripted Dict and List fields failed pickling on python 3.6.
+Fix pickling of Structured Configs with fields annotated as Dict[KT, VT] or List[T] on Python 3.6.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -764,3 +764,7 @@ def is_generic_dict(type_: Any) -> bool:
     :return: bool
     """
     return is_dict_annotation(type_) and len(get_dict_key_value_types(type_)) > 0
+
+
+def is_container_annotation(type_: Any) -> bool:
+    return is_list_annotation(type_) or is_dict_annotation(type_)

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -90,17 +90,17 @@ class BaseContainer(Container, ABC):
 
     # Support pickle
     def __getstate__(self) -> Dict[str, Any]:
-        dict_ = copy.copy(self.__dict__)
-        dict_["_metadata"] = copy.copy(dict_["_metadata"])
+        dict_copy = copy.copy(self.__dict__)
+        dict_copy["_metadata"] = copy.copy(dict_copy["_metadata"])
         ref_type = self._metadata.ref_type
         if is_container_annotation(ref_type):
             if is_dict_annotation(ref_type):
-                dict_["_metadata"].ref_type = Dict
+                dict_copy["_metadata"].ref_type = Dict
             elif is_list_annotation(ref_type):
-                dict_["_metadata"].ref_type = List
+                dict_copy["_metadata"].ref_type = List
             else:
                 assert False
-        return dict_
+        return dict_copy
 
     # Support pickle
     def __setstate__(self, d: Dict[str, Any]) -> None:

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -89,10 +89,30 @@ class BaseContainer(Container, ABC):
 
     # Support pickle
     def __getstate__(self) -> Dict[str, Any]:
-        return self.__dict__
+        from omegaconf._utils import is_dict_annotation
+
+        dict_ = copy.copy(self.__dict__)
+        dict_["_metadata"] = copy.copy(dict_["_metadata"])
+        if self._has_ref_type():
+            if is_dict_annotation(self._metadata.ref_type):
+                dict_["_metadata"].ref_type = Dict
+            else:
+                dict_["_metadata"].ref_type = List
+        return dict_
 
     # Support pickle
     def __setstate__(self, d: Dict[str, Any]) -> None:
+        from omegaconf import DictConfig
+        from omegaconf._utils import is_generic_dict
+
+        if isinstance(self, DictConfig):
+            key_type = d["_metadata"].key_type
+        element_type = d["_metadata"].element_type
+        if is_generic_dict(d["_metadata"].ref_type):
+            d["_metadata"].ref_type = Dict[key_type, element_type]  # type: ignore
+        else:
+            d["_metadata"].ref_type = List[element_type]  # type: ignore
+
         self.__dict__.update(d)
 
     @abstractmethod

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -89,28 +89,28 @@ class BaseContainer(Container, ABC):
 
     # Support pickle
     def __getstate__(self) -> Dict[str, Any]:
-        from omegaconf._utils import is_dict_annotation
-
         dict_ = copy.copy(self.__dict__)
         dict_["_metadata"] = copy.copy(dict_["_metadata"])
         if self._has_ref_type():
-            if is_dict_annotation(self._metadata.ref_type):
+            ref_type = self._metadata.ref_type
+            if is_dict_annotation(ref_type):
                 dict_["_metadata"].ref_type = Dict
-            else:
+            elif is_list_annotation(ref_type):
                 dict_["_metadata"].ref_type = List
         return dict_
 
     # Support pickle
     def __setstate__(self, d: Dict[str, Any]) -> None:
         from omegaconf import DictConfig
-        from omegaconf._utils import is_generic_dict
+        from omegaconf._utils import is_generic_dict, is_generic_list
 
         if isinstance(self, DictConfig):
             key_type = d["_metadata"].key_type
         element_type = d["_metadata"].element_type
-        if is_generic_dict(d["_metadata"].ref_type):
+        ref_type = d["_metadata"].ref_type
+        if is_generic_dict(ref_type):
             d["_metadata"].ref_type = Dict[key_type, element_type]  # type: ignore
-        else:
+        elif is_generic_list(ref_type):
             d["_metadata"].ref_type = List[element_type]  # type: ignore
 
         self.__dict__.update(d)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -144,3 +144,13 @@ class Module:
 @dataclass
 class Package:
     modules: List[Module] = MISSING
+
+
+@dataclass
+class SubscriptedList:
+    list: List[int] = field(default_factory=lambda: [1, 2])
+
+
+@dataclass
+class SubscriptedDict:
+    dict: Dict[str, int] = field(default_factory=lambda: {"foo": 4})

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -6,13 +6,14 @@ import pickle
 import tempfile
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, Type
+from typing import Any, Dict, List, Type
 
 import pytest
 
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
+from omegaconf._utils import get_ref_type
 
-from . import PersonA, PersonD
+from . import PersonA, PersonD, SubscriptedDict, SubscriptedList
 
 
 def save_load_from_file(conf: Any, resolve: bool, expected: Any) -> None:
@@ -185,3 +186,41 @@ def test_load_empty_file(tmpdir: str) -> None:
 
     with open(empty) as f:
         assert OmegaConf.load(f) == {}
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "input_,node,element_type,key_type,optional,ref_type",
+    [
+        (SubscriptedDict, "dict", int, str, False, Dict[str, int]),
+        (SubscriptedList, "list", int, None, False, List[int]),
+    ],
+)
+def test_pickle_generic(
+    input_: Any,
+    node: str,
+    optional: bool,
+    element_type: Any,
+    key_type: Any,
+    ref_type: Any,
+) -> None:
+    cfg = OmegaConf.structured(input_)
+    with tempfile.TemporaryFile() as fp:
+        import pickle
+
+        pickle.dump(cfg, fp)
+        fp.flush()
+        fp.seek(0)
+        cfg2 = pickle.load(fp)
+
+        def get_node(cfg: Any, key: str) -> Any:
+            if key is None:
+                return cfg
+            else:
+                return cfg._get_node(key)
+
+        assert cfg == cfg2
+        assert get_ref_type(get_node(cfg2, node)) == ref_type
+        assert get_node(cfg2, node)._metadata.element_type == element_type
+        assert get_node(cfg2, node)._metadata.optional == optional
+        if isinstance(input_, DictConfig):
+            assert get_node(cfg2, node)._metadata.key_type == key_type

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -189,7 +189,7 @@ def test_load_empty_file(tmpdir: str) -> None:
 
 
 @pytest.mark.parametrize(  # type: ignore
-    "input_,node,element_type,key_type,optional,ref_type",
+    "input_,key,element_type,key_type,optional,ref_type",
     [
         (SubscriptedDict, "dict", int, str, False, Dict[str, int]),
         (SubscriptedList, "list", int, None, False, List[int]),
@@ -197,7 +197,7 @@ def test_load_empty_file(tmpdir: str) -> None:
 )
 def test_pickle_generic(
     input_: Any,
-    node: str,
+    key: str,
     optional: bool,
     element_type: Any,
     key_type: Any,
@@ -218,9 +218,10 @@ def test_pickle_generic(
             else:
                 return cfg._get_node(key)
 
+        node = get_node(cfg2, key)
         assert cfg == cfg2
-        assert get_ref_type(get_node(cfg2, node)) == ref_type
-        assert get_node(cfg2, node)._metadata.element_type == element_type
-        assert get_node(cfg2, node)._metadata.optional == optional
+        assert get_ref_type(node) == ref_type
+        assert node._metadata.element_type == element_type
+        assert node._metadata.optional == optional
         if isinstance(input_, DictConfig):
-            assert get_node(cfg2, node)._metadata.key_type == key_type
+            assert node._metadata.key_type == key_type


### PR DESCRIPTION
Closes #407 .

Now when pickling structured configs ref_types like `Dict[kt, vt]` and `List[vt]` are transformed to `Dict` and `List` respectively and then reconstructed when loading.

The reason behind this is for ensuring that the config doesn't get modified after pickle.
```python
dict_ = copy.copy(self.__dict__)
dict_["_metadata"] = copy.copy(dict_["_metadata"])
```