### PR TITLE
remove shallow copy in previous_content

### DIFF
--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -555,7 +555,6 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
 
     def _set_value(self, value: Any, flags: Optional[Dict[str, bool]] = None) -> None:
         try:
-            # shallow copy of content
             previous_content = self.__dict__["_content"]
             self._set_value_impl(value, flags)
         except Exception as e:

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -556,7 +556,7 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
     def _set_value(self, value: Any, flags: Optional[Dict[str, bool]] = None) -> None:
         try:
             # shallow copy of content
-            previous_content = copy.copy(self.__dict__["_content"])
+            previous_content = self.__dict__["_content"]
             self._set_value_impl(value, flags)
         except Exception as e:
             self.__dict__["_content"] = previous_content


### PR DESCRIPTION
In #434 we noticed that a shallow copy wasn't needed.