### PR TITLE
Change exception type when dereferencing a node without a parent

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -23,7 +23,6 @@ from .errors import (
     InterpolationValidationError,
     KeyValidationError,
     MissingMandatoryValue,
-    OmegaConfBaseException,
     UnsupportedInterpolationType,
     ValidationError,
 )
@@ -211,7 +210,7 @@ class Node(ABC):
 
         parent = self._get_parent()
         if parent is None:
-            raise OmegaConfBaseException(
+            raise InterpolationResolutionError(
                 "Cannot resolve interpolation for a node without a parent"
             )
         assert parent is not None

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -25,7 +25,6 @@ from omegaconf.errors import (
     InterpolationKeyError,
     InterpolationResolutionError,
     InterpolationValidationError,
-    OmegaConfBaseException,
     UnsupportedInterpolationType,
 )
 
@@ -711,7 +710,10 @@ def test_interpolation_after_copy(copy_func: Any, data: Any, key: Any) -> None:
 
 
 def test_resolve_interpolation_without_parent() -> None:
-    with pytest.raises(OmegaConfBaseException):
+    with pytest.raises(
+        InterpolationResolutionError,
+        match=re.escape("Cannot resolve interpolation for a node without a parent"),
+    ):
         DictConfig(content="${foo}")._dereference_node()
 
 


### PR DESCRIPTION
It is now an `InterpolationResolutionError` instead of an
`OmegaConfBaseException` (which is not supposed to be raised directly).