### PR TITLE
remove deprecated `exclude_structured_configs` option from `to_container`

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -580,7 +580,6 @@ class OmegaConf:
         resolve: bool = False,
         enum_to_str: bool = False,
         structured_config_mode: SCMode = SCMode.DICT,
-        exclude_structured_configs: Optional[bool] = None,
     ) -> Union[Dict[DictKeyType, Any], List[Any], None, str]:
         """
         Resursively converts an OmegaConf config to a primitive container (dict or list).
@@ -590,23 +589,8 @@ class OmegaConf:
         :param structured_config_mode: Specify how Structured Configs (DictConfigs backed by a dataclass) are handled.
             By default (`structured_config_mode=SCMode.DICT`) structured configs are converted to plain dicts.
             If `structured_config_mode=SCMode.DICT_CONFIG`, structured config nodes will remain as DictConfig.
-        :param exclude_structured_configs: (DEPRECATED) If true, do not convert structured configs.
-            Equivalent to `structured_config_mode=SCMode.DICT_CONFIG`.
         :return: A dict or a list representing this config as a primitive container.
         """
-        if exclude_structured_configs is not None:
-            warnings.warn(
-                dedent(
-                    """\
-                The exclude_structured_configs argument to to_container is deprecated.
-                See https://github.com/omry/omegaconf/issues/548 for migration instructions.
-                """
-                ),
-                UserWarning,
-                stacklevel=2,
-            )
-            if exclude_structured_configs is True:
-                structured_config_mode = SCMode.DICT_CONFIG
         if not OmegaConf.is_config(cfg):
             raise ValueError(
                 f"Input cfg is not an OmegaConf config object ({type_str(type(cfg))})"

--- a/tests/test_to_container.py
+++ b/tests/test_to_container.py
@@ -2,7 +2,7 @@ import re
 from enum import Enum
 from typing import Any, Dict, List
 
-from pytest import fixture, mark, param, raises, warns
+from pytest import fixture, mark, param, raises
 
 from omegaconf import DictConfig, ListConfig, OmegaConf, SCMode
 from tests import Color, User
@@ -76,20 +76,12 @@ class TestSCMode:
         assert ret == ex_dict
         assert isinstance(ret[key], dict)
 
-        with warns(UserWarning):
-            ret = OmegaConf.to_container(cfg, exclude_structured_configs=False)
-        assert ret == ex_dict
-
     def test_scmode_dict_config(
         self, cfg: Any, ex_dict: Any, ex_dict_config: Any, key: Any
     ) -> None:
         ret = OmegaConf.to_container(cfg, structured_config_mode=SCMode.DICT_CONFIG)
         assert ret == ex_dict_config
         assert isinstance(ret[key], DictConfig)
-
-        with warns(UserWarning):
-            ret = OmegaConf.to_container(cfg, exclude_structured_configs=True)
-        assert ret == ex_dict_config
 
 
 @mark.parametrize(


### PR DESCRIPTION
This PR removes the deprecated `exclude_structured_configs` option.

This is a follow-up to #552.
Closes #556.