### PR TITLE
Fields annotated as Dict now has their struct flag set to False by default

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,.nox,.tox,omegaconf/grammar/gen
+exclude = .git,.nox,.tox,omegaconf/grammar/gen, build
 max-line-length = 119
 select = E,F,W,C
 ignore=W503,E203

--- a/news/461.bugfix
+++ b/news/461.bugfix
@@ -1,1 +1,1 @@
-Dict fields and subclasses are now open to new keys even if the there is a parent node in struct mode.
+Dict fields and subclasses are now open to new keys even if there is a parent node in struct mode.

--- a/news/461.bugfix
+++ b/news/461.bugfix
@@ -1,0 +1,1 @@
+Dict fields and subclasses are now open to new keys even if the there is a parent node in struct mode.

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -631,6 +631,10 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
                     value,
                     allow_objects=self._get_flag("allow_objects"),
                 )
+                # Structured Configs that are a subclass of Dict gets their struct flag set to False by default.
+                if is_dict(get_type_of(value)):
+                    self._set_flag("struct", False)
+
                 for k, v in data.items():
                     self.__setitem__(k, v)
                 self._metadata.object_type = get_type_of(value)

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -631,7 +631,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
                     value,
                     allow_objects=self._get_flag("allow_objects"),
                 )
-                # Structured Configs that are a subclass of Dict gets their struct flag set to False by default.
+                # Structured Configs that are a subclass of Dict get their struct flag set to False by default.
                 if is_dict(get_type_of(value)):
                     self._set_flag("struct", False)
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -906,6 +906,9 @@ def _node_wrap(
     )
     if is_dict:
         key_type, element_type = get_dict_key_value_types(type_)
+        flags = {}
+        if is_dict_annotation(type_):
+            flags["struct"] = False
         node = DictConfig(
             content=value,
             key=key,
@@ -914,6 +917,7 @@ def _node_wrap(
             is_optional=is_optional,
             key_type=key_type,
             element_type=element_type,
+            flags=flags,
         )
     elif is_list:
         element_type = get_list_element_type(type_)

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -746,6 +746,22 @@ class TestConfigs:
         with raises(ValidationError):
             dct.fail = "fail"
 
+    def test_dict_is_open_even_with_parent_in_struct_mode(self, module: Any) -> Any:
+        cfg = OmegaConf.structured({"a": module.DictExamples})
+        OmegaConf.set_struct(cfg, True)
+        assert not OmegaConf.is_struct(cfg.a.any)
+        cfg.a.any["foo"] = "bar"
+        assert cfg.a.any["foo"] == "bar"
+
+    def test_dict_subclass_is_open_even_with_parent_in_struct_mode(
+        self, module: Any
+    ) -> Any:
+        cfg = OmegaConf.structured({"a": module.DictSubclass.Str2Str})
+        OmegaConf.set_struct(cfg, True)
+        assert not OmegaConf.is_struct(cfg.a)
+        cfg.a["foo"] = "bar"
+        assert cfg.a["foo"] == "bar"
+
     def test_list_of_objects(self, module: Any) -> None:
         conf = OmegaConf.structured(module.ListOfObjects)
         assert conf.users[0].age == 18


### PR DESCRIPTION
close #461

The expectation of a Structured Config with a Dict field is that the dict field is free to accept new keys:
```python
@dataclass
class Foo:
  bar: Dict[str, str]
```

This expectation is violated if the Structured Config has a parent in struct mode.
```python
cfg = OmegaConf.create({"foo" : Foo})
OmegaConf.set_struct(cfg, True)  # setting struct flag on the parent.
cfg.foo.bar["a"] = 10 # this will fail now.
```

This PR is fixing the issue by explicitly setting DictConfig typed as Dict[K, V] to have a struct flag set to False.
There could be some side effects to this (this will open up any non DictConfig children (not structured configs) of the dict), but that seems pretty unlikely to cause a real issue in practice.

This is a potential use case for non recursive config flags, but for now I am parking that idea and will revisit if there is better use case.