### PR TITLE
Update notebook to synch with the docs

### DIFF
--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -503,13 +503,23 @@
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Missing mandatory value: log.file\n",
+      "    full_key: log.file\n",
+      "    object_type=dict\n"
+     ]
+    }
+   ],
    "source": [
-    "import pytest\n",
     "from omegaconf import MissingMandatoryValue\n",
-    "\n",
-    "with pytest.raises(MissingMandatoryValue):\n",
-    "    conf.log.file"
+    "try:\n",
+    "    conf.log.file\n",
+    "except MissingMandatoryValue as exc:\n",
+    "    print(exc)"
    ]
   },
   {

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -617,61 +617,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Interpolated nodes can be any node in the config, not just leaf nodes:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cfg.player.height: 180\n",
-      "cfg.player.weight: 75\n",
-      "=== Switching player\n",
-      "cfg.player.height: 195\n",
-      "cfg.player.weight: 90\n"
-     ]
-    }
-   ],
-   "source": [
-    "from textwrap import dedent\n",
-    "cfg = OmegaConf.create(\n",
-    "    dedent(\n",
-    "        \"\"\"\\\n",
-    "        john:\n",
-    "            height: 180\n",
-    "            weight: 75\n",
-    "\n",
-    "        fred:\n",
-    "            height: 195\n",
-    "            weight: 90\n",
-    "            \n",
-    "        player: ${john}\n",
-    "        \"\"\"\n",
-    "    )\n",
-    ")\n",
-    "print(f\"cfg.player.height: {cfg.player.height}\")\n",
-    "print(f\"cfg.player.weight: {cfg.player.weight}\")\n",
-    "print(\"=== Switching player\")\n",
-    "cfg.player = \"${fred}\"\n",
-    "print(f\"cfg.player.height: {cfg.player.height}\")\n",
-    "print(f\"cfg.player.weight: {cfg.player.weight}\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Interpolations may be nested, enabling more advanced behavior like dynamically selecting a sub-config:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -684,21 +635,49 @@
     }
    ],
    "source": [
-    "from textwrap import dedent\n",
     "cfg = OmegaConf.create(\n",
-    "    dedent(\n",
-    "        \"\"\"\\\n",
-    "        plans:\n",
-    "            A: plan A\n",
-    "            B: plan B\n",
-    "        selected_plan: A\n",
-    "        plan: ${plans.${selected_plan}}\n",
-    "        \"\"\"\n",
-    "    )\n",
+    "    {\n",
+    "        \"plans\": {\"A\": \"plan A\", \"B\": \"plan B\"},\n",
+    "        \"selected_plan\": \"A\",\n",
+    "        \"plan\": \"${plans.${selected_plan}}\",\n",
+    "    }\n",
     ")\n",
     "print(f\"Default: cfg.plan = {cfg.plan}\")\n",
     "cfg.selected_plan = \"B\"\n",
     "print(f\"After selecting plan B: cfg.plan = {cfg.plan}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Interpolated nodes can be any node in the config, not just leaf nodes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(180, 75)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cfg = OmegaConf.create(\n",
+    "    {\n",
+    "        \"john\": {\"height\": 180, \"weight\": 75},\n",
+    "        \"player\": \"${john}\",\n",
+    "    }\n",
+    ")\n",
+    "(cfg.player.height, cfg.player.weight)"
    ]
   },
   {
@@ -791,17 +770,20 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "'abc123'\n"
-     ]
+     "data": {
+      "text/plain": [
+       "'abc123'"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "os.environ.pop('DB_PASSWORD', None)  # ensure env variable does not exist\n",
     "cfg = OmegaConf.create({'database': {'password': '${env:DB_PASSWORD,abc123}'}})\n",
-    "print(repr(cfg.database.password))"
+    "cfg.database.password"
    ]
   },
   {
@@ -927,12 +909,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "With cache: \n",
-      "0.9664535356921388\n",
-      "0.9664535356921388\n",
-      "Without cache: \n",
-      "0.4407325991753527\n",
-      "0.007491470058587191\n"
+      "With cache: 7220 7220\n",
+      "Without cache: 1914 122\n"
      ]
     }
    ],
@@ -940,18 +918,16 @@
     "import random\n",
     "random.seed(1234)\n",
     "\n",
-    "OmegaConf.register_new_resolver(\"cached\", random.random)\n",
-    "OmegaConf.register_new_resolver(\"uncached\", random.random, use_cache=False)\n",
+    "OmegaConf.register_new_resolver(\"cached\", random.randint)\n",
+    "OmegaConf.register_new_resolver(\"uncached\", random.randint, use_cache=False)\n",
     "\n",
-    "cfg = OmegaConf.create({\"cached\": \"${cached:}\", \"uncached\": \"${uncached:}\"})\n",
+    "cfg = OmegaConf.create({\"cached\": \"${cached:0,10000}\", \"uncached\": \"${uncached:0,10000}\"})\n",
     "\n",
-    "print(\"With cache: \")\n",
-    "print(cfg.cached)\n",
-    "print(cfg.cached)  # same as above\n",
+    "# same value on repeated access thanks to the cache\n",
+    "print(\"With cache:\", cfg.cached, cfg.cached)\n",
     "\n",
-    "print(\"Without cache: \")\n",
-    "print(cfg.uncached)\n",
-    "print(cfg.uncached)  # *not* the same as above"
+    "# not the same since the cache is disabled\n",
+    "print(\"Without cache:\", cfg.uncached, cfg.uncached)"
    ]
   },
   {
@@ -1081,7 +1057,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.5"
   },
   "pycharm": {
    "stem_cell": {

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -354,8 +354,8 @@ Interpolated nodes can be any node in the config, not just leaf nodes:
     ...         "player": "${john}",
     ...     }
     ... )
-    >>> cfg.player
-    {'height': 180, 'weight': 75}
+    >>> (cfg.player.height, cfg.player.weight)
+    (180, 75)
 
 
 Environment variable interpolation


### PR DESCRIPTION
The main purpose is to get (almost) the same content in the docs and in the notebook.

There is also a minor change to the doc on node interpolation, to make
it clearer that we can use them as config objects (they are not plain
Python dictionaries).