### PR TITLE
Simplify the escaping of backslashes in quoted strings

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -610,10 +610,13 @@ class Container(Node):
         key: Any,
         value: "Node",
         throw_on_resolution_failure: bool,
+        force_resolution: bool = False,
     ) -> Any:
-        value_kind = get_value_kind(value)
-        if value_kind != ValueKind.INTERPOLATION:
-            return value
+        if not force_resolution:
+            # Skip resolution if not an interpolation.
+            value_kind = get_value_kind(value)
+            if value_kind != ValueKind.INTERPOLATION:
+                return value
 
         parse_tree = parse(_get_value(value))
         return self._resolve_interpolation_from_parse_tree(
@@ -662,6 +665,9 @@ class Container(Node):
                     is_optional=True,
                 ),
                 throw_on_resolution_failure=True,
+                # We must always process the string as if it contained an
+                # interpolation, for proper un-escaping of backslashes (\\).
+                force_resolution=True,
             )
             return str(quoted_val)
 

--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -17,7 +17,7 @@ options {tokenVocab = OmegaConfGrammarLexer;}
 
 // Main rules used to parse OmegaConf strings.
 
-configValue: (toplevelStr | (toplevelStr? (interpolation toplevelStr?)+)) EOF;
+configValue: (toplevelStr | (toplevelStr? (interpolation toplevelStr?)+))? EOF;
 singleElement: element EOF;
 
 // Top-level string (that does not need to be parsed).


### PR DESCRIPTION
Fixes #615

Highlighting the important points of this PR:

* The main goal is to remove the "double un-escaping" of backslashes when processing quoted strings in the grammar (see #615)
* A side effect is the need to process the content of all quoted strings through the grammar. This includes the empty string, which was not allowed before (so this PR allows it as well, and adds some explicit tests for it)
* Another side effect is that grammar tests that used a dummy quoted string callback (returning the string "as is" since it doesn't contain interpolations) aren't valid anymore (since backslashes must now be properly un-escaped by this callback). So I refactored a bit the tests accordingly, splitting them by "needs callback" vs "doesn't need callback", instead of "has interpolation" vs "doesn't have interpolation" (the question of a deeper refactoring of these tests will be addressed later)