### PR TITLE
Type validation of interpolations

### DIFF
--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -347,7 +347,7 @@ Interpolated values are validated, and converted when possible, to the annotated
     >>> cfg.int_key  # fails due to type mismatch
     Traceback (most recent call last):
       ...
-    omegaconf.errors.ValidationError: Value 'string' could not be converted to Integer
+    omegaconf.errors.InterpolationValidationError: Value 'string' could not be converted to Integer
         full_key: int_key
         object_type=Interpolation
     >>> cfg.str_key = "1234"  # string value

--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -309,7 +309,7 @@ Optional fields
 Interpolations
 ^^^^^^^^^^^^^^
 
-:ref:`interpolation` works normally with Structured configs but static type checkers may object to you assigning a string to an other types.
+:ref:`interpolation` works normally with Structured configs but static type checkers may object to you assigning a string to another type.
 To work around it, use SI and II described below.
 
 .. doctest::
@@ -333,18 +333,38 @@ To work around it, use SI and II described below.
     >>> assert conf.c == 100
 
 
-Type validation is performed on assignment, but not on values returned by interpolation, e.g:
+Interpolated values are validated, and converted when possible, to the annotated type when the interpolation is accessed, e.g:
 
 .. doctest::
 
-    >>> from omegaconf import SI
+    >>> from omegaconf import II
     >>> @dataclass
     ... class Interpolation:
-    ...     int_key: int = II("str_key")
     ...     str_key: str = "string"
+    ...     int_key: int = II("str_key")
 
     >>> cfg = OmegaConf.structured(Interpolation)
-    >>> assert cfg.int_key == "string"
+    >>> cfg.int_key  # fails due to type mismatch
+    Traceback (most recent call last):
+      ...
+    omegaconf.errors.ValidationError: Value 'string' could not be converted to Integer
+        full_key: int_key
+        object_type=Interpolation
+    >>> cfg.str_key = "1234"  # string value
+    >>> assert cfg.int_key == 1234  # automatically convert str to int
+
+Note however that this validation step is currently skipped for container node interpolations:
+
+.. doctest::
+
+    >>> @dataclass
+    ... class NotValidated:
+    ...     some_int: int = 0
+    ...     some_dict: Dict[str, str] = II("some_int")
+
+    >>> cfg = OmegaConf.structured(NotValidated)
+    >>> assert cfg.some_dict == 0  # type mismatch, but no error
+
 
 Frozen
 ^^^^^^

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -472,6 +472,19 @@ simply use quotes to bypass character limitations in strings.
     'Hello, World'
 
 
+Custom resolvers can return lists or dictionaries, that are automatically converted into DictConfig and ListConfig:
+
+.. doctest::
+
+    >>> OmegaConf.register_new_resolver(
+    ...     "min_max", lambda *a: {"min": min(a), "max": max(a)}
+    ... )
+    >>> c = OmegaConf.create({'stats': '${min_max: -1, 3, 2, 5, -10}'})
+    >>> assert isinstance(c.stats, DictConfig)
+    >>> c.stats.min, c.stats.max
+    (-10, 5)
+
+
 You can take advantage of nested interpolations to perform custom operations over variables:
 
 .. doctest::

--- a/news/488.api_change
+++ b/news/488.api_change
@@ -1,1 +1,1 @@
-If the value of a typed node is obtained from an interpolation, it is now validated (and possibly converted) based on the node's type.
+When resolving an interpolation of a typed config value, the interpolated value is validated and possibly converted based on the node's type.

--- a/news/488.api_change
+++ b/news/488.api_change
@@ -1,0 +1,1 @@
+If the value of a typed node is obtained from an interpolation, it is now validated (and possibly converted) based on the node's type.

--- a/news/540.api_change
+++ b/news/540.api_change
@@ -1,0 +1,1 @@
+A custom resolver interpolation whose output is a list or dictionary is now automatically converted into a ListConfig or DictConfig.

