### PR TITLE
Fix #433 bug where ListConfig is modified after assignment of wrong value.

### DIFF
--- a/news/433.bugfix
+++ b/news/433.bugfix
@@ -1,0 +1,1 @@
+Fix assignment of an invalid value to a ListConfig to raise an exception without modifying the config object

--- a/news/433.bugfix
+++ b/news/433.bugfix
@@ -1,1 +1,1 @@
-Fix assignment of an invalid value to a ListConfig to raise an exception without modifying the config object
+Fix bug where assignment of an invalid value to a ListConfig raised an exception but left the object modified.

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -504,6 +504,16 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
         return False
 
     def _set_value(self, value: Any, flags: Optional[Dict[str, bool]] = None) -> None:
+        try:
+            previous_content = self.__dict__["_content"]
+            self._set_value_impl(value, flags)
+        except Exception as e:
+            self.__dict__["_content"] = previous_content
+            raise e
+
+    def _set_value_impl(
+        self, value: Any, flags: Optional[Dict[str, bool]] = None
+    ) -> None:
         from omegaconf import OmegaConf, flag_override
 
         if flags is None:

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -769,6 +769,7 @@ class TestConfigs:
             cfg.list = value
         with pytest.raises(ValidationError):
             cfg.tuple = value
+        assert cfg == OmegaConf.structured(module.ListClass)
 
     @pytest.mark.parametrize(  # type: ignore
         "value",


### PR DESCRIPTION
Closes #433 .