### PR TITLE
Changing default ref_type to Any

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -4,6 +4,7 @@ import re
 import string
 import sys
 from enum import Enum
+from textwrap import dedent
 from typing import Any, Dict, List, Match, Optional, Tuple, Type, Union, get_type_hints
 
 import yaml
@@ -613,11 +614,21 @@ def format_and_raise(
         KEY_TYPE=f"{type(key).__name__}",
     )
 
-    template = """$MSG
-\tfull_key: $FULL_KEY
-\treference_type=$REF_TYPE
-\tobject_type=$OBJECT_TYPE"""
-
+    if ref_type not in (None, Any):
+        template = dedent(
+            """\
+            $MSG
+                full_key: $FULL_KEY
+                reference_type=$REF_TYPE
+                object_type=$OBJECT_TYPE"""
+        )
+    else:
+        template = dedent(
+            """\
+            $MSG
+                full_key: $FULL_KEY
+                object_type=$OBJECT_TYPE"""
+        )
     s = string.Template(template=template)
 
     message = s.substitute(

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -21,9 +21,9 @@ _MARKER_ = object()
 @dataclass
 class Metadata:
 
-    ref_type: Optional[Type[Any]]
+    ref_type: Union[Type[Any], Any]
 
-    object_type: Optional[Type[Any]]
+    object_type: Union[Type[Any], Any]
 
     optional: bool
 
@@ -47,6 +47,8 @@ class ContainerMetadata(Metadata):
     element_type: Any = None
 
     def __post_init__(self) -> None:
+        if self.ref_type is None:
+            self.ref_type = Any
         assert self.key_type is Any or isinstance(self.key_type, type)
         if self.element_type is not None:
             assert self.element_type is Any or isinstance(self.element_type, type)
@@ -438,7 +440,7 @@ class Container(Node):
                         value=value,
                         parent=self,
                         metadata=Metadata(
-                            ref_type=None, object_type=None, key=key, optional=True
+                            ref_type=Any, object_type=Any, key=key, optional=True
                         ),
                     )
                 except Exception as e:

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -47,7 +47,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
         content: Union[List[Any], Tuple[Any, ...], str, None],
         key: Any = None,
         parent: Optional[Container] = None,
-        element_type: Optional[Type[Any]] = None,
+        element_type: Union[Type[Any], Any] = Any,
         is_optional: bool = True,
         ref_type: Union[Type[Any], Any] = Any,
         flags: Optional[Dict[str, bool]] = None,

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -142,7 +142,7 @@ class AnyNode(ValueNode):
             parent=parent,
             value=value,
             metadata=Metadata(
-                ref_type=Any, object_type=None, key=key, optional=is_optional  # type: ignore
+                ref_type=Any, object_type=None, key=key, optional=is_optional
             ),
         )
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -231,34 +231,26 @@ class OmegaConf:
                     or is_structured_config(obj)
                     or obj is None
                 ):
-                    ref_type = None
-                    if is_structured_config(obj):
-                        ref_type = get_type_of(obj)
-                    elif OmegaConf.is_dict(obj):
-                        ref_type = obj._metadata.ref_type
-
-                    if ref_type is None:
-                        ref_type = OmegaConf.get_type(obj)
-
                     if isinstance(obj, DictConfig):
                         key_type = obj._metadata.key_type
                         element_type = obj._metadata.element_type
                     else:
-                        key_type, element_type = get_dict_key_value_types(ref_type)
+                        obj_type = OmegaConf.get_type(obj)
+                        key_type, element_type = get_dict_key_value_types(obj_type)
                     return DictConfig(
                         content=obj,
                         parent=parent,
-                        ref_type=ref_type,
+                        ref_type=Any,
                         key_type=key_type,
                         element_type=element_type,
                         flags=flags,
                     )
                 elif is_primitive_list(obj) or OmegaConf.is_list(obj):
