### PR TITLE
Use interpolation resolution error

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 from ._utils import ValueKind, _get_value, format_and_raise, get_value_kind
 from .errors import (
     ConfigKeyError,
+    InterpolationResolutionError,
     MissingMandatoryValue,
     OmegaConfBaseException,
     UnsupportedInterpolationType,
@@ -429,7 +430,7 @@ class Container(Node):
             # if parent is None or (value is None and last_key not in parent):  # type: ignore
             if parent is None or value is None:
                 if throw_on_resolution_failure:
-                    raise ConfigKeyError(
+                    raise InterpolationResolutionError(
                         f"{inter_type} interpolation key '{inter_key}' not found"
                     )
                 else:

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -38,6 +38,7 @@ from .errors import (
     ConfigAttributeError,
     ConfigKeyError,
     ConfigTypeError,
+    InterpolationResolutionError,
     KeyValidationError,
     MissingMandatoryValue,
     OmegaConfBaseException,
@@ -513,7 +514,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             except UnsupportedInterpolationType:
                 # Value that has unsupported interpolation counts as existing.
                 return True
-            except (MissingMandatoryValue, KeyError):
+            except (MissingMandatoryValue, KeyError, InterpolationResolutionError):
                 return False
 
     def __iter__(self) -> Iterator[DictKeyType]:

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -54,6 +54,7 @@ from .base import Container, Node
 from .basecontainer import BaseContainer
 from .errors import (
     ConfigKeyError,
+    InterpolationResolutionError,
     MissingMandatoryValue,
     OmegaConfBaseException,
     UnsupportedInterpolationType,
@@ -639,7 +640,7 @@ class OmegaConf:
                     throw_on_missing=throw_on_missing,
                     throw_on_resolution_failure=throw_on_resolution_failure,
                 )
-            except ConfigKeyError:
+            except (ConfigKeyError, InterpolationResolutionError):
                 if default is not _EMPTY_MARKER_:
                     return default
                 else:

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -7,8 +7,8 @@ import pytest
 
 from omegaconf import MISSING, AnyNode, ListConfig, OmegaConf, flag_override
 from omegaconf.errors import (
-    ConfigKeyError,
     ConfigTypeError,
+    InterpolationResolutionError,
     KeyValidationError,
     MissingMandatoryValue,
     UnsupportedValueType,
@@ -70,7 +70,7 @@ def test_iterate_list_with_missing_interpolation() -> None:
     c = OmegaConf.create([1, "${10}"])
     itr = iter(c)
     assert 1 == next(itr)
-    with pytest.raises(ConfigKeyError):
+    with pytest.raises(InterpolationResolutionError):
         next(itr)
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -214,6 +214,19 @@ params = [
         ),
         id="dict,accessing_missing_str_interpolation",
     ),
+    pytest.param(
+        Expected(
+            create=lambda: OmegaConf.create({"foo": {"bar": "${.missing}"}}),
+            op=lambda cfg: getattr(cfg.foo, "bar"),
+            exception_type=ConfigAttributeError,
+            msg="str interpolation key 'missing' not found",
+            key="bar",
+            full_key="foo.bar",
+            child_node=lambda cfg: cfg.foo._get_node("bar"),
+            parent_node=lambda cfg: cfg.foo,
+        ),
+        id="dict,accessing_missing_relative_interpolation",
+    ),
     # setattr
     pytest.param(
         Expected(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -22,6 +22,7 @@ from omegaconf.errors import (
     ConfigKeyError,
     ConfigTypeError,
     ConfigValueError,
+    InterpolationResolutionError,
     KeyValidationError,
     MissingMandatoryValue,
     OmegaConfBaseException,
@@ -196,7 +197,7 @@ params = [
         Expected(
             create=lambda: OmegaConf.create({"foo": "${missing}"}),
             op=lambda cfg: getattr(cfg, "foo"),
-            exception_type=ConfigAttributeError,
+            exception_type=InterpolationResolutionError,
             msg="str interpolation key 'missing' not found",
             key="foo",
             child_node=lambda cfg: cfg._get_node("foo"),
@@ -207,7 +208,7 @@ params = [
         Expected(
             create=lambda: OmegaConf.create({"foo": "foo_${missing}"}),
             op=lambda cfg: getattr(cfg, "foo"),
-            exception_type=ConfigAttributeError,
+            exception_type=InterpolationResolutionError,
             msg="str interpolation key 'missing' not found",
             key="foo",
             child_node=lambda cfg: cfg._get_node("foo"),
@@ -218,7 +219,7 @@ params = [
         Expected(
             create=lambda: OmegaConf.create({"foo": {"bar": "${.missing}"}}),
             op=lambda cfg: getattr(cfg.foo, "bar"),
-            exception_type=ConfigAttributeError,
+            exception_type=InterpolationResolutionError,
             msg="str interpolation key 'missing' not found",
             key="bar",
             full_key="foo.bar",

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -17,15 +17,29 @@ from omegaconf import (
     ValidationError,
 )
 from omegaconf._utils import _ensure_container
-from omegaconf.errors import ConfigAttributeError, OmegaConfBaseException
+from omegaconf.errors import (
+    ConfigAttributeError,
+    InterpolationResolutionError,
+    OmegaConfBaseException,
+)
 
 
 @pytest.mark.parametrize(
     "cfg,key,expected",
     [
         pytest.param({"a": "${b}", "b": 10}, "a", 10, id="simple"),
-        pytest.param({"a": "${x}"}, "a", pytest.raises(KeyError), id="not_found"),
-        pytest.param({"a": "${x.y}"}, "a", pytest.raises(KeyError), id="not_found"),
+        pytest.param(
+            {"a": "${x}"},
+            "a",
+            pytest.raises(InterpolationResolutionError),
+            id="not_found",
+        ),
+        pytest.param(
+            {"a": "${x.y}"},
+            "a",
+            pytest.raises(InterpolationResolutionError),
+            id="not_found",
+        ),
         pytest.param({"a": "foo_${b}", "b": "bar"}, "a", "foo_bar", id="str_inter"),
         pytest.param(
             {"a": "${x}_${y}", "x": "foo", "y": "bar"},
@@ -393,7 +407,7 @@ def test_interpolation_in_list_key_error() -> None:
     # Test that a KeyError is thrown if an str_interpolation key is not available
     c = OmegaConf.create(["${10}"])
 
-    with pytest.raises(KeyError):
+    with pytest.raises(InterpolationResolutionError):
         c[0]
 
 

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -15,7 +15,11 @@ from omegaconf import (
     OmegaConf,
     StringNode,
 )
-from omegaconf.errors import ConfigKeyError, UnsupportedInterpolationType
+from omegaconf.errors import (
+    ConfigKeyError,
+    InterpolationResolutionError,
+    UnsupportedInterpolationType,
+)
 from tests import (
     Color,
     ConcretePlugin,
@@ -30,7 +34,7 @@ from tests import (
     [
         ({}, "foo", False, raises(ConfigKeyError)),
         ({"foo": True}, "foo", False, does_not_raise()),
-        ({"foo": "${no_such_key}"}, "foo", False, raises(ConfigKeyError)),
+        ({"foo": "${no_such_key}"}, "foo", False, raises(InterpolationResolutionError)),
         ({"foo": MISSING}, "foo", True, raises(MissingMandatoryValue)),
         pytest.param(
             {"foo": "${bar}", "bar": DictConfig(content=MISSING)},


### PR DESCRIPTION
Based on comment https://github.com/omry/omegaconf/pull/516#discussion_r571080800
we use a separate exception type `InterpolationResolutionError` to indicate failure of interpolation, instead of using `ConfigKeyError`.