### PR TITLE
Use get_type_hints() to resolve string annotations

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -4,7 +4,7 @@ import re
 import string
 import sys
 from enum import Enum
-from typing import Any, Dict, List, Match, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Match, Optional, Tuple, Type, Union, get_type_hints
 
 import yaml
 
@@ -225,9 +225,10 @@ def get_dataclass_data(
     flags = {"allow_objects": allow_objects} if allow_objects is not None else {}
     dummy_parent = OmegaConf.create({}, flags=flags)
     d = {}
+    resolved_hints = get_type_hints(get_type_of(obj))
     for field in dataclasses.fields(obj):
         name = field.name
-        is_optional, type_ = _resolve_optional(field.type)
+        is_optional, type_ = _resolve_optional(resolved_hints[field.name])
         type_ = _resolve_forward(type_, obj.__module__)
 
         if hasattr(obj, name):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -224,6 +224,18 @@ def test_is_dataclass(mocker: Any) -> None:
     assert not _utils.is_dataclass(10)
 
 
+def test_resolve_types() -> None:
+    # simulate `from __future__ import annotations` by using strings for the types
+    @dataclass
+    class Foo:
+        a: "int" = "2"  # type: ignore
+        b: "float" = "0.0"  # type: ignore
+        c: "str" = 2  # type: ignore
+
+    assert _utils.get_structured_config_data(Foo) == {"a": 2, "b": 0.0, "c": "2"}
+    assert _utils.get_structured_config_data(Foo()) == {"a": 2, "b": 0.0, "c": "2"}
+
+
 def test_is_attr_class(mocker: Any) -> None:
     @attr.s
     class Foo:


### PR DESCRIPTION
Closes #303 

When using `from __future__ import annotations` (which will become default behavior in Python 3.10), type annotations are stored as strings. The standard library provides `typing.get_type_hints()` to convert these strings to types.

For the tests, I simulated this behavior by wrapping the type annotations in quotes:

```python
@dataclass
class Foo:
    a: "int"
```
This has the same effect and also works on Python 3.6. (The future import was introduced in Python 3.7.)

I was a bit unsure about the tests. Let me know if I can improve them.