### PR TITLE
Introduce new `oc.env` and `oc.decode` resolvers

### DIFF
--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -710,8 +710,7 @@
    "source": [
     "# Let's set up the environment first (only needed for this demonstration)\n",
     "import os\n",
-    "os.environ['USER'] = 'omry'\n",
-    "os.environ['USERID'] = '123456'"
+    "os.environ['USER'] = 'omry'"
    ]
   },
   {
@@ -737,7 +736,6 @@
       "user:\n",
       "  name: ${oc.env:USER}\n",
       "  home: /home/${oc.env:USER}\n",
-      "  id: ${oc.env:USERID}\n",
       "\n"
      ]
     }
@@ -763,7 +761,6 @@
       "user:\n",
       "  name: omry\n",
       "  home: /home/omry\n",
-      "  id: '123456'\n",
       "\n"
      ]
     }

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -775,9 +775,9 @@
    "metadata": {},
    "source": [
     "You can specify a default value to use in case the environment variable is not defined.\n",
-    "This default value must be a string (with the exception of `${oc.env:VAR,null}` that returns `None` if `VAR` is not defined).\n",
+    "This default value can be a string or ``null`` (representing Python ``None``). Passing a default with a different type will result in an error.\n",
     "\n",
-    "The following example sets `abc123` as the the default value when `DB_PASSWORD` is not defined:"
+    "The following example sets default database passwords when ``DB_PASSWORD`` is not defined:"
    ]
   },
   {
@@ -786,20 +786,26 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'abc123'"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'abc123'\n",
+      "'12345'\n"
+     ]
     }
    ],
    "source": [
     "os.environ.pop('DB_PASSWORD', None)  # ensure env variable does not exist\n",
-    "cfg = OmegaConf.create({'database': {'password': '${oc.env:DB_PASSWORD,abc123}'}})\n",
-    "cfg.database.password"
+    "cfg = OmegaConf.create(\n",
+    "    {\n",
+    "        \"database\": {\n",
+    "            \"password1\": \"${oc.env:DB_PASSWORD,abc123}\",  # the string 'abc123'\n",
+    "            \"password2\": \"${oc.env:DB_PASSWORD,'12345'}\",  # the string '12345'\n",
+    "        },\n",
+    "    }\n",
+    ")\n",
+    "print(repr(cfg.database.password1))\n",
+    "print(repr(cfg.database.password2))"
    ]
   },
   {

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -698,7 +698,8 @@
    "source": [
     "## Environment variable interpolation\n",
     "\n",
-    "Environment variable interpolation is also supported."
+    "Environment variable interpolation is also supported.\n",
+    "An environment variable is always returned as a string."
    ]
   },
   {
@@ -709,14 +710,15 @@
    "source": [
     "# Let's set up the environment first (only needed for this demonstration)\n",
     "import os\n",
-    "os.environ['USER'] = 'omry'"
+    "os.environ['USER'] = 'omry'\n",
+    "os.environ['USERID'] = '123456'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is an example config file interpolates with the USER environment variable:"
+    "Here is an example config file interpolating with the USER and USERID environment variables:"
    ]
   },
   {
@@ -733,8 +735,9 @@
      "output_type": "stream",
      "text": [
       "user:\n",
-      "  name: ${env:USER}\n",
-      "  home: /home/${env:USER}\n",
+      "  name: ${oc.env:USER}\n",
+      "  home: /home/${oc.env:USER}\n",
+      "  id: ${oc.env:USERID}\n",
       "\n"
      ]
     }
@@ -760,6 +763,7 @@
       "user:\n",
       "  name: omry\n",
       "  home: /home/omry\n",
+      "  id: '123456'\n",
       "\n"
      ]
     }
@@ -773,7 +777,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can specify a default value to use in case the environment variable is not defined. The following example sets `abc123` as the the default value when `DB_PASSWORD` is not defined."
+    "You can specify a default value to use in case the environment variable is not defined.\n",
+    "This default value must be a string (with the exception of `${oc.env:VAR,null}` that returns `None` if `VAR` is not defined).\n",
+    "\n",
+    "The following example sets `abc123` as the the default value when `DB_PASSWORD` is not defined:"
    ]
   },
   {
@@ -794,7 +801,7 @@
    ],
    "source": [
     "os.environ.pop('DB_PASSWORD', None)  # ensure env variable does not exist\n",
-    "cfg = OmegaConf.create({'database': {'password': '${env:DB_PASSWORD,abc123}'}})\n",
+    "cfg = OmegaConf.create({'database': {'password': '${oc.env:DB_PASSWORD,abc123}'}})\n",
     "cfg.database.password"
    ]
   },
@@ -802,7 +809,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Environment variables are parsed when they are recognized as valid quantities that may be evaluated (e.g., int, float, dict, list):"
+    "## Decoding strings with interpolations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can automatically convert a string to its corresponding type (e.g., bool, int, float, dict, list) using `oc.decode`.\n",
+    "This resolver also accepts ``None`` as input, in which case it returns ``None``.\n",
+    "\n",
+    "This can be useful for instance to parse environment variables:"
    ]
   },
   {
@@ -814,25 +831,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3308\n",
-      "['host1', 'host2', 'host3']\n",
-      "'a%#@~{}$*&^?/<'\n"
+      "port (int): 3308\n",
+      "nodes (list): ['host1', 'host2', 'host3']\n",
+      "nodes (None due to missing variable): None\n"
      ]
     }
    ],
    "source": [
-    "cfg = OmegaConf.create({'database': {'password': '${env:DB_PASSWORD,abc123}',\n",
-    "                                    'user': 'someuser',\n",
-    "                                    'port': '${env:DB_PORT,3306}',\n",
-    "                                    'nodes': '${env:DB_NODES,[]}'}})\n",
+    "cfg = OmegaConf.create(\n",
+    "    {\n",
+    "        \"database\": {\n",
+    "            \"port\": '${oc.decode:${oc.env:DB_PORT}}',\n",
+    "            \"nodes\": '${oc.decode:${oc.env:DB_NODES,null}}',\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
     "\n",
-    "os.environ[\"DB_PORT\"] = '3308'  # integer\n",
-    "os.environ[\"DB_NODES\"] = '[host1, host2, host3]'  # list\n",
-    "os.environ[\"DB_PASSWORD\"] = 'a%#@~{}$*&^?/<'  # string\n",
+    "os.environ[\"DB_PORT\"] = \"3308\"  # integer\n",
+    "os.environ[\"DB_NODES\"] = \"[host1, host2, host3]\"  # list\n",
     "\n",
-    "print(repr(cfg.database.port))\n",
-    "print(repr(cfg.database.nodes))\n",
-    "print(repr(cfg.database.password))"
+    "print(\"port (int):\", repr(cfg.database.port))\n",
+    "print(\"nodes (list):\", repr(cfg.database.nodes))\n",
+    "\n",
+    "del os.environ[\"DB_NODES\"]\n",
+    "print(\"nodes (None due to missing variable):\", repr(cfg.database.nodes))"
    ]
   },
   {

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -717,7 +717,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is an example config file interpolating with the USER and USERID environment variables:"
+    "Here is an example config file interpolates with the USER environment variable:"
    ]
   },
   {

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -816,7 +816,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can automatically convert a string to its corresponding type (e.g., bool, int, float, dict, list) using `oc.decode`.\n",
+    "You can automatically convert a string to its corresponding type (e.g., bool, int, float, dict, list) using `oc.decode` (which can even resolve interpolations).\n",
     "This resolver also accepts ``None`` as input, in which case it returns ``None``.\n",
     "\n",
     "This can be useful for instance to parse environment variables:"
@@ -833,7 +833,8 @@
      "text": [
       "port (int): 3308\n",
       "nodes (list): ['host1', 'host2', 'host3']\n",
-      "nodes (None due to missing variable): None\n"
+      "timeout (missing variable): None\n",
+      "timeout (interpolation): 3308\n"
      ]
     }
    ],