-                    ref_type = OmegaConf.get_type(obj)
-                    element_type = get_list_element_type(ref_type)
+                    obj_type = OmegaConf.get_type(obj)
+                    element_type = get_list_element_type(obj_type)
                     return ListConfig(
                         element_type=element_type,
-                        ref_type=ref_type,
+                        ref_type=Any,
                         content=obj,
                         parent=parent,
                         flags=flags,
@@ -805,7 +797,7 @@ def _node_wrap(
     is_optional: bool,
     value: Any,
     key: Any,
-    ref_type: Any = None,
+    ref_type: Any = Any,
 ) -> Node:
     node: Node
     is_dict = is_primitive_dict(value) or is_dict_annotation(type_)
@@ -836,7 +828,7 @@ def _node_wrap(
             ref_type=ref_type,
         )
     elif is_structured_config(type_) or is_structured_config(value):
-        key_type, element_type = get_dict_key_value_types(type_)
+        key_type, element_type = get_dict_key_value_types(value)
         node = DictConfig(
             ref_type=type_,
             is_optional=is_optional,

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -811,3 +811,12 @@ def test_self_assign_list_value_with_ref_type(c: Any) -> None:
     cfg = OmegaConf.create(c)
     cfg.a = cfg.a
     assert cfg == c
+
+
+def test_assign_to_sc_field_without_ref_type():
+    cfg = OmegaConf.create({"plugin": ConcretePlugin})
+    with pytest.raises(ValidationError):
+        cfg.plugin.params.foo = "bar"
+
+    cfg.plugin = 10
+    assert cfg.plugin == 10

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
+from textwrap import dedent
 from typing import Any, List, Optional
 
 import pytest
@@ -170,7 +171,11 @@ def test_nested_list_assign_illegal_value() -> None:
     with pytest.raises(
         UnsupportedValueType,
         match=re.escape(
-            "Value 'IllegalType' is not a supported primitive type\n\tfull_key: a[0]"
+            dedent(
+                """\
+                Value 'IllegalType' is not a supported primitive type
+                    full_key: a[0]"""
+            )
         ),
     ):
         c.a[0] = IllegalType()

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,8 +1,7 @@
 """Testing for OmegaConf"""
 import re
 import sys
-from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import pytest
 import yaml
@@ -286,11 +285,11 @@ def test_create_untyped_list() -> None:
     from omegaconf._utils import get_ref_type
 
     cfg = ListConfig(ref_type=List, content=[])
-    assert get_ref_type(cfg) == Optional[List[Any]]
+    assert get_ref_type(cfg) == Optional[List]
 
 
 def test_create_untyped_dict() -> None:
     from omegaconf._utils import get_ref_type
 
     cfg = DictConfig(ref_type=Dict, content={})
-    assert get_ref_type(cfg) == Optional[Dict[Union[str, Enum], Any]]
+    assert get_ref_type(cfg) == Optional[Dict]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,7 +2,7 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type
 
 import pytest
 
@@ -102,7 +102,6 @@ params = [
             parent_node=lambda cfg: cfg,
             child_node=lambda cfg: cfg._get_node("num"),
             object_type=StructuredWithMissing,
-            ref_type=Optional[StructuredWithMissing],
             key="num",
         ),
         id="structured:update_with_invalid_value",
@@ -116,7 +115,6 @@ params = [
             parent_node=lambda cfg: cfg,
             child_node=lambda cfg: cfg._get_node("num"),
             object_type=StructuredWithMissing,
-            ref_type=Optional[StructuredWithMissing],
             key="num",
         ),
         id="structured:update:none_to_non_optional",
@@ -127,7 +125,6 @@ params = [
             op=lambda cfg: OmegaConf.update(cfg, "a", IllegalType(), merge=True),
             key="a",
             exception_type=UnsupportedValueType,
-            ref_type=Optional[Dict[Union[str, Enum], Any]],
             msg="Value 'IllegalType' is not a supported primitive type",
         ),
         id="dict:update:object_of_illegal_type",
@@ -140,7 +137,6 @@ params = [
             key="foo",
             child_node=lambda cfg: cfg._get_node("foo"),
             exception_type=ReadonlyConfigError,
-            ref_type=Optional[Dict[Union[str, Enum], Any]],
             msg="Cannot pop from read-only node",
         ),
         id="dict,readonly:pop",
@@ -175,7 +171,6 @@ params = [
             msg="Key 'fail' not in 'ConcretePlugin'",
             key="fail",
             object_type=ConcretePlugin,
-            ref_type=Optional[ConcretePlugin],
         ),
         id="structured:access_invalid_attribute",
     ),
@@ -231,7 +226,6 @@ params = [
             msg="Invalid type assigned : int is not a subclass of FoobarParams. value: 20",
             key="params",
             object_type=ConcretePlugin,
-            ref_type=Optional[ConcretePlugin],
             child_node=lambda cfg: cfg.params,
         ),
         id="structured:setattr,invalid_type_assigned_to_structured",
@@ -445,7 +439,7 @@ params = [
                 """\
                 Key foo (str) is incompatible with (int)
                 \tfull_key: foo
-                \treference_type=Optional[Dict[int, Any]]
+                \treference_type=Any
                 \tobject_type=dict"""
             ),
             key="foo",
@@ -546,7 +540,6 @@ params = [
             exception_type=ValidationError,
             msg="Value 'fail' could not be converted to Integer",
             key="baz",
-            ref_type=Optional[Dict[str, int]],
         ),
         id="DictConfig[str,int]:assigned_str_value",
     ),
