### PR TITLE
refactor: clean up MISSING checks

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -334,6 +334,23 @@ class ValueKind(Enum):
     INTERPOLATION = 2
 
 
+def _is_missing_value(value: Any) -> bool:
+    from omegaconf import Node
+
+    if isinstance(value, Node):
+        value = value._value()
+    return _is_missing_literal(value)
+
+
+def _is_missing_literal(value: Any) -> bool:
+    from omegaconf import MISSING, Node
+
+    assert not isinstance(value, Node)
+    ret = isinstance(value, str) and value == MISSING
+    assert isinstance(ret, bool)
+    return ret
+
+
 def get_value_kind(
     value: Any, strict_interpolation_validation: bool = False
 ) -> ValueKind:
@@ -351,10 +368,10 @@ def get_value_kind(
         this parsing step is skipped: this is more efficient, but will not detect errors.
     """
 
-    value = _get_value(value)
-
-    if isinstance(value, str) and value == "???":
+    if _is_missing_value(value):
         return ValueKind.MANDATORY_MISSING
+
+    value = _get_value(value)
 
     # We identify potential interpolations by the presence of "${" in the string.
     # Note that escaped interpolations (ex: "esc: \${bar}") are identified as

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -7,7 +7,13 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 from antlr4 import ParserRuleContext
 
-from ._utils import ValueKind, _get_value, format_and_raise, get_value_kind
+from ._utils import (
+    ValueKind,
+    _get_value,
+    _is_missing_literal,
+    format_and_raise,
+    get_value_kind,
+)
 from .errors import (
     ConfigKeyError,
     InterpolationResolutionError,
@@ -207,7 +213,7 @@ class Node(ABC):
             # not interpolation, compare directly
             if throw_on_missing:
                 value = self._value()
-                if value == "???":
+                if _is_missing_literal(value):
                     raise MissingMandatoryValue("Missing mandatory value")
             return self
 

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -19,6 +19,7 @@ from ._utils import (
     ValueKind,
     _get_value,
     _is_interpolation,
+    _is_missing_value,
     _valid_dict_key_annotation_type,
     format_and_raise,
     get_structured_config_data,
@@ -170,7 +171,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         if vk == ValueKind.INTERPOLATION:
             return
         self._validate_non_optional(key, value)
-        if (isinstance(value, str) and value == "???") or value is None:
+        if vk is ValueKind.MANDATORY_MISSING or value is None:
             return
 
         target = self._get_node(key) if key is not None else self
@@ -605,7 +606,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
     def _set_value_impl(
         self, value: Any, flags: Optional[Dict[str, bool]] = None
     ) -> None:
-        from omegaconf import OmegaConf, flag_override
+        from omegaconf import MISSING, OmegaConf, flag_override
 
         if flags is None:
             flags = {}
@@ -619,8 +620,8 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         elif _is_interpolation(value, strict_interpolation_validation=True):
             self.__dict__["_content"] = value
             self._metadata.object_type = None
-        elif value == "???":
-            self.__dict__["_content"] = "???"
+        elif _is_missing_value(value):
+            self.__dict__["_content"] = MISSING
             self._metadata.object_type = None
         else:
             self.__dict__["_content"] = {}

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -171,7 +171,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         if vk == ValueKind.INTERPOLATION:
             return
         self._validate_non_optional(key, value)
-        if vk is ValueKind.MANDATORY_MISSING or value is None:
+        if vk == ValueKind.MANDATORY_MISSING or value is None:
             return
 
         target = self._get_node(key) if key is not None else self

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -565,7 +565,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
     def _set_value_impl(
         self, value: Any, flags: Optional[Dict[str, bool]] = None
     ) -> None:
-        from omegaconf import OmegaConf, flag_override
+        from omegaconf import MISSING, OmegaConf, flag_override
 
         if flags is None:
             flags = {}
@@ -578,7 +578,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                 )
             self.__dict__["_content"] = None
         elif vk is ValueKind.MANDATORY_MISSING:
-            self.__dict__["_content"] = "???"
+            self.__dict__["_content"] = MISSING
         elif vk == ValueKind.INTERPOLATION:
             self.__dict__["_content"] = value
         else:

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -116,9 +116,7 @@ class ValueNode(Node):
                 # Will happen if interpolation is accessing keys that does not exist.
                 return False
         else:
-            ret = _is_missing_literal(self._value())
-            assert isinstance(ret, bool)
-            return ret
+            return _is_missing_literal(self._value())
 
     def _is_interpolation(self) -> bool:
         return _is_interpolation(self._value())

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional, Type, Union
 from omegaconf._utils import (
     ValueKind,
     _is_interpolation,
+    _is_missing_literal,
     get_type_of,
     get_value_kind,
     is_primitive_container,
@@ -115,7 +116,7 @@ class ValueNode(Node):
                 # Will happen if interpolation is accessing keys that does not exist.
                 return False
         else:
-            ret = self._value() == "???"
+            ret = _is_missing_literal(self._value())
             assert isinstance(ret, bool)
             return ret
 

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional, Type, Union
 from omegaconf._utils import (
     ValueKind,
     _is_interpolation,
-    _is_missing_literal,
+    _is_missing_value,
     get_type_of,
     get_value_kind,
     is_primitive_container,
@@ -116,7 +116,7 @@ class ValueNode(Node):
                 # Will happen if interpolation is accessing keys that does not exist.
                 return False
         else:
-            return _is_missing_literal(self._value())
+            return _is_missing_value(self)
 
     def _is_interpolation(self) -> bool:
         return _is_interpolation(self._value())


### PR DESCRIPTION
This clears all literal "???" under the omegaconf module except the definition of MISSING.