@@ -843,18 +844,21 @@
     "        \"database\": {\n",
     "            \"port\": '${oc.decode:${oc.env:DB_PORT}}',\n",
     "            \"nodes\": '${oc.decode:${oc.env:DB_NODES,null}}',\n",
+    "            \"timeout\": '${oc.decode:${oc.env:DB_TIMEOUT,null}}',\n",
     "        }\n",
     "    }\n",
     ")\n",
     "\n",
     "os.environ[\"DB_PORT\"] = \"3308\"  # integer\n",
     "os.environ[\"DB_NODES\"] = \"[host1, host2, host3]\"  # list\n",
+    "os.environ.pop(\"DB_TIMEOUT\", None)  # unset variable\n",
     "\n",
     "print(\"port (int):\", repr(cfg.database.port))\n",
     "print(\"nodes (list):\", repr(cfg.database.nodes))\n",
+    "print(\"timeout (missing variable):\", repr(cfg.database.timeout))\n",
     "\n",
-    "del os.environ[\"DB_NODES\"]\n",
-    "print(\"nodes (None due to missing variable):\", repr(cfg.database.nodes))"
+    "os.environ[\"DB_TIMEOUT\"] = \"${.port}\"\n",
+    "print(\"timeout (interpolation):\", repr(cfg.database.timeout))"
    ]
   },
   {

--- a/docs/source/env_interpolation.yaml
+++ b/docs/source/env_interpolation.yaml
@@ -1,4 +1,3 @@
 user:
   name: ${oc.env:USER}
   home: /home/${oc.env:USER}
-  id: ${oc.env:USERID}

--- a/docs/source/env_interpolation.yaml
+++ b/docs/source/env_interpolation.yaml
@@ -1,3 +1,4 @@
 user:
-  name: ${env:USER}
-  home: /home/${env:USER}
+  name: ${oc.env:USER}
+  home: /home/${oc.env:USER}
+  id: ${oc.env:USERID}

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -340,13 +340,9 @@ Example:
     >>> # Primitive interpolation types are inherited from the reference
     >>> show(conf.client.server_port)
     type: int, value: 80
+    >>> # String interpolations concatenate fragments into a string
     >>> show(conf.client.description)
     type: str, value: 'Client of http://localhost:80/'
-
-    >>> # Composite interpolation types are always string
-    >>> show(conf.client.url)
-    type: str, value: 'http://localhost:80/'
-
 
 Interpolations may be nested, enabling more advanced behavior like dynamically selecting a sub-config:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -6,7 +6,6 @@
     import tempfile
     import pickle
     os.environ['USER'] = 'omry'
-    os.environ['USERID'] = '123456'
     os.environ.pop('DB_TIMEOUT', None)
 
 .. testsetup:: loaded
@@ -403,8 +402,6 @@ Input YAML file:
     'omry'
     >>> conf.user.home
     '/home/omry'
-    >>> conf.user.id  # returned as string, even if it is a number
-    '123456'
 
 You can specify a default value to use in case the environment variable is not defined.
 This default value can be a string or `null` (representing Python `None`). Passing a default with a different type will result in an error.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -404,16 +404,23 @@ Input YAML file:
     '/home/omry'
 
 You can specify a default value to use in case the environment variable is not defined.
-This default value can be a string or `null` (representing Python `None`). Passing a default with a different type will result in an error.
-The following example sets ``abc123`` as the default value when ``DB_PASSWORD`` is not defined.
+This default value can be a string or ``null`` (representing Python ``None``). Passing a default with a different type will result in an error.
+The following example sets default database passwords when ``DB_PASSWORD`` is not defined:
 
 .. doctest::
 
-    >>> cfg = OmegaConf.create({
-    ...       'database': {'password': '${oc.env:DB_PASSWORD,abc123}'}
-    ... })
-    >>> cfg.database.password
+    >>> cfg = OmegaConf.create(
+    ...     {
+    ...         "database": {
+    ...             "password1": "${oc.env:DB_PASSWORD,abc123}",
+    ...             "password2": "${oc.env:DB_PASSWORD,'12345'}",
+    ...         },
+    ...     }
+    ... )
+    >>> cfg.database.password1  # the string 'abc123'
     'abc123'
+    >>> cfg.database.password2  # the string '12345'
+    '12345'
 
 
 Decoding strings with interpolations

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -385,8 +385,7 @@ Interpolated nodes can be any node in the config, not just leaf nodes:
 Environment variable interpolation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Environment variable interpolation is also supported.
-An environment variable is always returned as a string.
+Access to environment variables is supported using ``oc.env``:
 
 Input YAML file:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -402,7 +402,7 @@ Input YAML file:
 
 You can specify a default value to use in case the environment variable is not defined.
 This default value can be a string or ``null`` (representing Python ``None``). Passing a default with a different type will result in an error.
-The following example sets default database passwords when ``DB_PASSWORD`` is not defined:
+The following example falls back to default passwords when ``DB_PASSWORD`` is not defined:
 
 .. doctest::
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -407,7 +407,7 @@ Input YAML file:
     '123456'
 
 You can specify a default value to use in case the environment variable is not defined.
-This default value must be a string (with the exception of ``${oc.env:VAR,null}`` that returns ``None`` if ``VAR`` is not defined).
+This default value can be a string or `null` (representing Python `None`). Passing a default with a different type will result in an error.
 The following example sets ``abc123`` as the default value when ``DB_PASSWORD`` is not defined.
 
 .. doctest::

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -341,6 +341,9 @@ Example:
     >>> show(conf.client.server_port)
     type: int, value: 80
     >>> # String interpolations concatenate fragments into a string
+    >>> show(conf.client.url)
+    type: str, value: 'http://localhost:80/'
+    >>> # Relative interpolation example
     >>> show(conf.client.description)
     type: str, value: 'Client of http://localhost:80/'
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -335,19 +335,17 @@ Example:
 .. doctest::
 
     >>> conf = OmegaConf.load('source/config_interpolation.yaml')
+    >>> def show(x):
+    ...     print(f"type: {type(x).__name__}, value: {repr(x)}")
     >>> # Primitive interpolation types are inherited from the reference
-    >>> conf.client.server_port
-    80
-    >>> type(conf.client.server_port).__name__
-    'int'
-    >>> conf.client.description
-    'Client of http://localhost:80/'
+    >>> show(conf.client.server_port)
+    type: int, value: 80
+    >>> show(conf.client.description)
+    type: str, value: 'Client of http://localhost:80/'
 
     >>> # Composite interpolation types are always string
-    >>> conf.client.url
-    'http://localhost:80/'
-    >>> type(conf.client.url).__name__
-    'str'
+    >>> show(conf.client.url)
+    type: str, value: 'http://localhost:80/'
 
 
 Interpolations may be nested, enabling more advanced behavior like dynamically selecting a sub-config:
@@ -446,8 +444,6 @@ This can be useful for instance to parse environment variables:
     ...         }
     ...     }
     ... )
