### PR TITLE
Fix bug #450 where DictConfig's copy didn't properly copy primitive types.

### DIFF
--- a/news/450.bugfix
+++ b/news/450.bugfix
@@ -1,1 +1,1 @@
-Fix bug where DictConfig's copy didn't properly copy primitive types.
+Fix bug where DictConfig's shallow copy didn't work properly in some cases.

--- a/news/450.bugfix
+++ b/news/450.bugfix
@@ -1,0 +1,1 @@
+Fix bug where DictConfig's copy didn't properly copy primitive types.

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -120,10 +120,12 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
             res.__dict__[k] = copy.copy(v)
         res._re_parent()
         content = self.__dict__["_content"]
-        if content is not MISSING and content is not None:
+        if content != MISSING and content is not None:
+            print(content)
             for k, v in content.items():
                 if isinstance(v, ValueNode):
                     res.__dict__["_content"][k] = copy.copy(v)
+
         return res
 
     def copy(self) -> "DictConfig":

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -113,13 +113,17 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
         return res
 
     def __copy__(self) -> "DictConfig":
+        from .omegaconf import MISSING
+
         res = DictConfig(content=None)
         for k, v in self.__dict__.items():
             res.__dict__[k] = copy.copy(v)
         res._re_parent()
-        for k, v in self.__dict__["_content"].items():
-            if isinstance(v, ValueNode):
-                res.__dict__["_content"][k] = copy.copy(v)
+        content = self.__dict__["_content"]
+        if content is not MISSING and content is not None:
+            for k, v in content.items():
+                if isinstance(v, ValueNode):
+                    res.__dict__["_content"][k] = copy.copy(v)
         return res
 
     def copy(self) -> "DictConfig":

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -117,6 +117,9 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
         for k, v in self.__dict__.items():
             res.__dict__[k] = copy.copy(v)
         res._re_parent()
+        for k, v in self.__dict__["_content"].items():
+            if isinstance(v, ValueNode):
+                res.__dict__["_content"][k] = copy.copy(v)
         return res
 
     def copy(self) -> "DictConfig":

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -121,7 +121,6 @@ class DictConfig(BaseContainer, MutableMapping[str, Any]):
         res._re_parent()
         content = self.__dict__["_content"]
         if content != MISSING and content is not None:
-            print(content)
             for k, v in content.items():
                 if isinstance(v, ValueNode):
                     res.__dict__["_content"][k] = copy.copy(v)

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -542,6 +542,14 @@ def test_masked_copy_is_deep() -> None:
         OmegaConf.masked_copy("fail", [])  # type: ignore
 
 
+def test_shallow_copy() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2})
+    c = cfg.copy()
+    cfg.a = 42
+    assert cfg.a == 42
+    assert c.a == 1
+
+
 def test_creation_with_invalid_key() -> None:
     with pytest.raises(KeyValidationError):
         OmegaConf.create({1: "a"})  # type: ignore

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 import pytest
 
 from omegaconf import (
+    MISSING,
     DictConfig,
     ListConfig,
     MissingMandatoryValue,
@@ -548,6 +549,22 @@ def test_shallow_copy() -> None:
     cfg.a = 42
     assert cfg.a == 42
     assert c.a == 1
+
+
+def test_shallow_copy_missing() -> None:
+    cfg = DictConfig(content=MISSING)
+    c = cfg.copy()
+    c._set_value({"foo": 1})
+    assert c.foo == 1
+    assert cfg._is_missing()
+
+
+def test_shallow_copy_none() -> None:
+    cfg = DictConfig(content=None)
+    c = cfg.copy()
+    c._set_value({"foo": 1})
+    assert c.foo == 1
+    assert cfg._is_none()
 
 
 def test_creation_with_invalid_key() -> None:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 import pytest
 
-from omegaconf import DictConfig, ListConfig, OmegaConf
+from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 from omegaconf._utils import get_ref_type
 
 from . import (
@@ -266,3 +266,27 @@ def test_pickle_untyped(
         assert get_node(cfg2, node)._metadata.optional == optional
         if isinstance(input_, DictConfig):
             assert get_node(cfg2, node)._metadata.key_type == key_type
+
+
+def test_pickle_missing() -> None:
+    cfg = DictConfig(content=MISSING)
+    with tempfile.TemporaryFile() as fp:
+        import pickle
+
+        pickle.dump(cfg, fp)
+        fp.flush()
+        fp.seek(0)
+        cfg2 = pickle.load(fp)
+        assert cfg == cfg2
+
+
+def test_pickle_none() -> None:
+    cfg = DictConfig(content=None)
+    with tempfile.TemporaryFile() as fp:
+        import pickle
+
+        pickle.dump(cfg, fp)
+        fp.flush()
+        fp.seek(0)
+        cfg2 = pickle.load(fp)
+        assert cfg == cfg2


### PR DESCRIPTION
Closes #450 .

When copying a dictconfig it copied its `_content` which is a dict, that means that ValueNodes is kept as before(shallow copy of a dict).