@@ -645,7 +638,6 @@ params = [
             key="foo",
             full_key="[foo]",
             msg="ListConfig indices must be integers or slices, not str",
-            ref_type=Optional[List[Any]],
         ),
         id="list:get_nox_ex:invalid_index_type",
     ),
@@ -668,7 +660,6 @@ params = [
             msg="Cannot get_node from a ListConfig object representing None",
             key=20,
             full_key="[20]",
-            ref_type=Optional[List[Any]],
         ),
         id="list:get_node_none",
     ),
@@ -877,7 +868,6 @@ params = [
             exception_type=ValidationError,
             object_type=None,
             msg="Non optional ListConfig cannot be constructed from None",
-            ref_type=List[int],
             low_level=True,
         ),
         id="list:create_not_optional:_set_value(None)",
@@ -904,7 +894,6 @@ params = [
             key=0,
             full_key="[0]",
             child_node=lambda cfg: cfg[0],
-            ref_type=Optional[List[int]],
         ),
         id="list,int_elements:assigned_str_element",
     ),
@@ -920,7 +909,6 @@ params = [
             key=0,
             full_key="[0]",
             child_node=lambda cfg: cfg[0],
-            ref_type=Optional[List[int]],
         ),
         id="list,int_elements:assigned_str_element",
     ),
@@ -935,7 +923,6 @@ params = [
             key=0,
             full_key="[0]",
             child_node=lambda cfg: cfg[0],
-            ref_type=Optional[List[Any]],
         ),
         id="list,not_optional:null_assignment",
     ),
@@ -982,7 +969,6 @@ params = [
             key=1,
             full_key="[1]",
             child_node=lambda _cfg: None,
-            ref_type=Optional[List[Any]],
         ),
         id="list:insert_into_missing",
     ),
@@ -995,7 +981,6 @@ params = [
             msg="Cannot get from a ListConfig object representing None",
             key=0,
             full_key="[0]",
-            ref_type=Optional[List[Any]],
         ),
         id="list:get_from_none",
     ),

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -4,10 +4,9 @@ import os
 import pathlib
 import pickle
 import tempfile
-from enum import Enum
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type
 
 import pytest
 
@@ -127,13 +126,9 @@ def test_save_illegal_type() -> None:
 
 
 @pytest.mark.parametrize(
-    "obj,ref_type",
-    [
-        ({"a": "b"}, Dict[Union[str, Enum], Any]),
-        ([1, 2, 3], List[Any]),
-    ],
+    "obj", [pytest.param({"a": "b"}, id="dict"), pytest.param([1, 2, 3], id="list")]
 )
