### PR TITLE
optimized list iterator some more

### DIFF
--- a/news/532.misc
+++ b/news/532.misc
@@ -1,1 +1,1 @@
-Optimized ListConfig iteration by 7.7x in a benchmark
+Optimized ListConfig iteration by 8.8x in a benchmark

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -532,12 +532,14 @@ def _get_value(value: Any) -> Any:
     from .base import Container
     from .nodes import ValueNode
 
-    if isinstance(value, Container) and (
-        value._is_none() or value._is_missing() or value._is_interpolation()
-    ):
-        return value._value()
     if isinstance(value, ValueNode):
-        value = value._value()
+        return value._value()
+    elif isinstance(value, Container):
+        boxed = value._value()
+        if boxed is None or _is_missing_literal(boxed) or _is_interpolation(boxed):
+            return boxed
+
+    # return primitives and regular OmegaConf Containers as is
     return value
 
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -124,7 +124,10 @@ class BaseContainer(Container, ABC):
         ...
 
     def __len__(self) -> int:
-        return self.__dict__["_content"].__len__()  # type: ignore
+        if self._is_none() or self._is_missing() or self._is_interpolation():
+            return 0
+        content = self.__dict__["_content"]
+        return len(content)
 
     def merge_with_cli(self) -> None:
         args_list = sys.argv[1:]

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -598,10 +598,23 @@ def test_dict_nested_structured_delitem() -> None:
     assert "name" not in c.user
 
 
-@pytest.mark.parametrize("d, expected", [({}, 0), ({"a": 10, "b": 11}, 2)])
-def test_dict_len(d: Any, expected: Any) -> None:
-    c = OmegaConf.create(d)
-    assert len(c) == expected
+@pytest.mark.parametrize(
+    "d, expected",
+    [
+        pytest.param(DictConfig({}), 0, id="empty"),
+        pytest.param(DictConfig({"a": 10}), 1, id="full"),
+        pytest.param(DictConfig(None), 0, id="none"),
+        pytest.param(DictConfig("???"), 0, id="missing"),
+        pytest.param(
+            DictConfig("${foo}", parent=OmegaConf.create({"foo": {"a": 10}})),
+            0,
+            id="interpolation",
+        ),
+        pytest.param(DictConfig("${foo}"), 0, id="broken_interpolation"),
+    ],
+)
+def test_dict_len(d: DictConfig, expected: Any) -> None:
+    assert d.__len__() == expected
 
 
 def test_dict_assign_illegal_value() -> None:


### PR DESCRIPTION
Closes #613

Second optimization pass.
This is more impressive than the 7.7 -> 8.8x recorded improvement since there seems to be a regression compares to the measurements in #533.
Speed is still not great, but I this is as close as it gets given that we are probably losing a bunch of low level optimization done on native list because we need to unbox primitive items when we iterate.

Comparing `test_list_iter[small_listconfig]` by itself to what is in master shows about 50% speedup:
![image](https://user-images.githubusercontent.com/376455/111587520-8f515300-877f-11eb-85a1-71147c6fe5b5.png)

When it's pitched against the native list iteration it's "only" 130 times slower now, compares to 180 times slower before:
![image](https://user-images.githubusercontent.com/376455/111587599-abed8b00-877f-11eb-89dd-913d7791a027.png)

By the way: here is why this is important:
https://twitter.com/jackyliang42/status/1371530444529881094