### PR TITLE
Introduced flags_root as an internal concept

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -277,7 +277,9 @@ class Node(ABC):
         return self._metadata.flags_root
 
     def _set_flags_root(self, flags_root: bool) -> None:
-        self._metadata.flags_root = flags_root
+        if self._metadata.flags_root != flags_root:
+            self._metadata.flags_root = flags_root
+            self._invalidate_flags_cache()
 
 
 class Container(Node):

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -49,6 +49,11 @@ class Metadata:
     #   set to true: flag is true
     #   set to false: flag is false
     flags: Optional[Dict[str, bool]] = None
+
+    # If True, when checking the value of a flag, if the flag is not set None is returned
+    # otherwise, the parent node is queried.
+    flags_root: bool = False
+
     resolver_cache: Dict[str, Any] = field(default_factory=lambda: defaultdict(dict))
 
     def __post_init__(self) -> None:
@@ -167,6 +172,9 @@ class Node(ABC):
         if flag in flags and flags[flag] is not None:
             return flags[flag]
 
+        if self._is_flags_root():
+            return None
+
         parent = self._get_parent()
         if parent is None:
             return None
@@ -264,6 +272,12 @@ class Node(ABC):
 
     def _set_key(self, key: Any) -> None:
         self._metadata.key = key
+
+    def _is_flags_root(self) -> bool:
+        return self._metadata.flags_root
+
+    def _set_flags_root(self, flags_root: bool) -> None:
+        self._metadata.flags_root = flags_root
 
 
 class Container(Node):

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -572,3 +572,12 @@ def test_string_interpolation_with_readonly_parent(cfg: Any, key: Any) -> None:
     cfg = OmegaConf.create(cfg)
     with pytest.raises(MissingMandatoryValue, match="Missing mandatory value"):
         cfg._get_node(key, throw_on_missing_value=True)
+
+
+def test_flags_root() -> None:
+    cfg = OmegaConf.create({"a": {"b": 10}})
+    cfg._set_flag("flag", True)
+    assert cfg.a._get_flag_no_cache("flag") is True
+
+    cfg.a._set_flags_root(True)
+    assert cfg.a._get_flag_no_cache("flag") is None


### PR DESCRIPTION
config flags are currently defined as:

> the value of a config flag is the value set on a node, 
> or the value from the parent node (if there is a parent), otherwise None.

This diff changes the definition to:

> the value of a config flag is the value set on a node, or None if the node is a flags root.
> otherwise, the value from the parent node (if there is a parent), otherwise None.

This means we can now indicate that flag access will not query the parent node for chosen nodes.
For now I am keeping it as an internal API to be used by Hydra config composition:
the hydra node itself is a flags root, meaning it will not be affected by flags set on the user config root.