### PR TITLE
Workaround for Dataframe object in the config: check whether value is string before mandatory missing check

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -328,10 +328,6 @@ def get_structured_config_data(
         raise ValueError(f"Unsupported type: {type(obj).__name__}")
 
 
-def is_mandatory_missing(value: Any) -> bool:
-    return isinstance(value, str) and value == "???"
-
-
 class ValueKind(Enum):
     VALUE = 0
     MANDATORY_MISSING = 1
@@ -357,7 +353,7 @@ def get_value_kind(
 
     value = _get_value(value)
 
-    if is_mandatory_missing(value):
+    if isinstance(value, str) and value == "???":
         return ValueKind.MANDATORY_MISSING
 
     # We identify potential interpolations by the presence of "${" in the string.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -353,6 +353,9 @@ def get_value_kind(
 
     value = _get_value(value)
 
+    if not isinstance(value, str):
+        return ValueKind.VALUE
+
     if value == "???":
         return ValueKind.MANDATORY_MISSING
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -328,6 +328,10 @@ def get_structured_config_data(
         raise ValueError(f"Unsupported type: {type(obj).__name__}")
 
 
+def is_mandatory_missing(value: Any) -> bool:
+    return isinstance(value, str) and value == "???"
+
+
 class ValueKind(Enum):
     VALUE = 0
     MANDATORY_MISSING = 1
@@ -353,7 +357,7 @@ def get_value_kind(
 
     value = _get_value(value)
 
-    if isinstance(value, str) and value == "???":
+    if is_mandatory_missing(value):
         return ValueKind.MANDATORY_MISSING
 
     # We identify potential interpolations by the presence of "${" in the string.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -353,10 +353,7 @@ def get_value_kind(
 
     value = _get_value(value)
 
-    if not isinstance(value, str):
-        return ValueKind.VALUE
-
-    if value == "???":
+    if isinstance(value, str) and value == "???":
         return ValueKind.MANDATORY_MISSING
 
     # We identify potential interpolations by the presence of "${" in the string.

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -9,17 +9,18 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import yaml
 
 from ._utils import (
+    ValueKind,
     _ensure_container,
     _get_value,
     _is_interpolation,
     _resolve_optional,
     get_ref_type,
     get_structured_config_data,
+    get_value_kind,
     get_yaml_loader,
     is_container_annotation,
     is_dict_annotation,
     is_list_annotation,
-    is_mandatory_missing,
     is_primitive_dict,
     is_primitive_type,
     is_structured_config,
@@ -48,6 +49,9 @@ class BaseContainer(Container, ABC):
         default_value: Any = DEFAULT_VALUE_MARKER,
     ) -> Any:
         """returns the value with the specified key, like obj.key and obj['key']"""
+
+        def is_mandatory_missing(val: Any) -> bool:
+            return bool(get_value_kind(val) == ValueKind.MANDATORY_MISSING)
 
         val = _get_value(value)
         has_default = default_value is not DEFAULT_VALUE_MARKER
@@ -780,7 +784,7 @@ def _create_structured_with_missing_fields(
 def _is_missing_value(value: Any) -> bool:
     if isinstance(value, Container):
         value = value._value()
-    ret = is_mandatory_missing(value)
+    ret = isinstance(value, str) and value == "???"
     assert isinstance(ret, bool)
     return ret
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -9,18 +9,17 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import yaml
 
 from ._utils import (
-    ValueKind,
     _ensure_container,
     _get_value,
     _is_interpolation,
     _resolve_optional,
     get_ref_type,
     get_structured_config_data,
-    get_value_kind,
     get_yaml_loader,
     is_container_annotation,
     is_dict_annotation,
     is_list_annotation,
+    is_mandatory_missing,
     is_primitive_dict,
     is_primitive_type,
     is_structured_config,
@@ -49,9 +48,6 @@ class BaseContainer(Container, ABC):
         default_value: Any = DEFAULT_VALUE_MARKER,
     ) -> Any:
         """returns the value with the specified key, like obj.key and obj['key']"""
-
-        def is_mandatory_missing(val: Any) -> bool:
-            return bool(get_value_kind(val) == ValueKind.MANDATORY_MISSING)
 
         val = _get_value(value)
         has_default = default_value is not DEFAULT_VALUE_MARKER
@@ -784,7 +780,7 @@ def _create_structured_with_missing_fields(
 def _is_missing_value(value: Any) -> bool:
     if isinstance(value, Container):
         value = value._value()
-    ret = isinstance(value, str) and value == "???"
+    ret = is_mandatory_missing(value)
     assert isinstance(ret, bool)
     return ret
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -784,7 +784,7 @@ def _create_structured_with_missing_fields(
 def _is_missing_value(value: Any) -> bool:
     if isinstance(value, Container):
         value = value._value()
-    ret = value == "???"
+    ret = value == "???" if isinstance(value, str) else False
     assert isinstance(ret, bool)
     return ret
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -784,7 +784,7 @@ def _create_structured_with_missing_fields(
 def _is_missing_value(value: Any) -> bool:
     if isinstance(value, Container):
         value = value._value()
-    ret = value == "???" if isinstance(value, str) else False
+    ret = isinstance(value, str) and value == "???"
     assert isinstance(ret, bool)
     return ret
 

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -26,7 +26,6 @@ from ._utils import (
     get_value_kind,
     is_container_annotation,
     is_dict,
-    is_mandatory_missing,
     is_primitive_dict,
     is_structured_config,
     is_structured_config_frozen,
@@ -171,7 +170,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         if vk == ValueKind.INTERPOLATION:
             return
         self._validate_non_optional(key, value)
-        if is_mandatory_missing(value) or value is None:
+        if (isinstance(value, str) and value == "???") or value is None:
             return
 
         target = self._get_node(key) if key is not None else self

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -170,7 +170,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         if vk == ValueKind.INTERPOLATION:
             return
         self._validate_non_optional(key, value)
-        if value == "???" or value is None:
+        if (isinstance(value, str) and value == "???") or value is None:
             return
 
         target = self._get_node(key) if key is not None else self

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -26,6 +26,7 @@ from ._utils import (
     get_value_kind,
     is_container_annotation,
     is_dict,
+    is_mandatory_missing,
     is_primitive_dict,
     is_structured_config,
     is_structured_config_frozen,
@@ -170,7 +171,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         if vk == ValueKind.INTERPOLATION:
             return
         self._validate_non_optional(key, value)
-        if (isinstance(value, str) and value == "???") or value is None:
+        if is_mandatory_missing(value) or value is None:
             return
 
         target = self._get_node(key) if key is not None else self

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -35,13 +35,17 @@ class NonCopyableIllegalType:
 
 
 class Dataframe:
+    """Emulates Pandas Dataframe equality and boolean behavior."""
+
     def __init__(self) -> None:
         pass
 
     def __eq__(self, other: Any) -> Any:
+        """Mimic pandas DataFrame __eq__, which returns a pandas DataFrame object"""
         return self
 
     def __bool__(self) -> None:
+        """Mimic pandas DataFrame __bool__, which raises a ValueError"""
         raise ValueError
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,6 +34,17 @@ class NonCopyableIllegalType:
         raise NotImplementedError()
 
 
+class Dataframe:
+    def __init__(self) -> None:
+        pass
+
+    def __eq__(self, other: Any) -> Any:
+        return self
+
+    def __bool__(self) -> None:
+        raise ValueError
+
+
 @contextmanager
 def does_not_raise(enter_result: Any = None) -> Iterator[Any]:
     yield enter_result

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -21,6 +21,7 @@ from tests import (
     C,
     ConcretePlugin,
     ConfWithMissingDict,
+    Dataframe,
     Group,
     IllegalType,
     InterpolationDict,
@@ -597,6 +598,14 @@ def test_merge_allow_objects(merge: Any) -> None:
     cfg._set_flag("allow_objects", True)
     ret = merge(cfg, {"foo": iv})
     assert ret == {"a": 10, "foo": iv}
+
+
+def test_merge_with_allow_Dataframe() -> None:
+    kwargs = OmegaConf.create({"a": Dataframe()}, flags={"allow_objects": True})
+    cfg = OmegaConf.create()
+
+    cfg.merge_with(kwargs)
+    assert isinstance(cfg.a, Dataframe)
 
 
 @pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -601,11 +601,9 @@ def test_merge_allow_objects(merge: Any) -> None:
 
 
 def test_merge_with_allow_Dataframe() -> None:
-    kwargs = OmegaConf.create({"a": Dataframe()}, flags={"allow_objects": True})
-    cfg = OmegaConf.create()
-
-    cfg.merge_with(kwargs)
-    assert isinstance(cfg.a, Dataframe)
+    cfg = OmegaConf.create({"a": Dataframe()}, flags={"allow_objects": True})
+    ret = OmegaConf.merge({}, cfg)
+    assert isinstance(ret.a, Dataframe)
 
 
 @pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -17,7 +17,7 @@ from omegaconf import (
     ValueNode,
 )
 from omegaconf.errors import UnsupportedValueType, ValidationError
-from tests import Color, Dataframe, IllegalType, User
+from tests import Color, IllegalType, User
 
 
 # testing valid conversions
@@ -559,10 +559,3 @@ def test_allow_objects() -> None:
     iv = IllegalType()
     c.foo = iv
     assert c.foo == iv
-
-
-def test_allow_Dataframe_objects() -> None:
-    c = OmegaConf.create()
-    c._set_flag("allow_objects", True)
-    c.a = Dataframe()
-    assert isinstance(c.a, Dataframe)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -17,7 +17,7 @@ from omegaconf import (
     ValueNode,
 )
 from omegaconf.errors import UnsupportedValueType, ValidationError
-from tests import Color, IllegalType, User
+from tests import Color, Dataframe, IllegalType, User
 
 
 # testing valid conversions
@@ -559,3 +559,10 @@ def test_allow_objects() -> None:
     iv = IllegalType()
     c.foo = iv
     assert c.foo == iv
+
+
+def test_allow_Dataframe_objects() -> None:
+    c = OmegaConf.create()
+    c._set_flag("allow_objects", True)
+    c.a = Dataframe()
+    assert isinstance(c.a, Dataframe)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,7 +23,15 @@ from omegaconf.nodes import (
     StringNode,
 )
 from omegaconf.omegaconf import _node_wrap
-from tests import Color, ConcretePlugin, IllegalType, Plugin, User, does_not_raise
+from tests import (
+    Color,
+    ConcretePlugin,
+    Dataframe,
+    IllegalType,
+    Plugin,
+    User,
+    does_not_raise,
+)
 
 
 @mark.parametrize(
@@ -255,6 +263,7 @@ class Dataclass:
         (False, _utils.ValueKind.VALUE),
         (Color.GREEN, _utils.ValueKind.VALUE),
         (Dataclass, _utils.ValueKind.VALUE),
+        (Dataframe(), _utils.ValueKind.VALUE),
         ("???", _utils.ValueKind.MANDATORY_MISSING),
         ("${foo.bar}", _utils.ValueKind.INTERPOLATION),
         ("ftp://${host}/path", _utils.ValueKind.INTERPOLATION),


### PR DESCRIPTION
Closes #566 

sidestep source of https://github.com/facebookresearch/hydra/issues/1285 at the omegaconf level