### PR TITLE
[ON HOLD] Simpler escaping in the grammar, and fix to quoted values

### DIFF
--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -21,7 +21,7 @@ configValue: (toplevelStr | (toplevelStr? (interpolation toplevelStr?)+)) EOF;
 singleElement: element EOF;
 
 // Top-level string (that does not need to be parsed).
-toplevelStr: (ESC | ESC_INTER | TOP_CHAR | TOP_STR)+;
+toplevelStr: (EVEN_BACKSLASHES | ESC_INTER | TOP_CHAR | TOP_STR)+;
 
 // Elements.
 

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -403,7 +403,7 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
                 if s.type == OmegaConfGrammarLexer.ESC:
                     chrs.append(s.text[1::2])
                 elif s.type == OmegaConfGrammarLexer.ESC_INTER:
-                    chrs.append(s.text[1:])
+                    assert False  # escaped interpolations are handled elsewhere
                 else:
                     chrs.append(s.text)
             else:


### PR DESCRIPTION
* In top-level strings, the only backslashes that can and should be
  escaped are those preceding an interpolation. For instance, if "x"
  is a node evaluating to "X":
```
        \${x}   -> ${x}
        \\${x}  -> \X
        \\\${x} -> \${x}
        ${x}\\  -> X\\
```
* In quoted strings, the only backslashes that can and should be escaped
  are those preceding a quote of the same type as the enclosing quotes.
  For instance:
```
        "abc\"def"   -> abc"def
        "abc\\"      -> abc\
        "abc\\\"def" -> abc\"def
        "abc\\\'def" -> abc\\\'def
```

This also fixes a bug with the parsing of quoted strings (see #617).

Fixes #615
Fixes #617