### PR TITLE
Grammar support for interpolations like ${.}. ${..} etc.

### DIFF
--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -41,7 +41,7 @@ sequence: (element (COMMA element?)*) | (COMMA element?)+;
 // Interpolations.
 
 interpolation: interpolationNode | interpolationResolver;
-interpolationNode: INTER_OPEN DOT* configKey (DOT configKey)* INTER_CLOSE;
+interpolationNode: INTER_OPEN DOT* (configKey (DOT configKey)*)? INTER_CLOSE;
 interpolationResolver: INTER_OPEN resolverName COLON sequence? BRACE_CLOSE;
 configKey: interpolation | ID | INTER_KEY;
 resolverName: (interpolation | ID) (DOT (interpolation | ID))* ;  // oc.env, myfunc, ns.${x}, ns1.ns2.f

--- a/omegaconf/grammar_parser.py
+++ b/omegaconf/grammar_parser.py
@@ -19,7 +19,7 @@ _grammar_cache = None
 # Build regex pattern to efficiently identify typical interpolations.
 # See test `test_match_simple_interpolation_pattern` for examples.
 _id = "[a-zA-Z_]\\w*"  # foo, foo_bar, abc123
-_dot_path = f"{_id}(\\.{_id})*"  # foo, foo.bar3, foo_.b4r.b0z
+_dot_path = f"(\\.)*({_id}(\\.{_id})*)?"  # foo, foo.bar3, foo_.b4r.b0z
 _inter_node = f"\\${{\\s*{_dot_path}\\s*}}"  # node interpolation
 _arg = "[a-zA-Z_0-9/\\-\\+.$%*@]+"  # string representing a resolver argument
 _args = f"{_arg}(\\s*,\\s*{_arg})*"  # list of resolver arguments

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -146,8 +146,8 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
     def visitInterpolationNode(
         self, ctx: OmegaConfGrammarParser.InterpolationNodeContext
     ) -> Optional["Node"]:
-        # INTER_OPEN DOT* configKey (DOT configKey)* INTER_CLOSE
-        assert ctx.getChildCount() >= 3
+        # INTER_OPEN DOT* (configKey (DOT configKey)*)? INTER_CLOSE
+        assert ctx.getChildCount() >= 2
 
         inter_key_tokens = []  # parsed elements of the dot path
         for child in ctx.getChildren():

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -545,3 +545,11 @@ def test_match_simple_interpolation_pattern(expression: str) -> None:
 )
 def test_do_not_match_simple_interpolation_pattern(expression: str) -> None:
     assert grammar_parser.SIMPLE_INTERPOLATION_PATTERN.match(expression) is None
+
+
+def test_empty_stack() -> None:
+    """
+    Check that an empty stack during ANTLR parsing raises a `GrammarParseError`.
+    """
+    with raises(GrammarParseError):
+        grammar_parser.parse("ab}", lexer_mode="VALUE_MODE")

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -524,6 +524,11 @@ class TestOmegaConfGrammar:
         "${foo:bar,0,a-b+c*d/$.%@}",
         "\\${foo}",
         "${foo.bar:boz}",
+        # relative interpolations
+        "${.}",
+        "${..}",
+        "${..foo}",
+        "${..foo.bar}",
     ],
 )
 def test_match_simple_interpolation_pattern(expression: str) -> None:

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -529,6 +529,8 @@ class TestOmegaConfGrammar:
         "${..}",
         "${..foo}",
         "${..foo.bar}",
+        # config root
+        "${}",
     ],
 )
 def test_match_simple_interpolation_pattern(expression: str) -> None:
@@ -564,6 +566,13 @@ def test_empty_stack() -> None:
 @mark.parametrize(
     ("inter", "key", "expected"),
     [
+        # config root
+        param(
+            "${}",
+            "",
+            {"dict": {"bar": 20}, "list": [1, 2]},
+            id="absolute_config_root",
+        ),
         # simple
         param("${dict.bar}", "", 20, id="dict_value"),
         param("${dict}", "", {"bar": 20}, id="dict_node"),

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -15,7 +15,6 @@ from omegaconf import (
     OmegaConf,
     Resolver,
     ValidationError,
-    grammar_parser,
 )
 from omegaconf._utils import _ensure_container
 from omegaconf.errors import (
@@ -711,14 +710,6 @@ def test_optional_after_interpolation() -> None:
     # Ensure that we can set an optional field to `None` even when it currently
     # points to a non-optional field.
     cfg.opt_num = None
-
-
-def test_empty_stack() -> None:
-    """
-    Check that an empty stack during ANTLR parsing raises a `GrammarParseError`.
-    """
-    with pytest.raises(GrammarParseError):
-        grammar_parser.parse("ab}", lexer_mode="VALUE_MODE")
 
 
 @pytest.mark.parametrize("ref", ["missing", "invalid"])


### PR DESCRIPTION
This enables implementing a form of select with a default value:
Side note, we should rethink support for passing the parent node automatically on demand (`${.}`), it will simplify this use case.
```python
from typing import Any

from omegaconf import OmegaConf
from omegaconf.omegaconf import _EMPTY_MARKER_

yaml = """\
a: 10
no_default: ${oc.select:${.}, a}
not_using_default: ${oc.select:${.}, a, 20}
using_default: ${oc.select:${.}, not_there, 20}
"""


def oc_select(node: Any, key: str, default: Any = _EMPTY_MARKER_):
    if default is _EMPTY_MARKER_:
        return OmegaConf.select(node, key)
    else:
        return OmegaConf.select(node, key, default=default)


OmegaConf.register_new_resolver("oc.select", oc_select)

cfg = OmegaConf.create(yaml)
assert cfg.a == 10
assert cfg.no_default == 10
assert cfg.not_using_default == 10
assert cfg.using_default == 20
```

Notes:
1. I did not like the complexity of the testing in test_grammar.py. seems like a new testing framework instead of a test designed to test some logic.
I created a simpler more localized test for interpolations. happy to discuss.

2. while it's not very big, it can be easier to review one commit at a time.