### PR TITLE
Benchmark and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.benchmarks
 .cache
 *.pyc
 .pytest_cache

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,0 +1,76 @@
+from typing import Any, Dict
+
+from pytest import fixture
+
+from omegaconf import OmegaConf
+
+
+def build(
+    d: Dict[str, Any], depth: int, width: int, leaf_value: Any = 1
+) -> Dict[str, Any]:
+    if depth == 0:
+        for i in range(width):
+            d[f"key_{i}"] = leaf_value
+    else:
+        for i in range(width):
+            c: Dict[str, Any] = {}
+            d[f"key_{i}"] = c
+            build(c, depth - 1, width, leaf_value)
+
+    return d
+
+
+@fixture(scope="module")
+def large_dict() -> Any:
+    return build({}, 11, 2)
+
+
+@fixture(scope="module")
+def small_dict() -> Any:
+    return build({}, 5, 2)
+
+
+@fixture(scope="module")
+def dict_with_list_leaf() -> Any:
+    return build({}, 5, 2, leaf_value=[1, 2])
+
+
+@fixture(scope="module")
+def small_dict_config(small_dict: Any) -> Any:
+    return OmegaConf.create(small_dict)
+
+
+@fixture(scope="module")
+def dict_config_with_list_leaf(dict_with_list_leaf: Any) -> Any:
+    return OmegaConf.create(dict_with_list_leaf)
+
+
+@fixture(scope="module")
+def large_dict_config(large_dict: Any) -> Any:
+    return OmegaConf.create(large_dict)
+
+
+def test_create_large_dict(large_dict: Any, benchmark: Any) -> None:
+    benchmark(OmegaConf.create, large_dict)
+
+
+def test_create_large_dictconfig(large_dict_config: Any, benchmark: Any) -> None:
+    benchmark(OmegaConf.create, large_dict_config)
+
+
+def test_create_small_dict(small_dict: Any, benchmark: Any) -> None:
+    benchmark(OmegaConf.create, small_dict)
+
+
+def test_create_small_dictconfig(small_dict_config: Any, benchmark: Any) -> None:
+    benchmark(OmegaConf.create, small_dict_config)
+
+
+def test_create_dict_with_list_leaves(dict_with_list_leaf: Any, benchmark: Any) -> None:
+    benchmark(OmegaConf.create, dict_with_list_leaf)
+
+
+def test_create_dict_config_with_list_leaves(
+    dict_config_with_list_leaf: Any, benchmark: Any
+) -> None:
+    benchmark(OmegaConf.create, dict_config_with_list_leaf)

--- a/news/477.feature
+++ b/news/477.feature
@@ -1,0 +1,1 @@
+Optimized config creation time

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,6 +21,12 @@ def omegaconf(session):
     session.run("pytest")
 
 
+@nox.session(python=PYTHON_VERSIONS)
+def benchmark(session):
+    deps(session)
+    session.run("pytest", "benchmark/benchmark.py")
+
+
 @nox.session
 def docs(session):
     deps(session)

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -486,6 +486,9 @@ class BaseContainer(Container, ABC):
         from .nodes import AnyNode, ValueNode
 
         if isinstance(value, Node):
+            value = copy.deepcopy(value)
+            value._set_parent(None)
+
             try:
                 old = value._key()
                 value._set_key(key)
@@ -551,7 +554,8 @@ class BaseContainer(Container, ABC):
             )
 
         def assign(value_key: Any, val: ValueNode) -> None:
-            v = copy.deepcopy(val)
+            assert val._get_parent() is None
+            v = val
             v._set_parent(self)
             v._set_key(value_key)
             self.__dict__["_content"][value_key] = v

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -114,18 +114,24 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         return res
 
     def __copy__(self) -> "DictConfig":
-        from .omegaconf import MISSING
-
         res = DictConfig(content=None)
         for k, v in self.__dict__.items():
-            res.__dict__[k] = copy.copy(v)
-        res._re_parent()
+            if k != "_content":
+                res.__dict__[k] = copy.copy(v)
         content = self.__dict__["_content"]
-        if content != MISSING and content is not None:
+        if isinstance(content, dict):
+            content_copy = {}
             for k, v in content.items():
                 if isinstance(v, ValueNode):
-                    res.__dict__["_content"][k] = copy.copy(v)
+                    content_copy[k] = copy.copy(v)
+                else:
+                    content_copy[k] = v
+        else:
+            content_copy = copy.copy(content)
 
+        res.__dict__["_content"] = content_copy
+
+        res._re_parent()
         return res
 
     def copy(self) -> "DictConfig":

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,6 +9,7 @@ pre-commit
 pyflakes
 pytest
 pytest-mock
+pytest-benchmark
 sphinx
 towncrier
 twine

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 
 import pytest
 
-from omegaconf import AnyNode, ListConfig, OmegaConf, flag_override, MISSING
+from omegaconf import MISSING, AnyNode, ListConfig, OmegaConf, flag_override
 from omegaconf.errors import (
     ConfigKeyError,
     ConfigTypeError,

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 
 import pytest
 
-from omegaconf import AnyNode, ListConfig, OmegaConf, flag_override
+from omegaconf import AnyNode, ListConfig, OmegaConf, flag_override, MISSING
 from omegaconf.errors import (
     ConfigKeyError,
     ConfigTypeError,
@@ -598,3 +598,28 @@ def test_getattr() -> None:
     assert getattr(cfg, "0") == src[0]
     assert getattr(cfg, "1") == src[1]
     assert getattr(cfg, "2") == src[2]
+
+
+def test_shallow_copy() -> None:
+    cfg = OmegaConf.create([1, 2])
+    c = cfg.copy()
+    assert cfg == c
+    cfg[0] = 42
+    assert cfg[0] == 42
+    assert c[0] == 1
+
+
+def test_shallow_copy_missing() -> None:
+    cfg = ListConfig(content=MISSING)
+    c = cfg.copy()
+    c._set_value([1])
+    assert c[0] == 1
+    assert cfg._is_missing()
+
+
+def test_shallow_copy_none() -> None:
+    cfg = ListConfig(content=None)
+    c = cfg.copy()
+    c._set_value([1])
+    assert c[0] == 1
+    assert cfg._is_none()


### PR DESCRIPTION
Closes #267
Closes #477

1. Adds a new benchmark using [pytest-benchmark](https://pytest-benchmark.readthedocs.io/en/latest/index.html).
Currently it tests creation from dict and from DictConfig. Notably creation from DictConfig is 5 times slower and needs some work.

The benchmark is executed in nox.
To run it manually:
```
$ pytest benchmark/benchmark.py
```

2. Fixed a several bugs with shallow copy
3. Added some more tests ensuring deepcopy semantics.

Optimizations:

1. Added flags cache. This improves initialization time from a large dict in the benchmark from 600ms to 450ms.
It also slows down the already slow the initialization from a large DictConfig from 1300ms to 1500ms, but this one needs more work anyway.

2. Optimized deepcopy for DictConfig (creation speedup from a large DictConfig is about 5x).
3. Optimized deepcopy for List (creation speedup from a large DictConfig containing ListConfig leaves is about 5x).