### PR TITLE
`to_pathdict()` serialization functionality

### DIFF
--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -54,6 +54,12 @@ def test_setattr_deep_map() -> None:
     c.a.b = {"z": 10}
     assert {"a": {"b": {"z": 10}}} == c
 
+def test_to_pathdict() -> None:
+    c = OmegaConf.create(dict(a=dict()))
+    c.a.b = {"c": 1}
+    c.a.y = {"z": 10}
+    assert {"a.b.c": 1, "a.y.z": 10} == OmegaConf.to_pathdict(c)
+
 
 def test_getattr() -> None:
     c = OmegaConf.create("a: b")


### PR DESCRIPTION
`OmegaConf.to_pathdict()` takes the same arguments as `OmegaConf.to_container()` (plus separator) 
and outputs a "flattened" dict. Useful for serializing when you can't have a nested hash map.
(Essentially the inverse operation of creating a config from a dotlist)

I'm not sure if the tests are in the right place, or if I should write more than just one.
Let me know what I need to change to get this accepted.