### PR TITLE
Unsafe merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Change the cell you want and then, execute it so the expected output is shown.
 Note that the output after you execute the cell is saved as expected ouput for further 
 testing.
 
-In case that the in [number] of cells aren't in order you should go to the 
+In case that the in[number] of cells aren't in order you should go to the 
 kernel in the toolbar and restart it.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Change the cell you want and then, execute it so the expected output is shown.
 Note that the output after you execute the cell is saved as expected ouput for further 
 testing.
 
-In case that that the in[number] of cells aren't in order you should go to the 
+In case that the in [number] of cells aren't in order you should go to the 
 kernel in the toolbar and restart it.
 
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
-from pytest import fixture
+from pytest import lazy_fixture  # type: ignore
+from pytest import fixture, mark
 
 from omegaconf import OmegaConf
 
@@ -50,27 +51,15 @@ def large_dict_config(large_dict: Any) -> Any:
     return OmegaConf.create(large_dict)
 
 
-def test_create_large_dict(large_dict: Any, benchmark: Any) -> None:
-    benchmark(OmegaConf.create, large_dict)
-
-
-def test_create_large_dictconfig(large_dict_config: Any, benchmark: Any) -> None:
-    benchmark(OmegaConf.create, large_dict_config)
-
-
-def test_create_small_dict(small_dict: Any, benchmark: Any) -> None:
-    benchmark(OmegaConf.create, small_dict)
-
-
-def test_create_small_dictconfig(small_dict_config: Any, benchmark: Any) -> None:
-    benchmark(OmegaConf.create, small_dict_config)
-
-
-def test_create_dict_with_list_leaves(dict_with_list_leaf: Any, benchmark: Any) -> None:
-    benchmark(OmegaConf.create, dict_with_list_leaf)
-
-
-def test_create_dict_config_with_list_leaves(
-    dict_config_with_list_leaf: Any, benchmark: Any
-) -> None:
-    benchmark(OmegaConf.create, dict_config_with_list_leaf)
+@mark.parametrize(
+    "data",
+    [
+        lazy_fixture("small_dict"),
+        lazy_fixture("large_dict"),
+        lazy_fixture("small_dict_config"),
+        lazy_fixture("large_dict_config"),
+        lazy_fixture("dict_config_with_list_leaf"),
+    ],
+)
+def test_omegaconf_create(data: Any, benchmark: Any) -> None:
+    benchmark(OmegaConf.create, data)

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from pytest import lazy_fixture  # type: ignore
-from pytest import fixture, mark
+from pytest import fixture, mark, param
 
 from omegaconf import OmegaConf
 
@@ -51,6 +51,11 @@ def large_dict_config(large_dict: Any) -> Any:
     return OmegaConf.create(large_dict)
 
 
+@fixture(scope="module")
+def merge_data(small_dict: Any) -> Any:
+    return [OmegaConf.create(small_dict) for _ in range(5)]
+
+
 @mark.parametrize(
     "data",
     [
@@ -63,3 +68,14 @@ def large_dict_config(large_dict: Any) -> Any:
 )
 def test_omegaconf_create(data: Any, benchmark: Any) -> None:
     benchmark(OmegaConf.create, data)
+
+
+@mark.parametrize(
+    "merge_function",
+    [
+        param(OmegaConf.merge, id="merge"),
+        param(OmegaConf.unsafe_merge, id="unsafe_merge"),
+    ],
+)
+def test_omegaconf_merge(merge_function: Any, merge_data: Any, benchmark: Any) -> None:
+    benchmark(merge_function, merge_data)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -402,6 +402,9 @@ Merging configurations
 Merging configurations enables the creation of reusable configuration files for each logical component
 instead of a single config file for each variation of your task.
 
+OmegaConf.merge()
+^^^^^^^^^^^^^^^^^
+
 Machine learning experiment example:
 
 .. code-block:: python
@@ -451,6 +454,18 @@ Note how the port changes to 82, and how the users lists are combined.
     log:
       file: log.txt
     <BLANKLINE>
+
+OmegaConf.unsafe_merge()
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+OmegaConf offers a second faster function to merge config objects:
+
+.. code-block:: python
+
+   conf = OmegaConf.unsafe_merge(base_cfg, model_cfg, optimizer_cfg, dataset_cfg)
+   
+Unlike OmegaConf.merge(), unsafe_merge() is destroying the input configs and they should no longer be used 
+after this call. The upside is that it's substantially faster.
 
 Configuration flags
 -------------------

--- a/news/482.feature
+++ b/news/482.feature
@@ -1,0 +1,1 @@
+Add OmegaConf.unsafe_merge(), a fast merge variant that destroys the input configs

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -486,7 +486,14 @@ class BaseContainer(Container, ABC):
         from .nodes import AnyNode, ValueNode
 
         if isinstance(value, Node):
-            value = copy.deepcopy(value)
+            do_deepcopy = not self._get_flag("no_deepcopy_set_nodes")
+            if not do_deepcopy and isinstance(value, Container):
+                # if value is from the same config, perform a deepcopy no matter what.
+                if self._get_root() is value._get_root():
+                    do_deepcopy = True
+
+            if do_deepcopy:
+                value = copy.deepcopy(value)
             value._set_parent(None)
 
             try:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,6 +10,7 @@ pyflakes
 pytest
 pytest-mock
 pytest-benchmark
+pytest-lazy-fixture
 sphinx
 towncrier
 twine

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -291,7 +291,7 @@ def test_flag_dict(flag: str) -> None:
 
 @pytest.mark.parametrize("flag", ["readonly", "struct"])
 def test_freeze_nested_dict(flag: str) -> None:
-    c = OmegaConf.create(dict(a=dict(b=2)))
+    c = OmegaConf.create({"a": {"b": 2}})
     assert not c._get_flag(flag)
     assert not c.a._get_flag(flag)
     c._set_flag(flag, True)
@@ -306,6 +306,22 @@ def test_freeze_nested_dict(flag: str) -> None:
     c.a._set_flag(flag, True)
     assert not c._get_flag(flag)
     assert c.a._get_flag(flag)
+
+
+def test_set_flags() -> None:
+    c = OmegaConf.create({"a": {"b": 2}})
+    assert not c._get_flag("readonly")
+    assert not c._get_flag("struct")
+    c._set_flag(["readonly", "struct"], True)
+    assert c._get_flag("readonly")
+    assert c._get_flag("struct")
+
+    c._set_flag(["readonly", "struct"], [False, True])
+    assert not c._get_flag("readonly")
+    assert c._get_flag("struct")
+
+    with pytest.raises(ValueError):
+        c._set_flag(["readonly", "struct"], [True, False, False])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #482

Add support for another variant of merge which is about 15 times faster in a benchmark.
The difference is that this version destroys the input configs, so it should only used if the input configs should not be used after the merge call.
It's working by not copying input nodes on set, this making the input configs inconsistent (their nodes parent no longer points to the original config, so interpolations and other things will fail for them.
Another difference than the normal merge is that this merge variant is merging directly into the first config node, eliminating the need for another whole deepcopy.

`pytest benchmark/benchmark.py --benchmark-sort=name  -k merge`:
![image](https://user-images.githubusercontent.com/376455/105437033-2b922a00-5c15-11eb-99a1-dde926f631b5.png)