--- a/news/540.feature
+++ b/news/540.feature
@@ -1,0 +1,1 @@
+Custom resolvers can now generate transient config nodes dynamically.

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -461,7 +461,7 @@ class Container(Node):
         if must_wrap:
             assert parent is None or isinstance(parent, BaseContainer)
             try:
-                return _node_wrap(
+                wrapped = _node_wrap(
                     type_=value._metadata.ref_type,
                     parent=parent,
                     is_optional=value._metadata.optional,
@@ -478,6 +478,11 @@ class Container(Node):
                         type_override=InterpolationValidationError,
                     )
                 return None
+            # Since we created a new node on the fly, future changes to this node are
+            # likely to be lost. We thus set the "readonly" flag to `True` to reduce
+            # the risk of accidental modifications.
+            wrapped._set_flag("readonly", True)
+            return wrapped
         else:
             assert isinstance(resolved, Node)
             return resolved

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -444,10 +444,10 @@ class Container(Node):
                     self._format_and_raise(key=key, value=res_value, cause=e)
                 return None
 
-            # If the same object is returned, it means the value is already valid
-            # "as is", and we can thus use it directly. Otherwise, the converted
-            # value has to be wrapped into a node.
-            if conv_value is not res_value:
+            # If the converted value is of the same type, it means that no conversion
+            # was actually needed. As a result, we can keep the original `resolved`
+            # (and otherwise, the converted value must be wrapped into a new node).
+            if type(conv_value) != type(res_value):
                 must_wrap = True
                 resolved = conv_value
 

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -417,6 +417,34 @@ class Container(Node):
         parse_tree: OmegaConfGrammarParser.ConfigValueContext,
         throw_on_resolution_failure: bool,
     ) -> Optional["Node"]:
+        """
+        Resolve an interpolation.
+
+        This happens in two steps:
+            1. The parse tree is visited, which outputs either a `Node` (e.g.,
+               for node interpolations "${foo}"), a string (e.g., for string
+               interpolations "hello ${name}", or any other arbitrary value
+               (e.g., or custom interpolations "${foo:bar}").
+            2. This output is potentially validated and converted when the node
+               being resolved (`value`) is typed.
+
+        If an error occurs in one of the above steps, an `InterpolationResolutionError`
+        (or a subclass of it) is raised, *unless* `throw_on_resolution_failure` is set
+        to `False` (in which case the return value is `None`).
+
+        :param parent: Parent of the node being resolved.
+        :param value: Node being resolved.
+        :param key: The associated key in the parent.
+        :param parse_tree: The parse tree as obtained from `grammar_parser.parse()`.
+        :param throw_on_resolution_failure: If `False`, then exceptions raised during
+            the resolution of the interpolation are silenced, and instead `None` is
+            returned.
+
+        :return: A `Node` that contains the interpolation result. This may be an existing
+            node in the config (in the case of a node interpolation "${foo}"), or a new
+            node that is created to wrap the interpolated value. It is `None` if and only if
+            `throw_on_resolution_failure` is `False` and an error occurs during resolution.
+        """
         from .basecontainer import BaseContainer
         from .nodes import AnyNode, ValueNode
         from .omegaconf import _node_wrap

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -292,9 +292,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             return key  # type: ignore
         elif issubclass(key_type, Enum):
             try:
-                ret = EnumNode.validate_and_convert_to_enum(key_type, key)
-                assert ret is not None
-                return ret
+                return EnumNode.validate_and_convert_to_enum(key_type, key)
             except ValidationError:
                 valid = ", ".join([x for x in key_type.__members__.keys()])
                 raise KeyValidationError(

--- a/omegaconf/errors.py
+++ b/omegaconf/errors.py
@@ -81,7 +81,7 @@ class InterpolationToMissingValueError(InterpolationResolutionError):
     """
 
 
-class InterpolationValidationError(InterpolationResolutionError):
+class InterpolationValidationError(InterpolationResolutionError, ValidationError):
     """
     Thrown when the result of an interpolation fails the validation step.
     """

--- a/omegaconf/errors.py
+++ b/omegaconf/errors.py
@@ -81,6 +81,12 @@ class InterpolationToMissingValueError(InterpolationResolutionError):
     """
 
 
+class InterpolationValidationError(InterpolationResolutionError):
+    """
+    Thrown when the result of an interpolation fails the validation step.
+    """
+
+
 class ConfigKeyError(OmegaConfBaseException, KeyError):
     """
     Thrown from DictConfig when a regular dict access would have caused a KeyError.

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -39,7 +39,7 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
     def __init__(
         self,
         node_interpolation_callback: Callable[[str], Optional["Node"]],
-        resolver_interpolation_callback: Callable[..., Optional["Node"]],
+        resolver_interpolation_callback: Callable[..., Any],
         quoted_string_callback: Callable[[str], str],
         **kw: Dict[Any, Any],
     ):
@@ -96,9 +96,7 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
             )
             return child.symbol.text
 
-    def visitConfigValue(
-        self, ctx: OmegaConfGrammarParser.ConfigValueContext
-    ) -> Union[str, Optional["Node"]]:
+    def visitConfigValue(self, ctx: OmegaConfGrammarParser.ConfigValueContext) -> Any:
         # (toplevelStr | (toplevelStr? (interpolation toplevelStr?)+)) EOF
         # Visit all children (except last one which is EOF)
         vals = [self.visit(c) for c in list(ctx.getChildren())[:-1]]
@@ -106,12 +104,8 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         if len(vals) == 1 and isinstance(
             ctx.getChild(0), OmegaConfGrammarParser.InterpolationContext
         ):
-            from .base import Node  # noqa F811
-
-            # Single interpolation: return the resulting node "as is".
-            ret = vals[0]
-            assert ret is None or isinstance(ret, Node), ret
-            return ret
+            # Single interpolation: return the result "as is".
+            return vals[0]
         # Concatenation of multiple components.
         return "".join(map(str, vals))
 
@@ -135,13 +129,9 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
 
     def visitInterpolation(
         self, ctx: OmegaConfGrammarParser.InterpolationContext
-    ) -> Optional["Node"]:
-        from .base import Node  # noqa F811
-
+    ) -> Any:
         assert ctx.getChildCount() == 1  # interpolationNode | interpolationResolver
-        ret = self.visit(ctx.getChild(0))
-        assert ret is None or isinstance(ret, Node)
-        return ret
+        return self.visit(ctx.getChild(0))
 
     def visitInterpolationNode(
         self, ctx: OmegaConfGrammarParser.InterpolationNodeContext
@@ -168,7 +158,7 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
 
     def visitInterpolationResolver(
         self, ctx: OmegaConfGrammarParser.InterpolationResolverContext
-    ) -> Optional["Node"]:
+    ) -> Any:
 
         # INTER_OPEN resolverName COLON sequence? BRACE_CLOSE
         assert 4 <= ctx.getChildCount() <= 5

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -1,6 +1,7 @@
 import copy
 import math
 import sys
+from abc import abstractmethod
 from enum import Enum
 from typing import Any, Dict, Optional, Type, Union
 
@@ -55,8 +56,9 @@ class ValueNode(Node):
         # Subclasses can assume that `value` is not None in `_validate_and_convert_impl()`.
         return self._validate_and_convert_impl(value)
 
+    @abstractmethod
     def _validate_and_convert_impl(self, value: Any) -> Any:
-        return value
+        ...
 
     def __str__(self) -> str:
         return str(self._val)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,10 +20,16 @@ def restore_resolvers() -> Any:
 
 
 @pytest.fixture(scope="function")
-def register_identity(restore_resolvers: Any) -> Any:
+def common_resolvers(restore_resolvers: Any) -> Any:
     """
     A fixture to register the common `identity` resolver.
     It depends on `restore_resolvers` to make it easier and safer to use.
     """
+
+    def cast(t: Any, v: Any) -> Any:
+        return {"str": str, "int": int}[t](v)  # cast `v` to type `t`
+
+    OmegaConf.register_new_resolver("cast", cast)
     OmegaConf.register_new_resolver("identity", lambda x: x)
+
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 
+from omegaconf import OmegaConf
 from omegaconf.basecontainer import BaseContainer
 
 
@@ -16,3 +17,13 @@ def restore_resolvers() -> Any:
     state = copy.deepcopy(BaseContainer._resolvers)
     yield
     BaseContainer._resolvers = state
+
+
+@pytest.fixture(scope="function")
+def register_identity(restore_resolvers: Any) -> Any:
+    """
+    A fixture to register the common `identity` resolver.
+    It depends on `restore_resolvers` to make it easier and safer to use.
+    """
+    OmegaConf.register_new_resolver("identity", lambda x: x)
+    yield

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -5,6 +5,7 @@ import pytest
 from pytest import raises
 
 from omegaconf import (
+    AnyNode,
     Container,
     DictConfig,
     IntegerNode,
@@ -519,7 +520,7 @@ def test_resolve_str_interpolation(query: str, result: Any) -> None:
         cfg._maybe_resolve_interpolation(
             parent=None,
             key=None,
-            value=StringNode(value=query),
+            value=AnyNode(value=query),
             throw_on_resolution_failure=True,
         )
         == result

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -778,6 +778,8 @@ def test_none_value_in_quoted_string(restore_resolvers: Any) -> None:
             id="intermediate_type_mismatch_ok",
         ),
         pytest.param(
+            # This example relies on the automatic casting of a string to int when
+            # assigned to an IntegerNode.
             User(name="Bond", age=SI("${cast:str,'7'}")),
             "age",
             7,

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -872,8 +872,7 @@ def test_interpolation_type_validated_ok(
             "age",
             pytest.raises(
                 InterpolationValidationError,
-                match=re.escape("'Bond' could not be converted to Integer")
-                ),
+                match=re.escape("'Bond' could not be converted to Integer"),
             ),
             id="type_mismatch_node_interpolation",
         ),

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -471,7 +471,7 @@ def test_resolver_no_cache(restore_resolvers: Any) -> None:
     assert c.k != c.k
 
 
-def test_resolver_dot_start(register_identity: Any) -> None:
+def test_resolver_dot_start(common_resolvers: Any) -> None:
     """
     Regression test for #373
     """
@@ -482,7 +482,7 @@ def test_resolver_dot_start(register_identity: Any) -> None:
     assert c.foo_dot == ".bar"
 
 
-def test_resolver_dot_start_legacy(register_identity: Any) -> None:
+def test_resolver_dot_start_legacy(common_resolvers: Any) -> None:
     c = OmegaConf.create(
         {"foo_nodot": "${identity:bar}", "foo_dot": "${identity:.bar}"}
     )
@@ -821,7 +821,7 @@ def test_interpolation_type_validated_ok(
     key: str,
     expected_value: Any,
     expected_node_type: Any,
-    register_identity: Any,
+    common_resolvers: Any,
 ) -> Any:
     def cast(t: Any, v: Any) -> Any:
         return {"str": str, "int": int}[t](v)  # cast `v` to type `t`
@@ -829,7 +829,6 @@ def test_interpolation_type_validated_ok(
     def drop_last(s: str) -> str:
         return s[0:-1]  # drop last character from string `s`
 
-    OmegaConf.register_new_resolver("cast", cast)
     OmegaConf.register_new_resolver("drop_last", drop_last)
 
     cfg = OmegaConf.structured(cfg)
@@ -910,13 +909,8 @@ def test_interpolation_type_validated_error(
     cfg: Any,
     key: str,
     expected_error: Any,
-    register_identity: Any,
+    common_resolvers: Any,
 ) -> None:
-    def cast(t: Any, v: Any) -> Any:
-        return {"str": str, "int": int}[t](v)  # cast `v` to type `t`
-
-    OmegaConf.register_new_resolver("cast", cast)
-
     cfg = OmegaConf.structured(cfg)
 
     with expected_error:
@@ -939,7 +933,7 @@ def test_interpolation_type_validated_error(
     ],
 )
 def test_interpolation_readonly_resolver_output(
-    register_identity: Any, cfg: Any, key: str
+    common_resolvers: Any, cfg: Any, key: str
 ) -> None:
     cfg = OmegaConf.create(cfg)
     sub_key: Any

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -864,13 +864,7 @@ def test_interpolation_type_validated_ok(
             "age",
             pytest.raises(
                 InterpolationValidationError,
-                match=re.escape(
-                    dedent(
-                        """\
-                        Value 'Bond' could not be converted to Integer
-                            full_key: age
-                        """
-                    )
+                match=re.escape("'Bond' could not be converted to Integer")
                 ),
             ),
             id="type_mismatch_node_interpolation",

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -471,11 +471,10 @@ def test_resolver_no_cache(restore_resolvers: Any) -> None:
     assert c.k != c.k
 
 
-def test_resolver_dot_start(restore_resolvers: Any) -> None:
+def test_resolver_dot_start(register_identity: Any) -> None:
     """
     Regression test for #373
     """
-    OmegaConf.register_new_resolver("identity", lambda x: x)
     c = OmegaConf.create(
         {"foo_nodot": "${identity:bar}", "foo_dot": "${identity:.bar}"}
     )
@@ -483,8 +482,7 @@ def test_resolver_dot_start(restore_resolvers: Any) -> None:
     assert c.foo_dot == ".bar"
 
 
-def test_resolver_dot_start_legacy(restore_resolvers: Any) -> None:
-    OmegaConf.legacy_register_resolver("identity", lambda x: x)
+def test_resolver_dot_start_legacy(register_identity: Any) -> None:
     c = OmegaConf.create(
         {"foo_nodot": "${identity:bar}", "foo_dot": "${identity:.bar}"}
     )
@@ -821,7 +819,7 @@ def test_interpolation_type_validated_ok(
     key: str,
     expected_value: Any,
     expected_node_type: Any,
-    restore_resolvers: Any,
+    register_identity: Any,
 ) -> Any:
     def cast(t: Any, v: Any) -> Any:
         return {"str": str, "int": int}[t](v)  # cast `v` to type `t`
@@ -831,7 +829,6 @@ def test_interpolation_type_validated_ok(
 
     OmegaConf.register_new_resolver("cast", cast)
     OmegaConf.register_new_resolver("drop_last", drop_last)
-    OmegaConf.register_new_resolver("identity", lambda x: x)
 
     cfg = OmegaConf.structured(cfg)
 
@@ -911,13 +908,12 @@ def test_interpolation_type_validated_error(
     cfg: Any,
     key: str,
     expected_error: Any,
-    restore_resolvers: Any,
+    register_identity: Any,
 ) -> None:
     def cast(t: Any, v: Any) -> Any:
         return {"str": str, "int": int}[t](v)  # cast `v` to type `t`
 
     OmegaConf.register_new_resolver("cast", cast)
-    OmegaConf.register_new_resolver("identity", lambda x: x)
 
     cfg = OmegaConf.structured(cfg)
 
@@ -941,9 +937,8 @@ def test_interpolation_type_validated_error(
     ],
 )
 def test_interpolation_readonly_resolver_output(
-    restore_resolvers: Any, cfg: Any, key: str
+    register_identity: Any, cfg: Any, key: str
 ) -> None:
-    OmegaConf.register_new_resolver("identity", lambda x: x)
     cfg = OmegaConf.create(cfg)
     sub_key: Any
     parent_key, sub_key = key.rsplit(".", 1)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -830,9 +830,6 @@ def test_interpolation_type_validated_ok(
     expected_node_type: Any,
     common_resolvers: Any,
 ) -> Any:
-    def cast(t: Any, v: Any) -> Any:
-        return {"str": str, "int": int}[t](v)  # cast `v` to type `t`
-
     def drop_last(s: str) -> str:
         return s[0:-1]  # drop last character from string `s`
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -772,7 +772,7 @@ def test_none_value_in_quoted_string(restore_resolvers: Any) -> None:
         ),
         pytest.param(
             # This example specifically test the case where intermediate resolver results
-            # are not of the same type as the key.
+            # cannot be cast to the same type as the key.
             User(name="Bond", age=SI("${cast:int,${drop_last:${drop_last:7xx}}}")),
             "age",
             7,

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -27,7 +27,6 @@ from omegaconf.errors import (
     InterpolationResolutionError,
     InterpolationValidationError,
     OmegaConfBaseException,
-    ReadonlyConfigError,
     UnsupportedInterpolationType,
 )
 
@@ -943,8 +942,7 @@ def test_interpolation_readonly_resolver_output(
     except ValueError:
         pass
     parent_node = OmegaConf.select(cfg, parent_key)
-    with pytest.raises(ReadonlyConfigError):
-        parent_node[sub_key] = -1
+    assert parent_node._get_flag("readonly")
 
 
 def test_interpolation_readonly_node() -> None:
@@ -953,8 +951,7 @@ def test_interpolation_readonly_node() -> None:
     assert resolved == 7
     # The `resolved` node must be read-only because `age` is an integer, so the
     # interpolation cannot return directly the `name` node.
-    with pytest.raises(ReadonlyConfigError):
-        resolved._set_value(8)
+    assert resolved._get_flag("readonly")
 
 
 def test_type_validation_error_no_throw() -> None:

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -801,9 +801,9 @@ def test_none_value_in_quoted_string(restore_resolvers: Any) -> None:
             id="list_int_to_str",
         ),
         pytest.param(
-            MissingDict(dict=SI("${identity:{a: b, c: d}}")),
+            MissingDict(dict=SI("${identity:{key1: val1, key2: val2}}")),
             "dict",
-            {"a": "b", "c": "d"},
+            {"key1": "val1", "key2": "val2"},
             DictConfig,
             id="dict_str",
         ),

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -951,6 +951,8 @@ def test_interpolation_readonly_node() -> None:
     cfg = OmegaConf.structured(User(name="7", age=II("name")))
     resolved = cfg._get_node("age")._dereference_node()
     assert resolved == 7
+    # The `resolved` node must be read-only because `age` is an integer, so the
+    # interpolation cannot return directly the `name` node.
     with pytest.raises(ReadonlyConfigError):
         resolved._set_value(8)
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -977,7 +977,7 @@ def test_type_validation_error_no_throw() -> None:
         ({"a": "${..y}"}, {"a": -1}),
     ],
 )
-def test_resolver_output_dictconfig(
+def test_resolver_output_dict_to_dictconfig(
     restore_resolvers: Any, cfg: Dict[str, Any], expected: Dict[str, Any]
 ) -> None:
     OmegaConf.register_new_resolver("dict", lambda: cfg)
@@ -996,7 +996,7 @@ def test_resolver_output_dictconfig(
         (["${..y}"], [-1]),
     ],
 )
-def test_resolver_output_listconfig(
+def test_resolver_output_list_to_listconfig(
     restore_resolvers: Any, cfg: List[Any], expected: List[Any]
 ) -> None:
     OmegaConf.register_new_resolver("list", lambda: cfg)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -176,7 +176,7 @@ class TestNodeTypesMatrix:
     def test_interpolation(
         self, node_type: Any, values: Any, restore_resolvers: Any, register_func: Any
     ) -> None:
-        resolver_output = 9999
+        resolver_output = "9999"
         register_func("func", lambda: resolver_output)
         values = copy.deepcopy(values)
         for value in values:


### PR DESCRIPTION
Validate and convert interpolation results to their intended type

This PR fixes several issues:

* For nested resolvers (ex: `${f:${g:x}}`), intermediate resolver
  outputs (of `g` in this example) were wrapped in a ValueNode just to
  be unwrapped immediately, which was wasteful. This commit pushes the
  node wrapping to the very last step of the interpolation resolution.

* There was no type checking to make sure that the result of an
  interpolation had a type consistent with the node's type (when
  specified). Now a check is made and the interpolation result may be
  converted into the desired type (see #488).

* If a resolver interpolation returns a dict / list, it is now wrapped
  into a DictConfig / ListConfig, instead of a ValueNode. This makes it
  possible to generate configs from resolvers (see #540). These configs
  are read-only since they are being re-generated on each access.


Fixes #488
Fixes #540