-    >>> def show(x):
-    ...     print(f"type: {type(x).__name__}, value: {x}")
     >>> os.environ["DB_PORT"] = "3308"
     >>> show(cfg.database.port)  # converted to int
     type: int, value: 3308
@@ -789,12 +785,11 @@ If resolve is set to True, interpolations will be resolved during conversion.
     >>> conf = OmegaConf.create({"foo": "bar", "foo2": "${foo}"})
     >>> assert type(conf) == DictConfig
     >>> primitive = OmegaConf.to_container(conf)
-    >>> assert type(primitive) == dict
-    >>> print(primitive)
-    {'foo': 'bar', 'foo2': '${foo}'}
+    >>> show(primitive)
+    type: dict, value: {'foo': 'bar', 'foo2': '${foo}'}
     >>> resolved = OmegaConf.to_container(conf, resolve=True)
-    >>> print(resolved)
-    {'foo': 'bar', 'foo2': 'bar'}
+    >>> show(resolved)
+    type: dict, value: {'foo': 'bar', 'foo2': 'bar'}
 
 You can customize the treatment of **OmegaConf.to_container()** for
 Structured Config nodes using the `structured_config_mode` option.
@@ -807,9 +802,8 @@ as DictConfig, allowing attribute style access on the resulting node.
     >>> from omegaconf import SCMode
     >>> conf = OmegaConf.create({"structured_config": MyConfig})
     >>> container = OmegaConf.to_container(conf, structured_config_mode=SCMode.DICT_CONFIG)
-    >>> print(container)
-    {'structured_config': {'port': 80, 'host': 'localhost'}}
-    >>> assert type(container) is dict
+    >>> show(container)
+    type: dict, value: {'structured_config': {'port': 80, 'host': 'localhost'}}
     >>> assert type(container["structured_config"]) is DictConfig
     >>> assert container["structured_config"].port == 80
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -803,8 +803,8 @@ as DictConfig, allowing attribute style access on the resulting node.
     >>> container = OmegaConf.to_container(conf, structured_config_mode=SCMode.DICT_CONFIG)
     >>> show(container)
     type: dict, value: {'structured_config': {'port': 80, 'host': 'localhost'}}
-    >>> assert type(container["structured_config"]) is DictConfig
-    >>> assert container["structured_config"].port == 80
+    >>> show(container["structured_config"])
+    type: DictConfig, value: {'port': 80, 'host': 'localhost'}
 
 OmegaConf.select
 ^^^^^^^^^^^^^^^^

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -7,6 +7,7 @@
     import pickle
     os.environ['USER'] = 'omry'
     os.environ['USERID'] = '123456'
+    os.environ.pop('DB_TIMEOUT', None)
 
 .. testsetup:: loaded
 
@@ -421,7 +422,8 @@ The following example sets ``abc123`` as the default value when ``DB_PASSWORD`` 
 Decoding strings with interpolations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can automatically convert a string to its corresponding type (e.g., bool, int, float, dict, list) using ``oc.decode``.
+You can automatically convert a string to its corresponding type (e.g., bool, int, float, dict, list) using ``oc.decode``
+(which can even resolve interpolations).
 This resolver also accepts ``None`` as input, in which case it returns ``None``.
 This can be useful for instance to parse environment variables:
 
@@ -431,7 +433,8 @@ This can be useful for instance to parse environment variables:
     ...     {
     ...         "database": {
     ...             "port": '${oc.decode:${oc.env:DB_PORT}}',
-    ...             "nodes": '${oc.decode:${oc.env:DB_NODES,null}}',
+    ...             "nodes": '${oc.decode:${oc.env:DB_NODES}}',
+    ...             "timeout": '${oc.decode:${oc.env:DB_TIMEOUT,null}}',
     ...         }
     ...     }
     ... )
@@ -441,10 +444,9 @@ This can be useful for instance to parse environment variables:
     >>> os.environ["DB_NODES"] = "[host1, host2, host3]"
     >>> cfg.database.nodes  # converted to list
     ['host1', 'host2', 'host3']
-    >>> del os.environ["DB_NODES"]
-    >>> cfg.database.nodes is None  # keeping `None` as is
-    True
-
+    >>> assert cfg.database.timeout is None  # keeping `None` as is
+    >>> os.environ["DB_TIMEOUT"] = "${.port}"
+    >>> assert cfg.database.timeout == 3308  # resolving interpolation
 
 
 Custom interpolations

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -6,6 +6,7 @@
     import tempfile
     import pickle
     os.environ['USER'] = 'omry'
+    # ensures that DB_TIMEOUT is not set in the doc.
     os.environ.pop('DB_TIMEOUT', None)
 
 .. testsetup:: loaded

--- a/news/230.bugfix
+++ b/news/230.bugfix
@@ -1,1 +1,0 @@
-`${env:MYVAR,null}` now properly returns `None` if the environment variable MYVAR is undefined.

--- a/news/445.feature.1
+++ b/news/445.feature.1
@@ -1,1 +1,1 @@
-Add ability to nest interpolations, e.g. ${foo.${bar}}}, ${env:{$var1},${var2}}, or ${${func}:x1,x2}
+Add ability to nest interpolations, e.g. ${foo.${bar}}}, ${oc.env:{$var1},${var2}}, or ${${func}:x1,x2}

--- a/news/573.api_change
+++ b/news/573.api_change
@@ -1,0 +1,1 @@
+The `env` resolver is deprecated in favor of `oc.env`, which keeps the string representation of environment variables.

--- a/news/573.api_change
+++ b/news/573.api_change
@@ -1,1 +1,1 @@
-The `env` resolver is deprecated in favor of `oc.env`, which keeps the string representation of environment variables and does not cache the resulting value.
+The `env` resolver is deprecated in favor of `oc.env`, which keeps the string representation of environment variables, does not cache the resulting value, and handles "null" as default value.

--- a/news/573.api_change
+++ b/news/573.api_change
@@ -1,1 +1,1 @@
-The `env` resolver is deprecated in favor of `oc.env`, which keeps the string representation of environment variables.
+The `env` resolver is deprecated in favor of `oc.env`, which keeps the string representation of environment variables and does not cache the resulting value.