-def test_pickle(obj: Any, ref_type: Any) -> None:
+def test_pickle(obj: Any) -> None:
     with tempfile.TemporaryFile() as fp:
         c = OmegaConf.create(obj)
         pickle.dump(c, fp)
@@ -141,7 +136,7 @@ def test_pickle(obj: Any, ref_type: Any) -> None:
         fp.seek(0)
         c1 = pickle.load(fp)
         assert c == c1
-        assert get_ref_type(c1) == Optional[ref_type]
+        assert get_ref_type(c1) == Any
         assert c1._metadata.element_type is Any
         assert c1._metadata.optional is True
         if isinstance(c, DictConfig):
@@ -203,14 +198,14 @@ def test_load_empty_file(tmpdir: str) -> None:
     [
         (UntypedList, "list", Any, Any, False, List[Any]),
         (UntypedList, "opt_list", Any, Any, True, Optional[List[Any]]),
-        (UntypedDict, "dict", Any, Any, False, Dict[Union[str, Enum], Any]),
+        (UntypedDict, "dict", Any, Any, False, Dict[Any, Any]),
         (
             UntypedDict,
             "opt_dict",
             Any,
             Any,
             True,
-            Optional[Dict[Union[str, Enum], Any]],
+            Optional[Dict[Any, Any]],
         ),
         (SubscriptedDict, "dict", int, str, False, Dict[str, int]),
         (SubscriptedList, "list", int, Any, False, List[int]),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import attr
-import pytest
+from pytest import param, raises, mark
 
 from omegaconf import DictConfig, ListConfig, Node, OmegaConf, _utils
 from omegaconf._utils import is_dict_annotation, is_list_annotation
@@ -21,71 +21,65 @@ from omegaconf.omegaconf import _node_wrap
 from . import Color, ConcretePlugin, IllegalType, Plugin, does_not_raise
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "target_type, value, expected",
     [
         # Any
-        pytest.param(Any, "foo", AnyNode("foo"), id="any"),
-        pytest.param(Any, True, AnyNode(True), id="any"),
-        pytest.param(Any, 1, AnyNode(1), id="any"),
-        pytest.param(Any, 1.0, AnyNode(1.0), id="any"),
-        pytest.param(Any, Color.RED, AnyNode(Color.RED), id="any"),
-        pytest.param(Any, {}, DictConfig(content={}), id="any_as_dict"),
-        pytest.param(Any, [], ListConfig(content=[]), id="any_as_list"),
+        param(Any, "foo", AnyNode("foo"), id="any"),
+        param(Any, True, AnyNode(True), id="any"),
+        param(Any, 1, AnyNode(1), id="any"),
+        param(Any, 1.0, AnyNode(1.0), id="any"),
+        param(Any, Color.RED, AnyNode(Color.RED), id="any"),
+        param(Any, {}, DictConfig(content={}), id="any_as_dict"),
+        param(Any, [], ListConfig(content=[]), id="any_as_list"),
         # int
-        pytest.param(int, "foo", ValidationError, id="int"),
-        pytest.param(int, True, ValidationError, id="int"),
-        pytest.param(int, 1, IntegerNode(1), id="int"),
-        pytest.param(int, 1.0, ValidationError, id="int"),
-        pytest.param(int, Color.RED, ValidationError, id="int"),
+        param(int, "foo", ValidationError, id="int"),
+        param(int, True, ValidationError, id="int"),
+        param(int, 1, IntegerNode(1), id="int"),
+        param(int, 1.0, ValidationError, id="int"),
+        param(int, Color.RED, ValidationError, id="int"),
         # float
-        pytest.param(float, "foo", ValidationError, id="float"),
-        pytest.param(float, True, ValidationError, id="float"),
-        pytest.param(float, 1, FloatNode(1), id="float"),
-        pytest.param(float, 1.0, FloatNode(1.0), id="float"),
-        pytest.param(float, Color.RED, ValidationError, id="float"),
+        param(float, "foo", ValidationError, id="float"),
+        param(float, True, ValidationError, id="float"),
+        param(float, 1, FloatNode(1), id="float"),
+        param(float, 1.0, FloatNode(1.0), id="float"),
+        param(float, Color.RED, ValidationError, id="float"),
         # # bool
-        pytest.param(bool, "foo", ValidationError, id="bool"),
-        pytest.param(bool, True, BooleanNode(True), id="bool"),
-        pytest.param(bool, 1, BooleanNode(True), id="bool"),
-        pytest.param(bool, 0, BooleanNode(False), id="bool"),
-        pytest.param(bool, 1.0, ValidationError, id="bool"),
-        pytest.param(bool, Color.RED, ValidationError, id="bool"),
-        pytest.param(bool, "true", BooleanNode(True), id="bool"),
-        pytest.param(bool, "false", BooleanNode(False), id="bool"),
-        pytest.param(bool, "on", BooleanNode(True), id="bool"),
-        pytest.param(bool, "off", BooleanNode(False), id="bool"),
+        param(bool, "foo", ValidationError, id="bool"),
+        param(bool, True, BooleanNode(True), id="bool"),
+        param(bool, 1, BooleanNode(True), id="bool"),
+        param(bool, 0, BooleanNode(False), id="bool"),
+        param(bool, 1.0, ValidationError, id="bool"),
+        param(bool, Color.RED, ValidationError, id="bool"),
+        param(bool, "true", BooleanNode(True), id="bool"),
+        param(bool, "false", BooleanNode(False), id="bool"),
+        param(bool, "on", BooleanNode(True), id="bool"),
+        param(bool, "off", BooleanNode(False), id="bool"),
         # str
-        pytest.param(str, "foo", StringNode("foo"), id="str"),
-        pytest.param(str, True, StringNode("True"), id="str"),
-        pytest.param(str, 1, StringNode("1"), id="str"),
-        pytest.param(str, 1.0, StringNode("1.0"), id="str"),
-        pytest.param(str, Color.RED, StringNode("Color.RED"), id="str"),
+        param(str, "foo", StringNode("foo"), id="str"),
+        param(str, True, StringNode("True"), id="str"),
+        param(str, 1, StringNode("1"), id="str"),
+        param(str, 1.0, StringNode("1.0"), id="str"),
+        param(str, Color.RED, StringNode("Color.RED"), id="str"),
         # Color
-        pytest.param(Color, "foo", ValidationError, id="Color"),
-        pytest.param(Color, True, ValidationError, id="Color"),
-        pytest.param(Color, 1, EnumNode(enum_type=Color, value=Color.RED), id="Color"),
-        pytest.param(Color, 1.0, ValidationError, id="Color"),
-        pytest.param(
-            Color, Color.RED, EnumNode(enum_type=Color, value=Color.RED), id="Color"
-        ),
-        pytest.param(
-            Color, "RED", EnumNode(enum_type=Color, value=Color.RED), id="Color"
-        ),
-        pytest.param(
+        param(Color, "foo", ValidationError, id="Color"),
+        param(Color, True, ValidationError, id="Color"),
+        param(Color, 1, EnumNode(enum_type=Color, value=Color.RED), id="Color"),
+        param(Color, 1.0, ValidationError, id="Color"),
+        param(Color, Color.RED, EnumNode(enum_type=Color, value=Color.RED), id="Color"),
+        param(Color, "RED", EnumNode(enum_type=Color, value=Color.RED), id="Color"),
+        param(
             Color, "Color.RED", EnumNode(enum_type=Color, value=Color.RED), id="Color"
         ),
         # bad type
-        pytest.param(IllegalType, "nope", ValidationError, id="bad_type"),
+        param(IllegalType, "nope", ValidationError, id="bad_type"),
         # DictConfig
-        pytest.param(
+        param(
             dict, {"foo": "bar"}, DictConfig(content={"foo": "bar"}), id="DictConfig"
         ),
-        pytest.param(
-            Plugin, Plugin(), DictConfig(content=Plugin()), id="DictConfig[Plugin]"
-        ),
+        param(Plugin, Plugin(), DictConfig(content=Plugin()), id="DictConfig[Plugin]"),
         # ListConfig
-        pytest.param(list, [1, 2, 3], ListConfig(content=[1, 2, 3]), id="ListConfig"),
+        param(list, [1, 2, 3], ListConfig(content=[1, 2, 3]), id="ListConfig"),
     ],
 )
 def test_node_wrap(target_type: Any, value: Any, expected: Any) -> None:
@@ -99,7 +93,7 @@ def test_node_wrap(target_type: Any, value: Any, expected: Any) -> None:
         assert res == expected
         assert res._key() == "foo"
     else:
-        with pytest.raises(expected):
+        with raises(expected):
             _maybe_wrap(
                 ref_type=target_type,
                 key=None,
@@ -150,7 +144,7 @@ class _TestUserClass:
     pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_, expected",
     [
         (int, True),
@@ -171,14 +165,14 @@ def test_valid_value_annotation_type(type_: type, expected: bool) -> None:
     assert valid_value_annotation_type(type_) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "test_cls_or_obj, expectation",
     [
         (_TestDataclass, does_not_raise()),
         (_TestDataclass(), does_not_raise()),
         (_TestAttrsClass, does_not_raise()),
         (_TestAttrsClass(), does_not_raise()),
-        ("invalid", pytest.raises(ValueError)),
+        ("invalid", raises(ValueError)),
     ],
 )
 def test_get_structured_config_data(test_cls_or_obj: Any, expectation: Any) -> None:
@@ -193,7 +187,7 @@ def test_get_structured_config_data(test_cls_or_obj: Any, expectation: Any) -> N
         assert d["dict1"] == {}
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "test_cls",
     [
         _TestDataclassIllegalValue,
@@ -201,10 +195,10 @@ def test_get_structured_config_data(test_cls_or_obj: Any, expectation: Any) -> N
     ],
 )
 def test_get_structured_config_data_illegal_value(test_cls: Any) -> None:
-    with pytest.raises(UnsupportedValueType):
+    with raises(UnsupportedValueType):
         _utils.get_structured_config_data(test_cls, allow_objects=None)
 
-    with pytest.raises(UnsupportedValueType):
+    with raises(UnsupportedValueType):
         _utils.get_structured_config_data(test_cls, allow_objects=False)
 
     d = _utils.get_structured_config_data(test_cls, allow_objects=True)
@@ -246,7 +240,7 @@ class Dataclass:
     pass
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "value,kind",
     [
         ("foo", _utils.ValueKind.VALUE),
@@ -294,17 +288,17 @@ def test_re_parent() -> None:
 def test_get_class() -> None:
     name = "tests.examples.test_dataclass_example.SimpleTypes"
     assert _utils._get_class(name).__name__ == "SimpleTypes"
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         _utils._get_class("not_found")
 
-    with pytest.raises(ModuleNotFoundError):
+    with raises(ModuleNotFoundError):
         _utils._get_class("foo.not_found")
 
-    with pytest.raises(ImportError):
+    with raises(ImportError):
         _utils._get_class("tests.examples.test_dataclass_example.not_found")
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "key_type,expected_key_type",
     [
         (str, str),
@@ -312,7 +306,7 @@ def test_get_class() -> None:
         (Any, Any),
     ],
 )
-@pytest.mark.parametrize(
+@mark.parametrize(
     "value_type,expected_value_type",
     [
         (int, int),
@@ -331,7 +325,7 @@ def test_get_key_value_types(
     )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_, is_primitive",
     [
         (int, True),
@@ -350,8 +344,8 @@ def test_is_primitive_type(type_: Any, is_primitive: bool) -> None:
     assert _utils.is_primitive_type(type_) == is_primitive
 
 
-@pytest.mark.parametrize("optional", [False, True])
-@pytest.mark.parametrize(
+@mark.parametrize("optional", [False, True])
+@mark.parametrize(
     "type_, expected",
     [
         (int, "int"),
@@ -388,7 +382,7 @@ def test_type_str_none() -> None:
     assert _utils.type_str(None) == "NoneType"
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_, expected",
     [
         (Optional[int], "Optional[int]"),
@@ -401,7 +395,7 @@ def test_type_str_union(type_: Any, expected: str) -> None:
     assert _utils.type_str(type_) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_, expected",
     [
         (Dict[str, int], True),
@@ -421,7 +415,7 @@ def test_is_dict_annotation(type_: Any, expected: Any) -> Any:
     assert is_dict_annotation(type_=type_) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_, expected",
     [
         (List[int], True),
@@ -442,100 +436,96 @@ def test_is_list_annotation(type_: Any, expected: Any) -> Any:
     assert is_list_annotation(type_=type_) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "obj, expected",
     [
         # Unwrapped values
-        pytest.param(10, Optional[int], id="int"),
-        pytest.param(10.0, Optional[float], id="float"),
-        pytest.param(True, Optional[bool], id="bool"),
-        pytest.param("bar", Optional[str], id="str"),
-        pytest.param(None, type(None), id="NoneType"),
-        pytest.param({}, Optional[Dict[Union[str, Enum], Any]], id="dict"),
-        pytest.param([], Optional[List[Any]], id="List[Any]"),
-        pytest.param(tuple(), Optional[List[Any]], id="List[Any]"),
-        pytest.param(ConcretePlugin(), Optional[ConcretePlugin], id="ConcretePlugin"),
-        pytest.param(ConcretePlugin, Optional[ConcretePlugin], id="ConcretePlugin"),
+        param(10, Optional[int], id="int"),
+        param(10.0, Optional[float], id="float"),
+        param(True, Optional[bool], id="bool"),
+        param("bar", Optional[str], id="str"),
+        param(None, type(None), id="NoneType"),
+        param({}, Optional[Dict[Union[str, Enum], Any]], id="dict"),
+        param([], Optional[List[Any]], id="List[Any]"),
+        param(tuple(), Optional[List[Any]], id="List[Any]"),
+        param(ConcretePlugin(), Optional[ConcretePlugin], id="ConcretePlugin"),
+        param(ConcretePlugin, Optional[ConcretePlugin], id="ConcretePlugin"),
         # Optional value nodes
-        pytest.param(IntegerNode(10), Optional[int], id="IntegerNode"),
-        pytest.param(FloatNode(10.0), Optional[float], id="FloatNode"),
-        pytest.param(BooleanNode(True), Optional[bool], id="BooleanNode"),
-        pytest.param(StringNode("bar"), Optional[str], id="StringNode"),
-        pytest.param(
+        param(IntegerNode(10), Optional[int], id="IntegerNode"),
+        param(FloatNode(10.0), Optional[float], id="FloatNode"),
+        param(BooleanNode(True), Optional[bool], id="BooleanNode"),
+        param(StringNode("bar"), Optional[str], id="StringNode"),
+        param(
             EnumNode(enum_type=Color, value=Color.RED),
             Optional[Color],
             id="EnumNode[Color]",
         ),
         # Non-optional value nodes:
-        pytest.param(IntegerNode(10, is_optional=False), int, id="IntegerNode"),
-        pytest.param(FloatNode(10.0, is_optional=False), float, id="FloatNode"),
-        pytest.param(BooleanNode(True, is_optional=False), bool, id="BooleanNode"),
-        pytest.param(StringNode("bar", is_optional=False), str, id="StringNode"),
-        pytest.param(
+        param(IntegerNode(10, is_optional=False), int, id="IntegerNode"),
+        param(FloatNode(10.0, is_optional=False), float, id="FloatNode"),
+        param(BooleanNode(True, is_optional=False), bool, id="BooleanNode"),
+        param(StringNode("bar", is_optional=False), str, id="StringNode"),
+        param(
             EnumNode(enum_type=Color, value=Color.RED, is_optional=False),
             Color,
             id="EnumNode[Color]",
         ),
         # DictConfig
-        pytest.param(DictConfig(content={}), Any, id="DictConfig"),
-        pytest.param(
+        param(DictConfig(content={}), Any, id="DictConfig"),
+        param(
             DictConfig(key_type=str, element_type=Color, content={}),
             Optional[Dict[str, Color]],
             id="DictConfig[str,Color]",
         ),
-        pytest.param(
+        param(
             DictConfig(key_type=Color, element_type=int, content={}),
             Optional[Dict[Color, int]],
             id="DictConfig[Color,int]",
         ),
-        pytest.param(
+        param(
             DictConfig(ref_type=Any, content=ConcretePlugin),
             Any,
             id="DictConfig[ConcretePlugin]_Any_reftype",
         ),
-        pytest.param(
+        param(
             DictConfig(content="???"),
             Optional[Dict[Union[str, Enum], Any]],
             id="DictConfig[Union[str, Enum], Any]_missing",
         ),
-        pytest.param(
+        param(
             DictConfig(content="???", element_type=int, key_type=str),
             Optional[Dict[str, int]],
             id="DictConfig[str, int]_missing",
         ),
-        pytest.param(
+        param(
             DictConfig(ref_type=Plugin, content=ConcretePlugin),
             Optional[Plugin],
             id="DictConfig[Plugin]",
         ),
-        pytest.param(
+        param(
             DictConfig(ref_type=Plugin, content=ConcretePlugin),
             Optional[Plugin],
             id="Plugin",
         ),
         # Non optional DictConfig
-        pytest.param(
+        param(
             DictConfig(ref_type=Plugin, content=ConcretePlugin, is_optional=False),
             Plugin,
             id="Plugin",
         ),
         # ListConfig
-        pytest.param(ListConfig([]), Optional[List[Any]], id="ListConfig[Any]"),
-        pytest.param(
+        param(ListConfig([]), Optional[List[Any]], id="ListConfig[Any]"),
+        param(
             ListConfig([], element_type=int), Optional[List[int]], id="ListConfig[int]"
         ),
-        pytest.param(
-            ListConfig(content="???"), Optional[List[Any]], id="ListConfig_missing"
-        ),
-        pytest.param(
+        param(ListConfig(content="???"), Optional[List[Any]], id="ListConfig_missing"),
+        param(
             ListConfig(content="???", element_type=int),
             Optional[List[int]],
             id="ListConfig[int]_missing",
         ),
-        pytest.param(
-            ListConfig(content=None), Optional[List[Any]], id="ListConfig_none"
-        ),
-        pytest.param(
+        param(ListConfig(content=None), Optional[List[Any]], id="ListConfig_none"),
+        param(
             ListConfig(content=None, element_type=int),
             Optional[List[int]],
             id="ListConfig[int]_none",


### PR DESCRIPTION
ref_type was meant to be equivalent to type annotation:
```
x : Foo = Bar()
```

Above, x should have the ref_type Foo.
ref_type is consulted when assigning values to x, to ensure that they are of the right type.
(such assignment results in a runtime exception in OmegaConf).

Over time, ref_type was used for additional things like encoding the key type and element type of a DictConfig.
In addition, for implementation reasons, ref_type of Structured Configs automatically matched the object type:

```
cfg = OmegaConf.create({"user":  User})
```
above, cfg.user has the ref_type User, which means it cannot be assigned anything else.
This is not intentional.
Such behavior is justified using Structured Config:
```python
@dataclass
class Config
  user: User = User()
```

but not when using the previous form.

This PR is:
1. Simplifying ref_type back to what i was always meant to be.
2. Simplifies error messages to only contain reference_type if it's not Any.
3. Unrelated: Fixes exceptions raised to contain the correct stack trace (debugging OmegaConf is now far less annoying).