### PR TITLE
Minor simplification in `_get_node_flag()`

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -146,7 +146,7 @@ class Node(ABC):
         :return: the state of the flag on this node.
         """
         assert self._metadata.flags is not None
-        return self._metadata.flags[flag] if flag in self._metadata.flags else None
+        return self._metadata.flags.get(flag)
 
     def _get_flag(self, flag: str) -> Optional[bool]:
         cache = self.__dict__["_flags_cache"]


### PR DESCRIPTION
This is more readable and avoids accessing the dictionary twice