### PR TITLE
Avoid infinite loop in `_get_full_key()`

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -615,7 +615,7 @@ def format_and_raise(
         except Exception as exc:
             # Since we are handling an exception, raising a different one here would
             # be misleading. Instead, we display it in the key.
-            full_key = f"<unresolvable due to {type(exc).__name__}: {exc}"
+            full_key = f"<unresolvable due to {type(exc).__name__}: {exc}>"
 
         object_type = OmegaConf.get_type(node)
         object_type_str = type_str(object_type)

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -610,7 +610,12 @@ def format_and_raise(
         if key is not None and not node._is_none():
             child_node = node._get_node(key, validate_access=False)
 
-        full_key = node._get_full_key(key=key)
+        try:
+            full_key = node._get_full_key(key=key)
+        except Exception as exc:
+            # Since we are handling an exception, raising a different one here would
+            # be misleading. Instead, we display it in the key.
+            full_key = f"<unresolvable due to {type(exc).__name__}: {exc}"
 
         object_type = OmegaConf.get_type(node)
         object_type_str = type_str(object_type)

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -28,8 +28,8 @@ from ._utils import (
 )
 from .base import Container, ContainerMetadata, DictKeyType, Node, SCMode
 from .errors import (
+    ConfigCycleDetectedException,
     MissingMandatoryValue,
-    OmegaConfBaseException,
     ReadonlyConfigError,
     ValidationError,
 )
@@ -732,7 +732,7 @@ class BaseContainer(Container, ABC):
         while cur._get_parent() is not None:
             cur = cur._get_parent()
             if id(cur) in memo:
-                raise OmegaConfBaseException(
+                raise ConfigCycleDetectedException(
                     f"Cycle when iterating over parents of key `{key}`"
                 )
             memo.add(id(cur))

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -27,7 +27,12 @@ from ._utils import (
     is_structured_config,
 )
 from .base import Container, ContainerMetadata, DictKeyType, Node, SCMode
-from .errors import MissingMandatoryValue, ReadonlyConfigError, ValidationError
+from .errors import (
+    MissingMandatoryValue,
+    OmegaConfBaseException,
+    ReadonlyConfigError,
+    ValidationError,
+)
 
 if TYPE_CHECKING:
     from .dictconfig import DictConfig  # pragma: no cover
@@ -723,11 +728,16 @@ class BaseContainer(Container, ABC):
             full_key = self._key()
 
         assert cur is not None
+        memo = {id(cur)}  # remember already visited nodes so as to detect cycles
         while cur._get_parent() is not None:
             cur = cur._get_parent()
+            if id(cur) in memo:
+                raise OmegaConfBaseException(
+                    f"Cycle when iterating over parents of key `{key}`"
+                )
+            memo.add(id(cur))
             assert cur is not None
-            key = cur._key()
-            if key is not None:
+            if cur._key() is not None:
                 full_key = prepand(
                     full_key, type(cur._get_parent()), type(cur), cur._key()
                 )

--- a/omegaconf/errors.py
+++ b/omegaconf/errors.py
@@ -129,6 +129,12 @@ class ConfigValueError(OmegaConfBaseException, ValueError):
     """
 
 
+class ConfigCycleDetectedException(OmegaConfBaseException):
+    """
+    Thrown when a cycle is detected in the graph made by config nodes.
+    """
+
+
 class GrammarParseError(OmegaConfBaseException):
     """
     Thrown when failing to parse an expression according to the ANTLR grammar.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent
@@ -1356,15 +1357,21 @@ def test_get_full_key_failure_in_format_and_raise() -> None:
     # raised even if another exception occurs in `format_and_raise()` when trying to
     # obtain the full key.
     c._set_parent(x_node)
-    with pytest.raises(
-        RecursionError,
-        match=re.escape(
+
+    # For some reason in Python 3.6 the error message may vary depending on how this
+    # test is run (`nox -s coverage-3.6` vs `nox -s omegaconf-3.6`). As a result, we
+    # do not check the message.
+    if sys.version_info < (3, 7):
+        match = ""
+    else:
+        match = re.escape(
             dedent(
                 """\
                 maximum recursion depth exceeded in comparison
                     full_key: <unresolvable due to OmegaConfBaseException: Cycle when iterating over parents of key `x`
                 """
             )
-        ),
-    ):
+        )
+
+    with pytest.raises(RecursionError, match=match):
         c.x

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1362,7 +1362,7 @@ def test_get_full_key_failure_in_format_and_raise() -> None:
     # message (which we have control on).
     match = re.escape(
         "full_key: <unresolvable due to OmegaConfBaseException: "
-        "Cycle when iterating over parents of key `x`"
+        "Cycle when iterating over parents of key `x`>"
     )
 
     with pytest.raises(RecursionError, match=match):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,4 @@
 import re
-import sys
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent
@@ -1358,20 +1357,13 @@ def test_get_full_key_failure_in_format_and_raise() -> None:
     # obtain the full key.
     c._set_parent(x_node)
 
-    # For some reason in Python 3.6 the error message may vary depending on how this
-    # test is run (`nox -s coverage-3.6` vs `nox -s omegaconf-3.6`). As a result, we
-    # do not check the message.
-    if sys.version_info < (3, 7):
-        match = ""
-    else:
-        match = re.escape(
-            dedent(
-                """\
-                maximum recursion depth exceeded in comparison
-                    full_key: <unresolvable due to OmegaConfBaseException: Cycle when iterating over parents of key `x`
-                """
-            )
-        )
+    # The exception message may vary depending on the Python version and seemingly
+    # irrelevant code changes. As a result, we only test the "full_key" part of the
+    # message (which we have control on).
+    match = re.escape(
+        "full_key: <unresolvable due to OmegaConfBaseException: "
+        "Cycle when iterating over parents of key `x`"
+    )
 
     with pytest.raises(RecursionError, match=match):
         c.x

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1361,7 +1361,7 @@ def test_get_full_key_failure_in_format_and_raise() -> None:
     # irrelevant code changes. As a result, we only test the "full_key" part of the
     # message (which we have control on).
     match = re.escape(
-        "full_key: <unresolvable due to OmegaConfBaseException: "
+        "full_key: <unresolvable due to ConfigCycleDetectedException: "
         "Cycle when iterating over parents of key `x`>"
     )
 


### PR DESCRIPTION
When there was a cycle when iterating over parents of a node,
`_get_full_key()` would get into an infinite loop.

This commit detects this situation to raise an explicit exception
instead.

In addition, `format_and_raise()` is modified to *not* raise exceptions
when trying to obtain the full key, so as to avoid hiding the original
exception with a different error. Instead, any exception raised when
trying to obtain the full key is displayed on the "full key" line of the
error message.