### PR TITLE
Do not throw when throw_on_resolution_failure is False

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -210,9 +210,11 @@ class Node(ABC):
 
         parent = self._get_parent()
         if parent is None:
-            raise InterpolationResolutionError(
-                "Cannot resolve interpolation for a node without a parent"
-            )
+            if throw_on_resolution_failure:
+                raise InterpolationResolutionError(
+                    "Cannot resolve interpolation for a node without a parent"
+                )
+            return None
         assert parent is not None
         key = self._key()
         return parent._resolve_interpolation_from_parse_tree(

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -676,6 +676,11 @@ def test_resolve_interpolation_without_parent() -> None:
         DictConfig(content="${foo}")._dereference_node()
 
 
+def test_resolve_interpolation_without_parent_no_throw() -> None:
+    cfg = DictConfig(content="${foo}")
+    assert cfg._dereference_node(throw_on_resolution_failure=False) is None
+
+
 def test_optional_after_interpolation() -> None:
     cfg = OmegaConf.structured(StructuredWithMissing(opt_num=II("num")))
     # Ensure that we can set an optional field to `None` even when it currently


### PR DESCRIPTION
Trying to dereference a node without a parent was raising an
`InterpolationResolutionError` even with `throw_on_resolution_failure`
set to False.

This bug was pointed out in https://github.com/omry/omegaconf/pull/607#discussion_r595485365 and is related to the recent #605.