--- a/news/574.feature
+++ b/news/574.feature
@@ -1,0 +1,1 @@
+New resolver `oc.decode` that can be used to automatically convert a string to bool, int, float, dict, list, etc.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -404,6 +404,11 @@ def get_value_kind(
         return ValueKind.VALUE
 
 
+def is_bool(st: str) -> bool:
+    st = str.lower(st)
+    return st == "true" or st == "false"
+
+
 def is_float(st: str) -> bool:
     try:
         float(st)
@@ -418,6 +423,19 @@ def is_int(st: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def decode_primitive(s: str) -> Any:
+    if is_bool(s):
+        return str.lower(s) == "true"
+
+    if is_int(s):
+        return int(s)
+
+    if is_float(s):
+        return float(s)
+
+    return s
 
 
 def is_primitive_list(obj: Any) -> bool:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -63,6 +63,18 @@ YAML_BOOL_TYPES = [
 _CMP_TYPES = {t: i for i, t in enumerate([float, int, bool, str, type(None)])}
 
 
+class Marker:
+    def __init__(self, desc: str):
+        self.desc = desc
+
+    def __repr__(self) -> str:
+        return self.desc
+
+
+# To be used as default value when `None` is not an option.
+_DEFAULT_MARKER_: Any = Marker("_DEFAULT_MARKER_")
+
+
 class OmegaConfDumper(yaml.Dumper):  # type: ignore
     str_representer_added = False
 
@@ -74,14 +86,6 @@ class OmegaConfDumper(yaml.Dumper):  # type: ignore
             data,
             style=("'" if with_quotes else None),
         )
-
-
-class Marker:
-    def __init__(self, desc: str):
-        self.desc = desc
-
-    def __repr__(self) -> str:
-        return self.desc
 
 
 def get_omega_conf_dumper() -> Type[OmegaConfDumper]:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -426,6 +426,7 @@ def is_int(st: str) -> bool:
         return False
 
 
+# DEPRECATED: remove in 2.2
 def decode_primitive(s: str) -> Any:
     if is_bool(s):
         return str.lower(s) == "true"

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -76,6 +76,14 @@ class OmegaConfDumper(yaml.Dumper):  # type: ignore
         )
 
 
+class Marker:
+    def __init__(self, desc: str):
+        self.desc = desc
+
+    def __repr__(self) -> str:
+        return self.desc
+
+
 def get_omega_conf_dumper() -> Type[OmegaConfDumper]:
     if not OmegaConfDumper.str_representer_added:
         OmegaConfDumper.add_representer(str, OmegaConfDumper.str_representer)

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -404,6 +404,7 @@ def get_value_kind(
         return ValueKind.VALUE
 
 
+# DEPRECATED: remove in 2.2
 def is_bool(st: str) -> bool:
     st = str.lower(st)
     return st == "true" or st == "false"

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 from antlr4 import ParserRuleContext
 
 from ._utils import (
+    Marker,
     ValueKind,
     _get_value,
     _is_missing_value,
@@ -32,7 +33,7 @@ from .grammar_visitor import GrammarVisitor
 
 DictKeyType = Union[str, int, Enum, float, bool]
 
-_MARKER_ = object()
+_MARKER_: Any = Marker("_MARKER_")
 
 
 @dataclass

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 from antlr4 import ParserRuleContext
 
 from ._utils import (
-    Marker,
+    _DEFAULT_MARKER_,
     ValueKind,
     _get_value,
     _is_missing_value,
@@ -32,8 +32,6 @@ from .grammar_parser import parse
 from .grammar_visitor import GrammarVisitor
 
 DictKeyType = Union[str, int, Enum, float, bool]
-
-_MARKER_: Any = Marker("_MARKER_")
 
 
 @dataclass
@@ -156,8 +154,8 @@ class Node(ABC):
         if cache is None:
             cache = self.__dict__["_flags_cache"] = {}
 
-        ret = cache.get(flag, _MARKER_)
-        if ret is _MARKER_:
+        ret = cache.get(flag, _DEFAULT_MARKER_)
+        if ret is _DEFAULT_MARKER_:
             ret = self._get_flag_no_cache(flag)
             cache[flag] = ret
         assert ret is None or isinstance(ret, bool)

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import yaml
 
 from ._utils import (
-    Marker,
+    _DEFAULT_MARKER_,
     _ensure_container,
     _get_value,
     _is_interpolation,
@@ -38,8 +38,6 @@ from .errors import (
 if TYPE_CHECKING:
     from .dictconfig import DictConfig  # pragma: no cover
 
-DEFAULT_VALUE_MARKER: Any = Marker("DEFAULT_VALUE_MARKER")
-
 
 class BaseContainer(Container, ABC):
     # static
@@ -53,11 +51,11 @@ class BaseContainer(Container, ABC):
         self,
         key: Union[DictKeyType, int],
         value: Node,
-        default_value: Any = DEFAULT_VALUE_MARKER,
+        default_value: Any = _DEFAULT_MARKER_,
     ) -> Any:
         """returns the value with the specified key, like obj.key and obj['key']"""
         if _is_missing_value(value):
-            if default_value is not DEFAULT_VALUE_MARKER:
+            if default_value is not _DEFAULT_MARKER_:
                 return default_value
             raise MissingMandatoryValue("Missing mandatory value: $FULL_KEY")
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import yaml
 
 from ._utils import (
+    Marker,
     _ensure_container,
     _get_value,
     _is_interpolation,
@@ -37,7 +38,7 @@ from .errors import (
 if TYPE_CHECKING:
     from .dictconfig import DictConfig  # pragma: no cover
 
-DEFAULT_VALUE_MARKER: Any = str("__DEFAULT_VALUE_MARKER__")
+DEFAULT_VALUE_MARKER: Any = Marker("DEFAULT_VALUE_MARKER")
 
 
 class BaseContainer(Container, ABC):

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 from ._utils import (
+    _DEFAULT_MARKER_,
     ValueKind,
     _get_value,
     _is_interpolation,
@@ -35,7 +36,7 @@ from ._utils import (
     valid_value_annotation_type,
 )
 from .base import Container, ContainerMetadata, DictKeyType, Node
-from .basecontainer import DEFAULT_VALUE_MARKER, BaseContainer
+from .basecontainer import BaseContainer
 from .errors import (
     ConfigAttributeError,
     ConfigKeyError,
@@ -345,7 +346,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             raise AttributeError()
 
         try:
-            return self._get_impl(key=key, default_value=DEFAULT_VALUE_MARKER)
+            return self._get_impl(key=key, default_value=_DEFAULT_MARKER_)
         except ConfigKeyError as e:
             self._format_and_raise(
                 key=key, value=None, cause=e, type_override=ConfigAttributeError
@@ -361,7 +362,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         """
 
         try:
-            return self._get_impl(key=key, default_value=DEFAULT_VALUE_MARKER)
+            return self._get_impl(key=key, default_value=_DEFAULT_MARKER_)
         except AttributeError as e:
             self._format_and_raise(
                 key=key, value=None, cause=e, type_override=ConfigKeyError
@@ -414,7 +415,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         try:
             node = self._get_node(key=key, throw_on_missing_key=True)
         except (ConfigAttributeError, ConfigKeyError):
-            if default_value is not DEFAULT_VALUE_MARKER:
+            if default_value is not _DEFAULT_MARKER_:
                 return default_value
             else:
                 raise
@@ -449,7 +450,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             raise MissingMandatoryValue("Missing mandatory value")
         return value
 
-    def pop(self, key: DictKeyType, default: Any = DEFAULT_VALUE_MARKER) -> Any:
+    def pop(self, key: DictKeyType, default: Any = _DEFAULT_MARKER_) -> Any:
         try:
             if self._get_flag("readonly"):
                 raise ReadonlyConfigError("Cannot pop from read-only node")
@@ -470,7 +471,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
                 del self[key]
                 return value
             else:
-                if default is not DEFAULT_VALUE_MARKER:
+                if default is not _DEFAULT_MARKER_:
                     return default
                 else:
                     full = self._get_full_key(key=key)

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -76,7 +76,7 @@ MISSING: Any = "???"
 # -  in OmegaConf.create() to differentiate between creating an empty {} DictConfig
 #    and creating a DictConfig with None content
 # - in env() to detect between no default value vs a default value set to None
-_EMPTY_MARKER_ = object()
+_EMPTY_MARKER_ = "_OMEGACONF_EMPTY_MARKER_"
 
 Resolver = Callable[..., Any]
 
@@ -114,7 +114,7 @@ def register_default_resolvers() -> None:
             else:
                 raise ValidationError(f"Environment variable '{key}' not found")
 
-    def env(key: str, default: Any = _EMPTY_MARKER_) -> Optional[str]:
+    def env(key: str, default: Optional[str] = _EMPTY_MARKER_) -> Optional[str]:
         if (
             default is not _EMPTY_MARKER_
             and default is not None
@@ -129,7 +129,6 @@ def register_default_resolvers() -> None:
             return os.environ[key]
         except KeyError:
             if default is not _EMPTY_MARKER_:
-                assert default is None or isinstance(default, str)  # redundant for mypy
                 return default
             else:
                 raise KeyError(f"Environment variable '{key}' not found")

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -28,6 +28,7 @@ import yaml
 
 from . import DictConfig, DictKeyType, ListConfig
 from ._utils import (
+    Marker,
     _ensure_container,
     _get_value,
     _is_none,
@@ -72,11 +73,11 @@ from .nodes import (
 
 MISSING: Any = "???"
 
-# A marker used:
+# Marker used:
 # -  in OmegaConf.create() to differentiate between creating an empty {} DictConfig
 #    and creating a DictConfig with None content
 # - in env() to detect between no default value vs a default value set to None
-_EMPTY_MARKER_ = "_OMEGACONF_EMPTY_MARKER_"
+_EMPTY_MARKER_: Any = Marker("_EMPTY_MARKER_")
 
 Resolver = Callable[..., Any]
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -120,15 +120,21 @@ def register_default_resolvers() -> None:
                 raise ValidationError(f"Environment variable '{key}' not found")
 
     def env(key: str, default: Any = _EMPTY_MARKER_) -> Optional[str]:
+        if (
+            default is not _EMPTY_MARKER_
+            and default is not None
+            and not isinstance(default, str)
+        ):
+            raise ValidationError(
+                f"The default value of the `oc.env` resolver must be a string or "
+                f"None, but `{default}` is of type {type(default).__name__}"
+            )
+
         try:
             return os.environ[key]
         except KeyError:
             if default is not _EMPTY_MARKER_:
-                if default is not None and not isinstance(default, str):
-                    raise ValidationError(
-                        f"The default value of the `oc.env` resolver must be a string or "
-                        f"None, but `{default}` is of type {type(default).__name__}"
-                    )
+                assert default is None or isinstance(default, str)  # redundant for mypy
                 return default
             else:
                 raise ValidationError(f"Environment variable '{key}' not found")

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -121,7 +121,7 @@ def register_default_resolvers() -> None:
             and default is not None
             and not isinstance(default, str)
         ):
-            raise ValidationError(
+            raise TypeError(
                 f"The default value of the `oc.env` resolver must be a string or "
                 f"None, but `{default}` is of type {type(default).__name__}"
             )

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -28,7 +28,7 @@ import yaml
 
 from . import DictConfig, DictKeyType, ListConfig
 from ._utils import (
-    Marker,
+    _DEFAULT_MARKER_,
     _ensure_container,
     _get_value,
     _is_none,
@@ -73,12 +73,6 @@ from .nodes import (
 
 MISSING: Any = "???"
 
-# Marker used:
-# -  in OmegaConf.create() to differentiate between creating an empty {} DictConfig
-#    and creating a DictConfig with None content
-# - in env() to detect between no default value vs a default value set to None
-_EMPTY_MARKER_: Any = Marker("_EMPTY_MARKER_")
-
 Resolver = Callable[..., Any]
 
 
@@ -115,9 +109,9 @@ def register_default_resolvers() -> None:
             else:
                 raise ValidationError(f"Environment variable '{key}' not found")
 
-    def env(key: str, default: Optional[str] = _EMPTY_MARKER_) -> Optional[str]:
+    def env(key: str, default: Optional[str] = _DEFAULT_MARKER_) -> Optional[str]:
         if (
-            default is not _EMPTY_MARKER_
+            default is not _DEFAULT_MARKER_
             and default is not None
             and not isinstance(default, str)
         ):
@@ -129,7 +123,7 @@ def register_default_resolvers() -> None:
         try:
             return os.environ[key]
         except KeyError:
-            if default is not _EMPTY_MARKER_:
+            if default is not _DEFAULT_MARKER_:
                 return default
             else:
                 raise KeyError(f"Environment variable '{key}' not found")
@@ -219,7 +213,7 @@ class OmegaConf:
 
     @staticmethod
     def create(  # noqa F811
-        obj: Any = _EMPTY_MARKER_,
+        obj: Any = _DEFAULT_MARKER_,
         parent: Optional[BaseContainer] = None,
         flags: Optional[Dict[str, bool]] = None,
     ) -> Union[DictConfig, ListConfig]:
@@ -684,7 +678,7 @@ class OmegaConf:
         cfg: Container,
         key: str,
         *,
-        default: Any = _EMPTY_MARKER_,
+        default: Any = _DEFAULT_MARKER_,
         throw_on_resolution_failure: bool = True,
         throw_on_missing: bool = False,
     ) -> Any:
@@ -696,13 +690,13 @@ class OmegaConf:
                     throw_on_resolution_failure=throw_on_resolution_failure,
                 )
             except ConfigKeyError:
-                if default is not _EMPTY_MARKER_:
+                if default is not _DEFAULT_MARKER_:
                     return default
                 else:
                     raise
 
             if (
-                default is not _EMPTY_MARKER_
+                default is not _DEFAULT_MARKER_
                 and _root is not None
                 and _last_key is not None
                 and _last_key not in _root
@@ -806,7 +800,7 @@ class OmegaConf:
 
     @staticmethod
     def _create_impl(  # noqa F811
-        obj: Any = _EMPTY_MARKER_,
+        obj: Any = _DEFAULT_MARKER_,
         parent: Optional[BaseContainer] = None,
         flags: Optional[Dict[str, bool]] = None,
     ) -> Union[DictConfig, ListConfig]:
@@ -815,7 +809,7 @@ class OmegaConf:
             from .dictconfig import DictConfig
             from .listconfig import ListConfig
 
-            if obj is _EMPTY_MARKER_:
+            if obj is _DEFAULT_MARKER_:
                 obj = {}
             if isinstance(obj, str):
                 obj = yaml.load(obj, Loader=get_yaml_loader())

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -143,9 +143,9 @@ def register_default_resolvers() -> None:
             return None
 
         if not isinstance(expr, str):
-            raise ValidationError(
+            raise TypeError(
                 f"`oc.decode` can only take strings or None as input, "
-                f"but `{expr}` if of type {type(expr).__name__}"
+                f"but `{expr}` is of type {type(expr).__name__}"
             )
 
         parse_tree = parse(expr, parser_rule="singleElement", lexer_mode="VALUE_MODE")

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -137,7 +137,7 @@ def register_default_resolvers() -> None:
                 assert default is None or isinstance(default, str)  # redundant for mypy
                 return default
             else:
-                raise ValidationError(f"Environment variable '{key}' not found")
+                raise KeyError(f"Environment variable '{key}' not found")
 
     def decode(expr: Optional[str], _parent_: Container) -> Any:
         """

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -110,12 +110,7 @@ def register_default_resolvers() -> None:
             return decode_primitive(os.environ[key])
         except KeyError:
             if default is not None:
-                # We handle the "null" string in a special way so as to preserve
-                # the old behavior of `env` while keeping the fix from #230.
-                if default.lower() == "null":
-                    return None
-                else:
-                    return decode_primitive(default)
+                return decode_primitive(default)
             else:
                 raise ValidationError(f"Environment variable '{key}' not found")
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -100,7 +100,7 @@ def SI(interpolation: str) -> Any:
 
 
 def register_default_resolvers() -> None:
-    # # DEPRECATED: remove in 2.2
+    # DEPRECATED: remove in 2.2
     def legacy_env(key: str, default: Optional[str] = None) -> Any:
         warnings.warn(
             "The `env` resolver is deprecated, see https://github.com/omry/omegaconf/issues/573",

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -457,15 +457,9 @@ def test_legacy_env_values_are_typed(
         assert c.my_key == expected
 
 
-@pytest.mark.parametrize("env_func", ["env", "oc.env"])
-def test_env_default_none(
-    monkeypatch: Any,
-    # DEPRECATED: remove `recwarn` in 2.2 with the legacy env resolver
-    recwarn: Any,
-    env_func: str,
-) -> None:
+def test_env_default_none(monkeypatch: Any) -> None:
     monkeypatch.delenv("MYKEY", raising=False)
-    c = OmegaConf.create({"my_key": "${%s:MYKEY, null}" % env_func})
+    c = OmegaConf.create({"my_key": "${oc.env:MYKEY, null}"})
     assert c.my_key is None
 
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -350,7 +350,10 @@ def test_decode(monkeypatch: Any, value: Optional[str], expected: Any) -> None:
     c = OmegaConf.create(
         {
             # The node of interest is "node" (others are used to test interpolations).
-            "parent": {"node": f"${{oc.decode:'{value}'}}", "sibling": 1},
+            "parent": {
+                "node": f"${{oc.decode:'{value}'}}",
+                "sibling": 1,
+            },
             "uncle": 2,
         }
     )

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -474,7 +474,7 @@ def test_env_non_str_default(monkeypatch: Any, has_var: bool) -> None:
     with pytest.raises(
         InterpolationResolutionError,
         match=re.escape(
-            "ValidationError raised while resolving interpolation: The default value "
+            "TypeError raised while resolving interpolation: The default value "
             "of the `oc.env` resolver must be a string or None, but `123` is of type int"
         ),
     ):

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -472,8 +472,13 @@ def test_env_default_none(monkeypatch: Any, env_func: str) -> None:
         assert c.my_key is None
 
 
-def test_env_non_str_default(monkeypatch: Any) -> None:
-    monkeypatch.delenv("MYKEY", raising=False)
+@pytest.mark.parametrize("has_var", [True, False])
+def test_env_non_str_default(monkeypatch: Any, has_var: bool) -> None:
+    if has_var:
+        monkeypatch.setenv("MYKEY", "456")
+    else:
+        monkeypatch.delenv("MYKEY", raising=False)
+
     c = OmegaConf.create({"my_key": "${oc.env:MYKEY, 123}"})
     with pytest.raises(
         InterpolationResolutionError,

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -457,9 +457,13 @@ def test_legacy_env_values_are_typed(
         assert c.my_key == expected
 
 
-# DEPRECATED: remove `recwarn` in 2.2 with the legacy env resolver
 @pytest.mark.parametrize("env_func", ["env", "oc.env"])
-def test_env_default_none(monkeypatch: Any, recwarn: Any, env_func: str) -> None:
+def test_env_default_none(
+    monkeypatch: Any,
+    # DEPRECATED: remove `recwarn` in 2.2 with the legacy env resolver
+    recwarn: Any,
+    env_func: str,
+) -> None:
     monkeypatch.delenv("MYKEY", raising=False)
     c = OmegaConf.create({"my_key": "${%s:MYKEY, null}" % env_func})
     assert c.my_key is None

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -373,8 +373,8 @@ def test_decode_none() -> None:
             pytest.raises(
                 InterpolationResolutionError,
                 match=re.escape(
-                    "ValidationError raised while resolving interpolation: "
-                    "`oc.decode` can only take strings or None as input, but `123` if of type int"
+                    "TypeError raised while resolving interpolation: "
+                    "`oc.decode` can only take strings or None as input, but `123` is of type int"
                 ),
             ),
             id="bad_type",

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -214,7 +214,7 @@ def test_type_inherit_type(cfg: Any) -> None:
 @pytest.mark.parametrize("env_func", ["env", "oc.env"])
 class TestEnvInterpolation:
     @pytest.mark.parametrize(
-        "cfg,env_name,env_val,key,expected",
+        ("cfg", "env_name", "env_val", "key", "expected"),
         [
             pytest.param(
                 {"path": "/test/${${env_func}:foo}"},

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -244,6 +244,8 @@ class TestEnvInterpolation:
     )
     def test_env_interpolation(
         self,
+        # DEPRECATED: remove in 2.2 with the legacy env resolver
+        recwarn: Any,
         monkeypatch: Any,
         env_func: str,
         cfg: Any,
@@ -258,12 +260,7 @@ class TestEnvInterpolation:
         cfg["env_func"] = env_func  # allows choosing which env resolver to use
         cfg = OmegaConf.create(cfg)
 
-        # The legacy env resolver triggers a deprecation warning.
-        if env_func == "env":
-            with pytest.warns(UserWarning):
-                assert OmegaConf.select(cfg, key) == expected
-        else:
-            assert OmegaConf.select(cfg, key) == expected
+        assert OmegaConf.select(cfg, key) == expected
 
     @pytest.mark.parametrize(
         ("cfg", "key", "expected"),
@@ -281,6 +278,8 @@ class TestEnvInterpolation:
     )
     def test_env_interpolation_error(
         self,
+        # DEPRECATED: remove in 2.2 with the legacy env resolver
+        recwarn: Any,
         env_func: str,
         cfg: Any,
         key: str,
@@ -289,14 +288,8 @@ class TestEnvInterpolation:
         cfg["env_func"] = env_func  # allows choosing which env resolver to use
         cfg = _ensure_container(cfg)
 
-        # The legacy env resolver triggers a deprecation warning.
-        if env_func == "env":
-            with pytest.warns(UserWarning):
-                with expected:
-                    OmegaConf.select(cfg, key)
-        else:
-            with expected:
-                OmegaConf.select(cfg, key)
+        with expected:
+            OmegaConf.select(cfg, key)
 
 
 def test_legacy_env_is_cached(monkeypatch: Any) -> None:
@@ -461,15 +454,12 @@ def test_legacy_env_values_are_typed(
         assert c.my_key == expected
 
 
+# DEPRECATED: remove `recwarn` in 2.2 with the legacy env resolver
 @pytest.mark.parametrize("env_func", ["env", "oc.env"])
-def test_env_default_none(monkeypatch: Any, env_func: str) -> None:
+def test_env_default_none(monkeypatch: Any, recwarn: Any, env_func: str) -> None:
     monkeypatch.delenv("MYKEY", raising=False)
     c = OmegaConf.create({"my_key": "${%s:MYKEY, null}" % env_func})
-    if env_func == "env":
-        with pytest.warns(UserWarning):
-            assert c.my_key is None
-    else:
-        assert c.my_key is None
+    assert c.my_key is None
 
 
 @pytest.mark.parametrize("has_var", [True, False])

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -211,71 +211,203 @@ def test_type_inherit_type(cfg: Any) -> None:
     assert type(cfg.s) == str  # check that string interpolations are always strings
 
 
+@pytest.mark.parametrize("env_func", ["env", "oc.env"])
+class TestEnvInterpolation:
+    @pytest.mark.parametrize(
+        "cfg,env_name,env_val,key,expected",
+        [
+            pytest.param(
+                {"path": "/test/${${env_func}:foo}"},
+                "foo",
+                "1234",
+                "path",
+                "/test/1234",
+                id="simple",
+            ),
+            pytest.param(
+                {"path": "/test/${${env_func}:not_found,ZZZ}"},
+                None,
+                None,
+                "path",
+                "/test/ZZZ",
+                id="not_found_with_default",
+            ),
+            pytest.param(
+                {"path": "/test/${${env_func}:not_found,a/b}"},
+                None,
+                None,
+                "path",
+                "/test/a/b",
+                id="not_found_with_default",
+            ),
+        ],
+    )
+    def test_env_interpolation(
+        self,
+        monkeypatch: Any,
+        env_func: str,
+        cfg: Any,
+        env_name: Optional[str],
+        env_val: str,
+        key: str,
+        expected: Any,
+    ) -> None:
+        if env_name is not None:
+            monkeypatch.setenv(env_name, env_val)
+
+        cfg["env_func"] = env_func  # allows choosing which env resolver to use
+        cfg = OmegaConf.create(cfg)
+
+        # The legacy env resolver triggers a deprecation warning.
+        if env_func == "env":
+            with pytest.warns(UserWarning):
+                assert OmegaConf.select(cfg, key) == expected
+        else:
+            assert OmegaConf.select(cfg, key) == expected
+
+    @pytest.mark.parametrize(
+        ("cfg", "key", "expected"),
+        [
+            pytest.param(
+                {"path": "/test/${${env_func}:not_found}"},
+                "path",
+                pytest.raises(
+                    InterpolationResolutionError,
+                    match=re.escape("Environment variable 'not_found' not found"),
+                ),
+                id="not_found",
+            ),
+        ],
+    )
+    def test_env_interpolation_error(
+        self,
+        env_func: str,
+        cfg: Any,
+        key: str,
+        expected: Any,
+    ) -> None:
+        cfg["env_func"] = env_func  # allows choosing which env resolver to use
+        cfg = _ensure_container(cfg)
+
+        # The legacy env resolver triggers a deprecation warning.
+        if env_func == "env":
+            with pytest.warns(UserWarning):
+                with expected:
+                    OmegaConf.select(cfg, key)
+        else:
+            with expected:
+                OmegaConf.select(cfg, key)
+
+
+def test_legacy_env_is_cached(monkeypatch: Any) -> None:
+    monkeypatch.setenv("FOOBAR", "1234")
+    c = OmegaConf.create({"foobar": "${env:FOOBAR}"})
+    with pytest.warns(UserWarning):
+        before = c.foobar
+        monkeypatch.setenv("FOOBAR", "3456")
+        assert c.foobar == before
+
+
+def test_env_is_not_cached(monkeypatch: Any) -> None:
+    monkeypatch.setenv("FOOBAR", "1234")
+    c = OmegaConf.create({"foobar": "${oc.env:FOOBAR}"})
+    before = c.foobar
+    monkeypatch.setenv("FOOBAR", "3456")
+    assert c.foobar != before
+
+
 @pytest.mark.parametrize(
-    "cfg,env_name,env_val,key,expected",
+    "value,expected",
+    [
+        # We only test a few typical cases: more extensive grammar tests are
+        # found in `test_grammar.py`.
+        # bool
+        ("false", False),
+        ("true", True),
+        # int
+        ("10", 10),
+        ("-10", -10),
+        # float
+        ("10.0", 10.0),
+        ("-10.0", -10.0),
+        # null
+        ("null", None),
+        ("NulL", None),
+        # strings
+        ("hello", "hello"),
+        ("hello world", "hello world"),
+        ("  123  ", "  123  "),
+        ('"123"', "123"),
+        # lists and dicts
+        ("[1, 2, 3]", [1, 2, 3]),
+        ("{a: 0, b: 1}", {"a": 0, "b": 1}),
+        ("[\t1, 2, 3\t]", [1, 2, 3]),
+        ("{   a: b\t  }", {"a": "b"}),
+        # resolvers
+        ("${oc.env:MYKEY}", 456),
+    ],
+)
+def test_decode(monkeypatch: Any, value: Optional[str], expected: Any) -> None:
+    monkeypatch.setenv("MYKEY", "456")
+    c = OmegaConf.create({"x": f"${{oc.decode:'{value}'}}"})
+    assert c.x == expected
+
+
+def test_decode_none() -> None:
+    c = OmegaConf.create({"x": "${oc.decode:null}"})
+    assert c.x is None
+
+
+@pytest.mark.parametrize(
+    ("value", "exc"),
     [
         pytest.param(
-            {"path": "/test/${env:foo}"},
-            "foo",
-            "1234",
-            "path",
-            "/test/1234",
-            id="simple",
-        ),
-        pytest.param(
-            {"path": "/test/${env:not_found}"},
-            None,
-            None,
-            "path",
+            123,
             pytest.raises(
                 InterpolationResolutionError,
-                match=re.escape("Environment variable 'not_found' not found"),
+                match=re.escape(
+                    "ValidationError raised while resolving interpolation: "
+                    "`oc.decode` can only take strings or None as input, but `123` if of type int"
+                ),
             ),
-            id="not_found",
+            id="bad_type",
         ),
         pytest.param(
-            {"path": "/test/${env:not_found,ZZZ}"},
-            None,
-            None,
-            "path",
-            "/test/ZZZ",
-            id="not_found_with_default",
+            "'[1, '",
+            pytest.raises(
+                InterpolationResolutionError,
+                match=re.escape(
+                    "GrammarParseError raised while resolving interpolation: "
+                    "missing BRACKET_CLOSE at '<EOF>'"
+                ),
+            ),
+            id="parse_error",
         ),
         pytest.param(
-            {"path": "/test/${env:not_found,a/b}"},
-            None,
-            None,
-            "path",
-            "/test/a/b",
-            id="not_found_with_default",
+            # Must be escaped to prevent resolution before feeding it to `oc.decode`.
+            "'\\${foo}'",
+            pytest.raises(
+                InterpolationResolutionError,
+                match=re.escape("Node interpolations are not supported by `oc.decode`"),
+            ),
+            id="node_interpolation",
         ),
     ],
 )
-def test_env_interpolation(
-    monkeypatch: Any,
-    cfg: Any,
-    env_name: Optional[str],
-    env_val: str,
-    key: str,
-    expected: Any,
-) -> None:
-    if env_name is not None:
-        monkeypatch.setenv(env_name, env_val)
-
-    cfg = _ensure_container(cfg)
-    if isinstance(expected, RaisesContext):
-        with expected:
-            OmegaConf.select(cfg, key)
-    else:
-        assert OmegaConf.select(cfg, key) == expected
+def test_decode_error(monkeypatch: Any, value: Any, exc: Any) -> None:
+    c = OmegaConf.create({"x": f"${{oc.decode:{value}}}"})
+    with exc:
+        c.x
 
 
-def test_env_is_cached(monkeypatch: Any) -> None:
-    monkeypatch.setenv("foobar", "1234")
-    c = OmegaConf.create({"foobar": "${env:foobar}"})
-    before = c.foobar
-    monkeypatch.setenv("foobar", "3456")
-    assert c.foobar == before
+@pytest.mark.parametrize(
+    "value",
+    ["false", "true", "10", "1.5", "null", "None", "${foo}"],
+)
+def test_env_preserves_string(monkeypatch: Any, value: str) -> None:
+    monkeypatch.setenv("MYKEY", value)
+    c = OmegaConf.create({"my_key": "${oc.env:MYKEY}"})
+    assert c.my_key == value
 
 
 @pytest.mark.parametrize(
@@ -304,45 +436,42 @@ def test_env_is_cached(monkeypatch: Any) -> None:
         # more advanced uses of the grammar
         ("ab \\{foo} cd", "ab \\{foo} cd"),
         ("ab \\\\{foo} cd", "ab \\\\{foo} cd"),
-        ("'\\${other_key}'", "${other_key}"),  # escaped interpolation
-        ("'ab \\${other_key} cd'", "ab ${other_key} cd"),  # escaped interpolation
-        ("[1, 2, 3]", [1, 2, 3]),
-        ("{a: 0, b: 1}", {"a": 0, "b": 1}),
-        ("  123  ", "  123  "),
         ("  1 2 3  ", "  1 2 3  "),
         ("\t[1, 2, 3]\t", "\t[1, 2, 3]\t"),
-        ("[\t1, 2, 3\t]", [1, 2, 3]),
         ("   {a: b}\t  ", "   {a: b}\t  "),
-        ("{   a: b\t  }", {"a": "b"}),
-        ("'123'", "123"),
-        ("${env:my_key_2}", 456),  # can call another resolver
     ],
 )
-def test_env_values_are_typed(monkeypatch: Any, value: Any, expected: Any) -> None:
-    monkeypatch.setenv("my_key", value)
-    monkeypatch.setenv("my_key_2", "456")
-    c = OmegaConf.create({"my_key": "${env:my_key}"})
-    assert c.my_key == expected
+def test_legacy_env_values_are_typed(
+    monkeypatch: Any, value: Any, expected: Any
+) -> None:
+    monkeypatch.setenv("MYKEY", value)
+    c = OmegaConf.create({"my_key": "${env:MYKEY}"})
+    with pytest.warns(UserWarning, match=re.escape("The `env` resolver is deprecated")):
+        assert c.my_key == expected
 
 
-def test_env_node_interpolation(monkeypatch: Any) -> None:
-    # Test that node interpolations are not supported in env variables.
-    monkeypatch.setenv("MYKEY", "${other_key}")
-    c = OmegaConf.create({"my_key": "${env:MYKEY}", "other_key": 123})
+@pytest.mark.parametrize("env_func", ["env", "oc.env"])
+def test_env_default_none(monkeypatch: Any, env_func: str) -> None:
+    monkeypatch.delenv("MYKEY", raising=False)
+    c = OmegaConf.create({"my_key": "${%s:MYKEY, null}" % env_func})
+    if env_func == "env":
+        with pytest.warns(UserWarning):
+            assert c.my_key is None
+    else:
+        assert c.my_key is None
+
+
+def test_env_non_str_default(monkeypatch: Any) -> None:
+    monkeypatch.delenv("MYKEY", raising=False)
+    c = OmegaConf.create({"my_key": "${oc.env:MYKEY, 123}"})
     with pytest.raises(
-        InterpolationKeyError,
+        InterpolationResolutionError,
         match=re.escape(
-            "When attempting to resolve env variable 'MYKEY', a node interpolation caused "
-            "the following exception: Interpolation key 'other_key' not found."
+            "ValidationError raised while resolving interpolation: The default value "
+            "of the `oc.env` resolver must be a string or None, but `123` is of type int"
         ),
     ):
         c.my_key
-
-
-def test_env_default_none(monkeypatch: Any) -> None:
-    monkeypatch.delenv("my_key", raising=False)
-    c = OmegaConf.create({"my_key": "${env:my_key, null}"})
-    assert c.my_key is None
 
 
 def test_register_resolver_twice_error(restore_resolvers: Any) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from pytest import mark, param, raises
 
 from omegaconf import DictConfig, ListConfig, Node, OmegaConf, _utils
 from omegaconf._utils import (
+    Marker,
     _ensure_container,
     _get_value,
     _make_hashable,
@@ -631,3 +632,8 @@ def test_ensure_container_raises_ValueError() -> None:
         ),
     ):
         _ensure_container("abc")
+
+
+def test_marker_string_representation() -> None:
+    marker = Marker("marker")
+    assert repr(marker) == "marker"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,7 +58,7 @@ from tests import (
         param(float, 1, FloatNode(1), id="float"),
         param(float, 1.0, FloatNode(1.0), id="float"),
         param(float, Color.RED, ValidationError, id="float"),
-        # # bool
+        # bool
         param(bool, "foo", ValidationError, id="bool"),
         param(bool, True, BooleanNode(True), id="bool"),
         param(bool, 1, BooleanNode(True), id="bool"),


### PR DESCRIPTION
* Restore and deprecate the old `env` resolver for backward
  compatibility with OmegaConf 2.0

* The new `oc.env` resolver keeps the string representation of
  environment variables, and does not use the cache

* The new `oc.decode` resolver can be used to parse and evaluate strings
  according to the OmegaConf grammar

Fixes #383
Fixes #573
Fixes #574

Notes:
* the diff for the notebook can be seen at https://odelalleau.github.io/diff/diff_notebook_decode.html
* the diff of test_interpolation.py is hard to read because there was an indentation change => I created a dummy diff at https://github.com/odelalleau/omegaconf/pull/2/files that doesn't have the indentation change for better readability