### PR TITLE
Support YAML merge tags

### DIFF
--- a/news/470.bugfix
+++ b/news/470.bugfix
@@ -1,1 +1,1 @@
-Support for merge tags in YAML files
+Fix support for merge tags in YAML files

--- a/news/470.bugfix
+++ b/news/470.bugfix
@@ -1,0 +1,1 @@
+Support for merge tags in YAML files

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,8 +1,8 @@
 """Testing for OmegaConf"""
 import re
 import sys
-from typing import Any, Dict, List, Optional
 from textwrap import dedent
+from typing import Any, Dict, List, Optional
 
 import pytest
 import yaml
@@ -296,32 +296,33 @@ def test_create_untyped_dict() -> None:
     assert get_ref_type(cfg) == Optional[Dict]
 
 
-def test_yaml_duplicate_keys() -> None:
-    from yaml.constructor import ConstructorError
-
-    with pytest.raises(ConstructorError):
-        OmegaConf.create(
-            dedent(
-                """\
+@pytest.mark.parametrize(
+    "input_",
+    [
+        dedent(
+            """\
                 a:
                   b: 1
                   c: 2
                   b: 3
                 """
-            )
-        )
-    with pytest.raises(ConstructorError):
-        OmegaConf.create(
-            dedent(
-                """\
+        ),
+        dedent(
+            """\
                 a:
                   b: 1
                 a:
                   b: 2
                 """
-            )
-        )
+        ),
+    ],
+)
+def test_yaml_duplicate_keys(input_: str) -> None:
+    with pytest.raises(yaml.constructor.ConstructorError):
+        OmegaConf.create(input_)
 
+
+def test_yaml_merge() -> None:
     cfg = OmegaConf.create(
         dedent(
             """\

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,7 +5,6 @@ import pathlib
 import pickle
 import tempfile
 from pathlib import Path
-from textwrap import dedent
 from typing import Any, Dict, List, Optional, Type
 
 import pytest
@@ -141,69 +140,6 @@ def test_pickle(obj: Any) -> None:
         assert c1._metadata.optional is True
         if isinstance(c, DictConfig):
             assert c1._metadata.key_type is Any
-
-
-def test_load_duplicate_keys_top() -> None:
-    from yaml.constructor import ConstructorError
-
-    try:
-        with tempfile.NamedTemporaryFile(delete=False) as fp:
-            content = dedent(
-                """\
-                a:
-                  b: 1
-                a:
-                  b: 2
-                """
-            )
-            fp.write(content.encode("utf-8"))
-        with pytest.raises(ConstructorError):
-            OmegaConf.load(fp.name)
-    finally:
-        os.unlink(fp.name)
-
-
-def test_load_duplicate_keys_sub() -> None:
-    from yaml.constructor import ConstructorError
-
-    try:
-        with tempfile.NamedTemporaryFile(delete=False) as fp:
-            content = dedent(
-                """\
-                a:
-                  b: 1
-                  c: 2
-                  b: 3
-                """
-            )
-            fp.write(content.encode("utf-8"))
-        with pytest.raises(ConstructorError):
-            OmegaConf.load(fp.name)
-    finally:
-        os.unlink(fp.name)
-
-
-def test_load_merge_duplicates() -> None:
-    try:
-        with tempfile.NamedTemporaryFile(delete=False) as fp:
-            content = dedent(
-                """\
-                a: &A
-                    x: 1
-                b: &B
-                    y: 2
-                c:
-                    <<: *A
-                    <<: *B
-                    x: 3
-                    z: 1
-                """
-            )
-            fp.write(content.encode("utf-8"))
-        cfg = OmegaConf.load(fp.name)
-        assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 3, "y": 2, "z": 1}}
-    finally:
-        os.unlink(fp.name)
 
 
 def test_load_empty_file(tmpdir: str) -> None:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -183,6 +183,29 @@ def test_load_duplicate_keys_sub() -> None:
         os.unlink(fp.name)
 
 
+def test_load_merge_duplicates() -> None:
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            content = dedent(
+                """\
+                a: &A
+                    x: 1
+                b: &B
+                    y: 2
+                c:
+                    <<: *A
+                    <<: *B
+                    x: 3
+                    z: 1
+                """
+            )
+            fp.write(content.encode("utf-8"))
+        cfg = OmegaConf.load(fp.name)
+        assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 3, "y": 2, "z": 1}}
+    finally:
+        os.unlink(fp.name)
+
+
 def test_load_empty_file(tmpdir: str) -> None:
     empty = Path(tmpdir) / "test.yaml"
     empty.touch()


### PR DESCRIPTION
This adds support for YAML merge tags (<< *ref) while retaining the
sanity check for duplicate keys. Note that the spec for merge keys
(https://yaml.org/type/merge.html) explicitly states that keys in the
current mapping override the ones in the merged mapping. Hence, the
check for duplicates is applied to scalar keys of the current mapping
only.

Fixes #470.