### PR TITLE
DictConfig.items() handles DictConfig(None) and DictConfig("???") consistently with ListConfig

### DIFF
--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -324,7 +324,8 @@ class BaseContainer(Container, ABC):
         if (dest._is_interpolation() or dest._is_missing()) and not src._is_missing():
             expand(dest)
 
-        for key, src_value in src.items_ex(resolve=False):
+        src_items = src.items_ex(resolve=False) if not src._is_missing() else []
+        for key, src_value in src_items:
             src_node = src._get_node(key, validate_access=False)
             dest_node = dest._get_node(key, validate_access=False)
             assert src_node is None or isinstance(src_node, Node)

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -607,7 +607,6 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
 
     @staticmethod
     def _list_eq(l1: Optional["ListConfig"], l2: Optional["ListConfig"]) -> bool:
-
         l1_none = l1.__dict__["_content"] is None
         l2_none = l2.__dict__["_content"] is None
         if l1_none and l2_none:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 import copy
 from typing import Any
 
-import pytest
+from pytest import fixture
 
 from omegaconf import OmegaConf
 from omegaconf.basecontainer import BaseContainer
 
 
-@pytest.fixture(scope="function")
+@fixture(scope="function")
 def restore_resolvers() -> Any:
     """
     A fixture to restore singletons state after this the function.
@@ -19,7 +19,7 @@ def restore_resolvers() -> Any:
     BaseContainer._resolvers = state
 
 
-@pytest.fixture(scope="function")
+@fixture(scope="function")
 def common_resolvers(restore_resolvers: Any) -> Any:
     """
     A fixture to register the common `identity` resolver.

--- a/tests/examples/dataclass_postponed_annotations.py
+++ b/tests/examples/dataclass_postponed_annotations.py
@@ -5,7 +5,7 @@ from __future__ import annotations  # type: ignore # noqa  # Python 3.6 linters 
 from dataclasses import dataclass, fields
 from enum import Enum
 
-import pytest
+from pytest import raises
 
 from omegaconf import OmegaConf, ValidationError
 
@@ -46,6 +46,6 @@ def conversions() -> None:
     conf.num = "20"  # type: ignore
     assert conf.num == 20
 
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         # ValidationError: "one" cannot be converted to an integer
         conf.num = "one"  # type: ignore

--- a/tests/examples/test_dataclass_example.py
+++ b/tests/examples/test_dataclass_example.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-import pytest
+from pytest import raises
 
 from omegaconf import (
     MISSING,
@@ -41,7 +41,7 @@ def test_simple_types_class() -> None:
 def test_static_typing() -> None:
     conf: SimpleTypes = OmegaConf.structured(SimpleTypes)
     assert conf.description == "text"  # passes static type checking
-    with pytest.raises(AttributeError):
+    with raises(AttributeError):
         # This will fail both the static type checking and at runtime
         # noinspection PyStatementEffect
         conf.no_such_attribute  # type: ignore
@@ -69,7 +69,7 @@ def test_conversions() -> None:
     conf.num = "20"  # type: ignore
 
     assert conf.num == 20
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         # ValidationError: "one" cannot be converted to an integer
         conf.num = "one"  # type: ignore
 
@@ -108,7 +108,7 @@ class Modifiers:
 def test_modifiers() -> None:
     conf: Modifiers = OmegaConf.structured(Modifiers)
     # regular fields cannot take None
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         conf.num = None  # type: ignore
 
     # but Optional fields can
@@ -116,7 +116,7 @@ def test_modifiers() -> None:
     assert conf.optional_num is None
 
     # Accessing a missing field will trigger MissingMandatoryValue exception
-    with pytest.raises(MissingMandatoryValue):
+    with raises(MissingMandatoryValue):
         # noinspection PyStatementEffect
         conf.another_num
 
@@ -163,11 +163,11 @@ manager:
 
     # you can assign a different object of the same type
     conf.admin = User(name="omry", height=Height.TALL)
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         # but not incompatible types
         conf.admin = 10
 
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         # You can't assign a dict even if the field matches
         conf.manager = {"name": "secret", "height": Height.TALL}
 
@@ -193,7 +193,7 @@ def test_typed_list_runtime_validation() -> None:
     conf.int_list[0] = "1000"  # also ok!
     assert conf.int_list[0] == 1000
 
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         conf.int_list[0] = "fail"
 
 
@@ -216,7 +216,7 @@ def test_typed_dict_runtime_validation() -> None:
     conf = OmegaConf.structured(Dicts)
     conf.untyped_dict["foo"] = "buzz"  # okay, list can hold any primitive type
     conf.str_to_height["Shorty"] = Height.SHORT  # Okay
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         # runtime failure, cannot convert True to Height
         conf.str_to_height["Yoda"] = True
 
@@ -232,11 +232,11 @@ def test_frozen() -> None:
     # frozen classes are read only, attempts to modify them at runtime
     # will result in a ReadonlyConfigError
     conf = OmegaConf.structured(FrozenClass)
-    with pytest.raises(ReadonlyConfigError):
+    with raises(ReadonlyConfigError):
         conf.x = 20
 
     # Read-only flag is recursive
-    with pytest.raises(ReadonlyConfigError):
+    with raises(ReadonlyConfigError):
         conf.list[0] = 20
 
 
@@ -277,7 +277,7 @@ def test_enum_key() -> None:
 def test_dict_of_objects() -> None:
     conf: WebServer = OmegaConf.structured(WebServer)
     conf.domains["blog"] = Domain(name="blog.example.com", path="/www/blog.example.com")
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         conf.domains.foo = 10  # type: ignore
 
     assert conf.domains["blog"].name == "blog.example.com"
@@ -300,7 +300,7 @@ def test_list_of_objects() -> None:
     conf.domains_list.append(
         Domain(name="blog.example.com", path="/www/blog.example.com")
     )
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         conf.domains_list.append(10)  # type: ignore
 
     assert conf.domains_list[0].name == "blog.example.com"
@@ -370,12 +370,12 @@ def test_merge_example() -> None:
         numbers: List[int] = field(default_factory=list)
 
     schema = OmegaConf.structured(MyConfig)
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         OmegaConf.merge(schema, OmegaConf.create({"log": {"rotation": "foo"}}))
 
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         cfg = schema.copy()
         cfg.numbers.append("fo")
 
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         OmegaConf.merge(schema, OmegaConf.create({"numbers": ["foo"]}))

--- a/tests/examples/test_postponed_annotations.py
+++ b/tests/examples/test_postponed_annotations.py
@@ -1,9 +1,9 @@
 import sys
 
-import pytest
+from pytest import mark
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python 3.7")
+@mark.skipif(sys.version_info < (3, 7), reason="requires Python 3.7")
 def test_simple_types_class_postponed() -> None:
     # import from a module which has `from __future__ import annotations`
     from tests.examples.dataclass_postponed_annotations import simple_types_class
@@ -11,7 +11,7 @@ def test_simple_types_class_postponed() -> None:
     simple_types_class()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python 3.7")
+@mark.skipif(sys.version_info < (3, 7), reason="requires Python 3.7")
 def test_conversions_postponed() -> None:
     # import from a module which has `from __future__ import annotations`
     from tests.examples.dataclass_postponed_annotations import conversions

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -2,7 +2,7 @@ import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import attr
-import pytest
+from pytest import importorskip
 
 from omegaconf import II, MISSING, SI
 from tests import Color
@@ -11,7 +11,7 @@ if sys.version_info >= (3, 8):  # pragma: no cover
     from typing import TypedDict
 
 # attr is a dependency of pytest which means it's always available when testing with pytest.
-pytest.importorskip("attr")
+importorskip("attr")
 
 
 class NotStructuredConfig:

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -3,7 +3,7 @@ import sys
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import pytest
+from pytest import importorskip
 
 from omegaconf import II, MISSING, SI
 from tests import Color
@@ -12,7 +12,7 @@ if sys.version_info >= (3, 8):  # pragma: no cover
     from typing import TypedDict
 
 # skip test if dataclasses are not available
-pytest.importorskip("dataclasses")
+importorskip("dataclasses")
 
 
 class NotStructuredConfig:

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -1,8 +1,7 @@
 import copy
 from typing import Any, Dict, Union
 
-import pytest
-from pytest import raises
+from pytest import mark, param, raises
 
 from omegaconf import (
     AnyNode,
@@ -22,7 +21,7 @@ from omegaconf.errors import ConfigAttributeError, ConfigKeyError, MissingMandat
 from tests import StructuredWithMissing, does_not_raise
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, key, value, expected",
     [
         # dict
@@ -48,7 +47,7 @@ def test_set_value(
     assert c == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, key, value",
     [
         # dict
@@ -63,7 +62,7 @@ def test_set_value_validation_fail(input_: Any, key: Any, value: Any) -> None:
         c[key] = value
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, key, value",
     [
         # dict
@@ -81,7 +80,7 @@ def test_replace_value_node_type_with_another(
     assert c[key] == value._value()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, is_empty",
     [
         ([], True),
@@ -95,18 +94,18 @@ def test_empty(input_: Any, is_empty: bool) -> None:
     assert c.is_empty() == is_empty
 
 
-@pytest.mark.parametrize("func", [str, repr])
-@pytest.mark.parametrize(
+@mark.parametrize("func", [str, repr])
+@mark.parametrize(
     "input_, expected",
     [
-        pytest.param([], "[]", id="list"),
-        pytest.param({}, "{}", id="dict"),
-        pytest.param([1, 2, 3], "[1, 2, 3]", id="list"),
-        pytest.param([1, 2, {"a": 3}], "[1, 2, {'a': 3}]", id="dict_in_list"),
-        pytest.param([1, 2, [10, 20]], "[1, 2, [10, 20]]", id="list_in_list"),
-        pytest.param({"b": {"b": 10}}, "{'b': {'b': 10}}", id="dict"),
-        pytest.param({"b": [1, 2, 3]}, "{'b': [1, 2, 3]}", id="list_in_dict"),
-        pytest.param(
+        param([], "[]", id="list"),
+        param({}, "{}", id="dict"),
+        param([1, 2, 3], "[1, 2, 3]", id="list"),
+        param([1, 2, {"a": 3}], "[1, 2, {'a': 3}]", id="dict_in_list"),
+        param([1, 2, [10, 20]], "[1, 2, [10, 20]]", id="list_in_list"),
+        param({"b": {"b": 10}}, "{'b': {'b': 10}}", id="dict"),
+        param({"b": [1, 2, 3]}, "{'b': [1, 2, 3]}", id="list_in_dict"),
+        param(
             StructuredWithMissing,
             (
                 "{'num': '???', 'opt_num': '???', 'dict': '???', 'opt_dict': '???', 'list': "
@@ -123,7 +122,7 @@ def test_str(func: Any, input_: Any, expected: str) -> None:
     assert string == expected
 
 
-@pytest.mark.parametrize("flag", ["readonly", "struct"])
+@mark.parametrize("flag", ["readonly", "struct"])
 def test_flag_dict(flag: str) -> None:
     c = OmegaConf.create()
     assert c._get_flag(flag) is None
@@ -135,7 +134,7 @@ def test_flag_dict(flag: str) -> None:
     assert c._get_flag(flag) is None
 
 
-@pytest.mark.parametrize("flag", ["readonly", "struct"])
+@mark.parametrize("flag", ["readonly", "struct"])
 def test_freeze_nested_dict(flag: str) -> None:
     c = OmegaConf.create({"a": {"b": 2}})
     assert not c._get_flag(flag)
@@ -166,12 +165,12 @@ def test_set_flags() -> None:
     assert not c._get_flag("readonly")
     assert c._get_flag("struct")
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         c._set_flag(["readonly", "struct"], [True, False, False])
 
 
-@pytest.mark.parametrize("no_deepcopy_set_nodes", [True, False])
-@pytest.mark.parametrize("node", [20, {"b": 10}, [1, 2]])
+@mark.parametrize("no_deepcopy_set_nodes", [True, False])
+@mark.parametrize("node", [20, {"b": 10}, [1, 2]])
 def test_get_flag_after_dict_assignment(no_deepcopy_set_nodes: bool, node: Any) -> None:
     cfg = OmegaConf.create({"c": node})
     cfg._set_flag("foo", True)
@@ -189,9 +188,7 @@ def test_get_flag_after_dict_assignment(no_deepcopy_set_nodes: bool, node: Any) 
     assert nc._get_flag("foo") is False
 
 
-@pytest.mark.parametrize(
-    "src", [[], [1, 2, 3], dict(), dict(a=10), StructuredWithMissing]
-)
+@mark.parametrize("src", [[], [1, 2, 3], dict(), dict(a=10), StructuredWithMissing])
 class TestDeepCopy:
     def test_deepcopy(self, src: Any) -> None:
         c1 = OmegaConf.create(src)
@@ -274,7 +271,7 @@ def test_deepcopy_and_merge_and_flags() -> None:
         OmegaConf.merge(c2, OmegaConf.from_dotlist(["dataset.bad_key=yes"]))
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg", [ListConfig(element_type=int, content=[]), DictConfig(content={})]
 )
 def test_deepcopy_preserves_container_type(cfg: Container) -> None:
@@ -282,24 +279,24 @@ def test_deepcopy_preserves_container_type(cfg: Container) -> None:
     assert cp._metadata.element_type == cfg._metadata.element_type
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "src, flag_name, func, expectation",
     [
-        pytest.param(
+        param(
             {},
             "struct",
             lambda c: c.__setitem__("foo", 1),
             raises(KeyError),
             id="struct_setiitem",
         ),
-        pytest.param(
+        param(
             {},
             "struct",
             lambda c: c.__setattr__("foo", 1),
             raises(AttributeError),
             id="struct_setattr",
         ),
-        pytest.param(
+        param(
             {},
             "readonly",
             lambda c: c.__setitem__("foo", 1),
@@ -333,22 +330,22 @@ def test_nested_flag_override() -> None:
 def test_multiple_flags_override() -> None:
     c = OmegaConf.create({"foo": "bar"})
     with flag_override(c, ["readonly"], True):
-        with pytest.raises(ReadonlyConfigError):
+        with raises(ReadonlyConfigError):
             c.foo = 10
 
     with flag_override(c, ["struct"], True):
-        with pytest.raises(ConfigAttributeError):
+        with raises(ConfigAttributeError):
             c.x = 10
 
     with flag_override(c, ["struct", "readonly"], True):
-        with pytest.raises(ConfigAttributeError):
+        with raises(ConfigAttributeError):
             c.x = 10
 
-        with pytest.raises(ReadonlyConfigError):
+        with raises(ReadonlyConfigError):
             c.foo = 20
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "src, func, expectation",
     [
         ({}, lambda c: c.__setitem__("foo", 1), raises(ReadonlyConfigError)),
@@ -367,7 +364,7 @@ def test_read_write_override(src: Any, func: Any, expectation: Any) -> None:
             func(c)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "src, func, expectation",
     [({}, lambda c: c.__setattr__("foo", 1), raises(AttributeError))],
 )
@@ -383,9 +380,7 @@ def test_struct_override(src: Any, func: Any, expectation: Any) -> None:
             func(c)
 
 
-@pytest.mark.parametrize(
-    "flag_name,ctx", [("struct", open_dict), ("readonly", read_write)]
-)
+@mark.parametrize("flag_name,ctx", [("struct", open_dict), ("readonly", read_write)])
 def test_open_dict_restore(flag_name: str, ctx: Any) -> None:
     """
     Tests that internal flags are restored properly when applying context on a child node
@@ -400,28 +395,28 @@ def test_open_dict_restore(flag_name: str, ctx: Any) -> None:
     assert not cfg.foo._get_node_flag(flag_name)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "copy_method",
     [
-        pytest.param(lambda x: copy.copy(x), id="copy.copy"),
-        pytest.param(lambda x: x.copy(), id="obj.copy"),
+        param(lambda x: copy.copy(x), id="copy.copy"),
+        param(lambda x: x.copy(), id="obj.copy"),
     ],
 )
 class TestCopy:
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "src",
         [
             # lists
-            pytest.param(OmegaConf.create([]), id="list_empty"),
-            pytest.param(OmegaConf.create([1, 2]), id="list"),
-            pytest.param(OmegaConf.create(["a", "b", "c"]), id="list"),
-            pytest.param(ListConfig(content=None), id="list_none"),
-            pytest.param(ListConfig(content="???"), id="list_missing"),
+            param(OmegaConf.create([]), id="list_empty"),
+            param(OmegaConf.create([1, 2]), id="list"),
+            param(OmegaConf.create(["a", "b", "c"]), id="list"),
+            param(ListConfig(content=None), id="list_none"),
+            param(ListConfig(content="???"), id="list_missing"),
             # dicts
-            pytest.param(OmegaConf.create({}), id="dict_empty"),
-            pytest.param(OmegaConf.create({"a": "b"}), id="dict"),
-            pytest.param(OmegaConf.create({"a": {"b": []}}), id="dict"),
-            pytest.param(DictConfig(content=None), id="dict_none"),
+            param(OmegaConf.create({}), id="dict_empty"),
+            param(OmegaConf.create({"a": "b"}), id="dict"),
+            param(OmegaConf.create({"a": {"b": []}}), id="dict"),
+            param(DictConfig(content=None), id="dict_none"),
         ],
     )
     def test_copy(self, copy_method: Any, src: Any) -> None:
@@ -429,10 +424,10 @@ class TestCopy:
         assert src is not cp
         assert src == cp
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "src",
         [
-            pytest.param(
+            param(
                 DictConfig(content={"a": {"c": 10}, "b": DictConfig(content="${a}")}),
                 id="dict_inter",
             )
@@ -450,7 +445,7 @@ class TestCopy:
         cp2 = copy_method(src)
         assert OmegaConf.is_interpolation(cp2, "b")
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "src,interpolating_key,interpolated_key",
         [([1, 2, "${0}"], 2, 0), ({"a": 10, "b": "${a}"}, "b", "a")],
     )
@@ -479,7 +474,7 @@ class TestCopy:
         assert cfg[0] is not cp[0]
 
 
-@pytest.mark.parametrize("copy_func", [copy.copy, copy.deepcopy])
+@mark.parametrize("copy_func", [copy.copy, copy.deepcopy])
 class TestParentAfterCopy:
     def test_dict_copy(self, copy_func: Any) -> None:
         cfg = OmegaConf.create({"a": {"b": 10}})
@@ -504,7 +499,7 @@ def test_omegaconf_init_not_implemented() -> None:
         OmegaConf()
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "query, result",
     [
         ("a", "a"),
@@ -534,7 +529,7 @@ def test_omegaconf_create() -> None:
         assert OmegaConf.create(10)  # type: ignore
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "parent, key, value, expected",
     [
         ([10, 11], 0, ["a", "b"], [["a", "b"], 11]),
@@ -551,7 +546,7 @@ def test_assign(parent: Any, key: Union[str, int], value: Any, expected: Any) ->
     assert c == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg, key, expected",
     [
         # dict
@@ -568,19 +563,19 @@ def test_get_node(cfg: Any, key: Any, expected: Any) -> None:
     assert cfg._get_node(key) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg, key",
     [
         # dict
-        pytest.param({"foo": "???"}, "foo", id="dict"),
+        param({"foo": "???"}, "foo", id="dict"),
         # list
-        pytest.param([10, "???", 30], 1, id="list_int"),
-        pytest.param([10, "???", 30], slice(1, 2), id="list_slice"),
+        param([10, "???", 30], 1, id="list_int"),
+        param([10, "???", 30], slice(1, 2), id="list_slice"),
     ],
 )
 def test_string_interpolation_with_readonly_parent(cfg: Any, key: Any) -> None:
     cfg = OmegaConf.create(cfg)
-    with pytest.raises(MissingMandatoryValue, match="Missing mandatory value"):
+    with raises(MissingMandatoryValue, match="Missing mandatory value"):
         cfg._get_node(key, throw_on_missing_value=True)
 
 

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -3,7 +3,7 @@ import re
 from textwrap import dedent
 from typing import Any, List, Optional
 
-import pytest
+from pytest import mark, param, raises
 
 from omegaconf import MISSING, AnyNode, DictConfig, ListConfig, OmegaConf, flag_override
 from omegaconf.errors import (
@@ -31,8 +31,8 @@ def test_list_of_dicts() -> None:
     assert c[1].key2 == "value2"
 
 
-@pytest.mark.parametrize("default", [None, 0, "default"])
-@pytest.mark.parametrize(
+@mark.parametrize("default", [None, 0, "default"])
+@mark.parametrize(
     ("cfg", "key"),
     [
         (["???"], 0),
@@ -46,8 +46,8 @@ def test_list_get_return_default(cfg: List[Any], key: int, default: Any) -> None
     assert val is default
 
 
-@pytest.mark.parametrize("default", [None, 0, "default"])
-@pytest.mark.parametrize(
+@mark.parametrize("default", [None, 0, "default"])
+@mark.parametrize(
     ("cfg", "key", "expected"),
     [
         (["found"], 0, "found"),
@@ -64,33 +64,33 @@ def test_list_get_do_not_return_default(
     assert val == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, expected, expected_no_resolve, list_key",
     [
-        pytest.param([1, 2], [1, 2], [1, 2], None, id="simple"),
-        pytest.param(["${1}", 2], [2, 2], ["${1}", 2], None, id="interpolation"),
-        pytest.param(
+        param([1, 2], [1, 2], [1, 2], None, id="simple"),
+        param(["${1}", 2], [2, 2], ["${1}", 2], None, id="interpolation"),
+        param(
             [ListConfig(None), ListConfig("${.2}"), [1, 2]],
             [None, ListConfig([1, 2]), ListConfig([1, 2])],
             [None, ListConfig("${.2}"), ListConfig([1, 2])],
             None,
             id="iter_over_lists",
         ),
-        pytest.param(
+        param(
             [DictConfig(None), DictConfig("${.2}"), {"a": 10}],
             [None, DictConfig({"a": 10}), DictConfig({"a": 10})],
             [None, DictConfig("${.2}"), DictConfig({"a": 10})],
             None,
             id="iter_over_dicts",
         ),
-        pytest.param(
+        param(
             ["???", ListConfig("???"), DictConfig("???")],
-            pytest.raises(MissingMandatoryValue),
+            raises(MissingMandatoryValue),
             ["???", ListConfig("???"), DictConfig("???")],
             None,
             id="iter_over_missing",
         ),
-        pytest.param(
+        param(
             {
                 "defaults": [
                     {"optimizer": "adam"},
@@ -143,7 +143,7 @@ def test_iterate_list_with_missing_interpolation() -> None:
     c = OmegaConf.create([1, "${10}"])
     itr = iter(c)
     assert 1 == next(itr)
-    with pytest.raises(InterpolationKeyError):
+    with raises(InterpolationKeyError):
         next(itr)
 
 
@@ -151,7 +151,7 @@ def test_iterate_list_with_missing() -> None:
     c = OmegaConf.create([1, "???"])
     itr = iter(c)
     assert 1 == next(itr)
-    with pytest.raises(MissingMandatoryValue):
+    with raises(MissingMandatoryValue):
         next(itr)
 
 
@@ -160,13 +160,13 @@ def test_items_with_interpolation() -> None:
     assert c == ["foo", "foo"]
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["cfg", "key", "expected_out", "expected_cfg"],
     [
-        pytest.param([1, 2, 3], 0, 1, [2, 3]),
-        pytest.param([1, 2, 3], None, 3, [1, 2]),
-        pytest.param(["???", 2, 3], 0, None, [2, 3]),
-        pytest.param([1, None, 3], 1, None, [1, 3]),
+        param([1, 2, 3], 0, 1, [2, 3]),
+        param([1, 2, 3], None, 3, [1, 2]),
+        param(["???", 2, 3], 0, None, [2, 3]),
+        param([1, None, 3], 1, None, [1, 3]),
     ],
 )
 def test_list_pop(
@@ -179,17 +179,17 @@ def test_list_pop(
     validate_list_keys(c)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["cfg", "key", "exc"],
     [
-        pytest.param([1, 2, 3], 100, IndexError),
-        pytest.param(["${4}", 2, 3], 0, InterpolationKeyError),
-        pytest.param(["${1}", "???", 3], 0, InterpolationToMissingValueError),
+        param([1, 2, 3], 100, IndexError),
+        param(["${4}", 2, 3], 0, InterpolationKeyError),
+        param(["${1}", "???", 3], 0, InterpolationToMissingValueError),
     ],
 )
 def test_list_pop_errors(cfg: List[Any], key: int, exc: type) -> None:
     c = OmegaConf.create(cfg)
-    with pytest.raises(exc):
+    with raises(exc):
         c.pop(key)
     assert c == cfg
     validate_list_keys(c)
@@ -199,7 +199,7 @@ def test_list_pop_on_unexpected_exception_not_modifying() -> None:
     src = [1, 2, 3, 4]
     c = OmegaConf.create(src)
 
-    with pytest.raises(ConfigTypeError):
+    with raises(ConfigTypeError):
         c.pop("foo")  # type: ignore
     assert c == src
 
@@ -217,20 +217,20 @@ def test_in_with_interpolation() -> None:
     assert 10 in c.a
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ("lst", "expected"),
     [
-        pytest.param(
+        param(
             ListConfig(content=None),
-            pytest.raises(
+            raises(
                 TypeError,
                 match="Cannot check if an item is in a ListConfig object representing None",
             ),
             id="ListConfig(None)",
         ),
-        pytest.param(
+        param(
             ListConfig(content="???"),
-            pytest.raises(
+            raises(
                 MissingMandatoryValue,
                 match="Cannot check if an item is in missing ListConfig",
             ),
@@ -255,7 +255,7 @@ def test_list_config_with_tuple() -> None:
 
 def test_items_on_list() -> None:
     c = OmegaConf.create([1, 2])
-    with pytest.raises(AttributeError):
+    with raises(AttributeError):
         c.items()
 
 
@@ -276,13 +276,13 @@ def test_list_delitem() -> None:
     assert c == [1, 2, 3]
     del c[0]
     assert c == [2, 3]
-    with pytest.raises(IndexError):
+    with raises(IndexError):
         del c[100]
 
     validate_list_keys(c)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "lst,expected",
     [
         (OmegaConf.create([1, 2]), 2),
@@ -298,7 +298,7 @@ def test_list_len(lst: Any, expected: Any) -> None:
 
 def test_nested_list_assign_illegal_value() -> None:
     c = OmegaConf.create({"a": [None]})
-    with pytest.raises(
+    with raises(
         UnsupportedValueType,
         match=re.escape(
             dedent(
@@ -322,22 +322,22 @@ def test_list_append() -> None:
     validate_list_keys(c)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "lc,element,expected",
     [
-        pytest.param(
+        param(
             ListConfig(content=[], element_type=int),
             "foo",
-            pytest.raises(
+            raises(
                 ValidationError,
                 match=re.escape("Value 'foo' could not be converted to Integer"),
             ),
             id="append_str_to_list[int]",
         ),
-        pytest.param(
+        param(
             ListConfig(content=[], element_type=Color),
             "foo",
-            pytest.raises(
+            raises(
                 ValidationError,
                 match=re.escape(
                     "Invalid value 'foo', expected one of [RED, GREEN, BLUE]"
@@ -345,10 +345,10 @@ def test_list_append() -> None:
             ),
             id="append_str_to_list[Color]",
         ),
-        pytest.param(
+        param(
             ListConfig(content=[], element_type=User),
             "foo",
-            pytest.raises(
+            raises(
                 ValidationError,
                 match=re.escape(
                     "Invalid type assigned : str is not a subclass of User. value: foo"
@@ -356,10 +356,10 @@ def test_list_append() -> None:
             ),
             id="append_str_to_list[User]",
         ),
-        pytest.param(
+        param(
             ListConfig(content=[], element_type=User),
             {"name": "Bond", "age": 7},
-            pytest.raises(
+            raises(
                 ValidationError,
                 match=re.escape(
                     "Invalid type assigned : dict is not a subclass of User. value: {'name': 'Bond', 'age': 7}"
@@ -367,10 +367,10 @@ def test_list_append() -> None:
             ),
             id="list:convert_dict_to_user",
         ),
-        pytest.param(
+        param(
             ListConfig(content=[], element_type=User),
             {},
-            pytest.raises(
+            raises(
                 ValidationError,
                 match=re.escape(
                     "Invalid type assigned : dict is not a subclass of User. value: {}"
@@ -387,22 +387,22 @@ def test_append_invalid_element_type(
         lc.append(element)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "lc,element,expected",
     [
-        pytest.param(
+        param(
             ListConfig(content=[], element_type=int),
             "10",
             10,
             id="list:convert_str_to_int",
         ),
-        pytest.param(
+        param(
             ListConfig(content=[], element_type=float),
             "10",
             10.0,
             id="list:convert_str_to_float",
         ),
-        pytest.param(
+        param(
             ListConfig(content=[], element_type=Color),
             "RED",
             Color.RED,
@@ -417,7 +417,7 @@ def test_append_convert(lc: ListConfig, element: Any, expected: Any) -> None:
     assert type(value) == type(expected)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "index, expected", [(slice(1, 3), [11, 12]), (slice(0, 3, 2), [10, 12]), (-1, 13)]
 )
 def test_list_index(index: Any, expected: Any) -> None:
@@ -425,7 +425,7 @@ def test_list_index(index: Any, expected: Any) -> None:
     assert c[index] == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg, expected",
     [
         (OmegaConf.create([1, 2, 3]), ["0", "1", "2"]),
@@ -443,7 +443,7 @@ def validate_list_keys(c: Any) -> None:
         assert c._get_node(i)._metadata.key == i
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, index, value, expected, expected_node_type, expectation",
     [
         (["a", "b", "c"], 1, 100, ["a", 100, "b", "c"], AnyNode, None),
@@ -488,16 +488,16 @@ def test_insert(
         assert c == expected
         assert type(c._get_node(index)) == expected_node_type
     else:
-        with pytest.raises(expectation):
+        with raises(expectation):
             c.insert(index, value)
     validate_list_keys(c)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "lst,idx,value,expectation",
     [
-        (ListConfig(content=None), 0, 10, pytest.raises(TypeError)),
-        (ListConfig(content="???"), 0, 10, pytest.raises(MissingMandatoryValue)),
+        (ListConfig(content=None), 0, 10, raises(TypeError)),
+        (ListConfig(content="???"), 0, 10, raises(MissingMandatoryValue)),
     ],
 )
 def test_insert_special_list(lst: Any, idx: Any, value: Any, expectation: Any) -> None:
@@ -505,7 +505,7 @@ def test_insert_special_list(lst: Any, idx: Any, value: Any, expectation: Any) -
         lst.insert(idx, value)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "src, append, result",
     [
         ([], [], []),
@@ -519,11 +519,11 @@ def test_extend(src: List[Any], append: List[Any], result: List[Any]) -> None:
     assert lst == result
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "src, remove, result, expectation",
     [
         ([10], 10, [], does_not_raise()),
-        ([], "oops", None, pytest.raises(ValueError)),
+        ([], "oops", None, raises(ValueError)),
         ([0, dict(a="blah"), 10], dict(a="blah"), [0, 10], does_not_raise()),
         ([1, 2, 1, 2], 2, [1, 1, 2], does_not_raise()),
     ],
@@ -536,8 +536,8 @@ def test_remove(src: List[Any], remove: Any, result: Any, expectation: Any) -> N
         assert lst == result
 
 
-@pytest.mark.parametrize("src", [[], [1, 2, 3], [None, dict(foo="bar")]])
-@pytest.mark.parametrize("num_clears", [1, 2])
+@mark.parametrize("src", [[], [1, 2, 3], [None, dict(foo="bar")]])
+@mark.parametrize("num_clears", [1, 2])
 def test_clear(src: List[Any], num_clears: int) -> None:
     lst = OmegaConf.create(src)
     for i in range(num_clears):
@@ -545,10 +545,10 @@ def test_clear(src: List[Any], num_clears: int) -> None:
     assert lst == []
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "src, item, expected_index, expectation",
     [
-        ([], 20, -1, pytest.raises(ValueError)),
+        ([], 20, -1, raises(ValueError)),
         ([10, 20], 10, 0, does_not_raise()),
         ([10, 20], 20, 1, does_not_raise()),
     ],
@@ -566,14 +566,14 @@ def test_index_with_range() -> None:
     assert lst.index(x=30) == 2
     assert lst.index(x=30, start=1) == 2
     assert lst.index(x=30, start=1, end=3) == 2
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         lst.index(x=30, start=3)
 
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         lst.index(x=30, end=2)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "src, item, count",
     [([], 10, 0), ([10], 10, 1), ([10, 2, 10], 10, 2), ([10, 2, 10], None, 0)],
 )
@@ -597,7 +597,7 @@ def test_sort() -> None:
 def test_insert_throws_not_changing_list() -> None:
     c = OmegaConf.create([])
     iv = IllegalType()
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         c.insert(0, iv)
     assert len(c) == 0
     assert c == []
@@ -610,7 +610,7 @@ def test_insert_throws_not_changing_list() -> None:
 def test_append_throws_not_changing_list() -> None:
     c = OmegaConf.create([])
     iv = IllegalType()
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         c.append(iv)
     assert len(c) == 0
     assert c == []
@@ -629,7 +629,7 @@ def test_hash() -> None:
     assert hash(c1) != hash(c2)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "in_list1, in_list2,in_expected",
     [
         ([], [], []),
@@ -665,11 +665,11 @@ def test_deep_add() -> None:
 
 def test_set_with_invalid_key() -> None:
     cfg = OmegaConf.create([1, 2, 3])
-    with pytest.raises(KeyValidationError):
+    with raises(KeyValidationError):
         cfg["foo"] = 4  # type: ignore
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "lst,idx,expected",
     [
         (OmegaConf.create([1, 2]), 0, 1),
@@ -679,13 +679,13 @@ def test_set_with_invalid_key() -> None:
 )
 def test_getitem(lst: Any, idx: Any, expected: Any) -> None:
     if isinstance(expected, type):
-        with pytest.raises(expected):
+        with raises(expected):
             lst.__getitem__(idx)
     else:
         assert lst.__getitem__(idx) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "sli",
     [
         (slice(None, None, None)),
@@ -708,7 +708,7 @@ def test_getitem_slice(sli: slice) -> None:
     assert olst.__getitem__(sli) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "lst,idx,expected",
     [
         (OmegaConf.create([1, 2]), 0, 1),
@@ -721,7 +721,7 @@ def test_getitem_slice(sli: slice) -> None:
 )
 def test_get(lst: Any, idx: Any, expected: Any) -> None:
     if isinstance(expected, type):
-        with pytest.raises(expected):
+        with raises(expected):
             lst.get(idx)
     else:
         assert lst.__getitem__(idx) == expected
@@ -730,7 +730,7 @@ def test_get(lst: Any, idx: Any, expected: Any) -> None:
 def test_getattr() -> None:
     src = ["a", "b", "c"]
     cfg = OmegaConf.create(src)
-    with pytest.raises(AttributeError):
+    with raises(AttributeError):
         getattr(cfg, "foo")
     assert getattr(cfg, "0") == src[0]
     assert getattr(cfg, "1") == src[1]
@@ -762,7 +762,7 @@ def test_shallow_copy_none() -> None:
     assert cfg._is_none()
 
 
-@pytest.mark.parametrize("flag", ["struct", "readonly"])
+@mark.parametrize("flag", ["struct", "readonly"])
 def test_listconfig_creation_with_parent_flag(flag: str) -> None:
     parent = OmegaConf.create([])
     parent._set_flag(flag, True)

--- a/tests/test_config_eq.py
+++ b/tests/test_config_eq.py
@@ -1,19 +1,19 @@
 from typing import Any
 
-import pytest
+from pytest import mark, param
 
 from omegaconf import AnyNode, DictConfig, ListConfig, OmegaConf
 from tests import Group, User
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "i1,i2",
     [
         # === LISTS ===
         # empty list
-        pytest.param([], [], id="empty"),
+        param([], [], id="empty"),
         # simple list
-        pytest.param(["a", 12, "15"], ["a", 12, "15"], id="simple_list"),
+        param(["a", 12, "15"], ["a", 12, "15"], id="simple_list"),
         # raw vs any
         ([1, 2, 12], [1, 2, AnyNode(12)]),
         # nested empty dict
@@ -42,50 +42,42 @@ from tests import Group, User
         # In python 3.6+ insert order changes iteration order. this ensures that equality is preserved.
         (dict(a=1, b=2, c=3, d=4, e=5), dict(e=5, b=2, c=3, d=4, a=1)),
         (DictConfig(content=None), DictConfig(content=None)),
-        pytest.param({"a": [1, 2]}, {"a": [1, 2]}, id="list_in_dict"),
+        param({"a": [1, 2]}, {"a": [1, 2]}, id="list_in_dict"),
         # With interpolations
         ([10, "${0}"], [10, 10]),
         (dict(a=12, b="${a}"), dict(a=12, b=12)),
         # With missing interpolation
-        pytest.param([10, "${0}"], [10, 10], id="list_simple_interpolation"),
-        pytest.param(
-            {"a": "${ref_error}"}, {"a": "${ref_error}"}, id="dict==dict,ref_error"
-        ),
-        pytest.param({"a": "???"}, {"a": "???"}, id="dict==dict,missing"),
-        pytest.param(User, User, id="User==User"),
-        pytest.param(
-            {"name": "poo", "age": 7}, User(name="poo", age=7), id="dict==User"
-        ),
-        pytest.param(Group, Group, id="Group==Group"),
-        pytest.param({"group": {"admin": None}}, {"group": Group}, id="dict==Group"),
-        pytest.param(
+        param([10, "${0}"], [10, 10], id="list_simple_interpolation"),
+        param({"a": "${ref_error}"}, {"a": "${ref_error}"}, id="dict==dict,ref_error"),
+        param({"a": "???"}, {"a": "???"}, id="dict==dict,missing"),
+        param(User, User, id="User==User"),
+        param({"name": "poo", "age": 7}, User(name="poo", age=7), id="dict==User"),
+        param(Group, Group, id="Group==Group"),
+        param({"group": {"admin": None}}, {"group": Group}, id="dict==Group"),
+        param(
             {"i1": "${n1}", "n1": {"a": 10}},
             {"i1": "${n1}", "n1": {"a": 10}},
             id="node_interpolation",
         ),
         # Inter containers
-        pytest.param(
+        param(
             {"foo": DictConfig(content="${bar}"), "bar": 10},
             {"foo": 10, "bar": 10},
             id="dictconfig_inter",
         ),
-        pytest.param(
+        param(
             {"foo": ListConfig(content="${bar}"), "bar": 10},
             {"foo": 10, "bar": 10},
             id="listconfig_inter",
         ),
         # None containers
-        pytest.param(
-            {"foo": DictConfig(content=None)}, {"foo": None}, id="dictconfig_none"
-        ),
-        pytest.param(
-            {"foo": ListConfig(content=None)}, {"foo": None}, id="listconfig_none"
-        ),
+        param({"foo": DictConfig(content=None)}, {"foo": None}, id="dictconfig_none"),
+        param({"foo": ListConfig(content=None)}, {"foo": None}, id="listconfig_none"),
         # Missing containers
-        pytest.param(
+        param(
             {"foo": DictConfig(content="???")}, {"foo": "???"}, id="dictconfig_missing"
         ),
-        pytest.param(
+        param(
             {"foo": ListConfig(content="???")}, {"foo": "???"}, id="listconfig_missing"
         ),
     ],
@@ -105,33 +97,31 @@ def test_eq(i1: Any, i2: Any) -> None:
     eq(c2, i2)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input1, input2",
     [
         # Dicts
-        pytest.param({}, {"a": 10}, id="empty_dict_neq_dict"),
-        pytest.param({}, [], id="empty_dict_vs_list"),
-        pytest.param({}, None, id="dict_neq_none"),
-        pytest.param({"foo": None}, {"foo": "bar"}, id="dict_none_neq_dict_not_none"),
-        pytest.param({"a": 12}, {"a": 13}, id="simple_dict_neq"),
-        pytest.param({"a": 0}, {"b": 0}, id="different_key_same_value"),
-        pytest.param(dict(a=12), dict(a=AnyNode(13))),
-        pytest.param(dict(a=12, b=dict()), dict(a=13, b=dict())),
-        pytest.param(dict(a=12, b=dict(c=10)), dict(a=13, b=dict(c=10))),
-        pytest.param(dict(a=12, b=[1, 2, 3]), dict(a=12, b=[10, 2, 3])),
-        pytest.param(
-            dict(a=12, b=[1, 2, AnyNode(3)]), dict(a=12, b=[1, 2, AnyNode(30)])
-        ),
+        param({}, {"a": 10}, id="empty_dict_neq_dict"),
+        param({}, [], id="empty_dict_vs_list"),
+        param({}, None, id="dict_neq_none"),
+        param({"foo": None}, {"foo": "bar"}, id="dict_none_neq_dict_not_none"),
+        param({"a": 12}, {"a": 13}, id="simple_dict_neq"),
+        param({"a": 0}, {"b": 0}, id="different_key_same_value"),
+        param(dict(a=12), dict(a=AnyNode(13))),
+        param(dict(a=12, b=dict()), dict(a=13, b=dict())),
+        param(dict(a=12, b=dict(c=10)), dict(a=13, b=dict(c=10))),
+        param(dict(a=12, b=[1, 2, 3]), dict(a=12, b=[10, 2, 3])),
+        param(dict(a=12, b=[1, 2, AnyNode(3)]), dict(a=12, b=[1, 2, AnyNode(30)])),
         # Lists
-        pytest.param([], [10], id="list:empty_vs_full"),
-        pytest.param([10], [11], id="list:different_value"),
+        param([], [10], id="list:empty_vs_full"),
+        param([10], [11], id="list:different_value"),
         ([12], [AnyNode(13)]),
         ([12, dict()], [13, dict()]),
         ([12, dict(c=10)], [13, dict(c=10)]),
         ([12, [1, 2, 3]], [12, [10, 2, 3]]),
         ([12, [1, 2, AnyNode(3)]], [12, [1, 2, AnyNode(30)]]),
         (dict(a="${foo1}"), dict(a="${foo2}")),
-        pytest.param(
+        param(
             {"i1": "${n1}", "n1": {"a": 10}},
             {"i1": "${n1}", "n1": {"a": 20}},
             id="node_interpolation",

--- a/tests/test_config_eq.py
+++ b/tests/test_config_eq.py
@@ -74,11 +74,13 @@ from tests import Group, User
         param({"foo": DictConfig(content=None)}, {"foo": None}, id="dictconfig_none"),
         param({"foo": ListConfig(content=None)}, {"foo": None}, id="listconfig_none"),
         # Missing containers
+        param(DictConfig("???"), DictConfig("???"), id="missing_dictconfig"),
+        param(ListConfig("???"), ListConfig("???"), id="missing_listconfig"),
         param(
-            {"foo": DictConfig(content="???")}, {"foo": "???"}, id="dictconfig_missing"
+            {"foo": DictConfig("???")}, {"foo": "???"}, id="nested_missing_dictconfig"
         ),
         param(
-            {"foo": ListConfig(content="???")}, {"foo": "???"}, id="listconfig_missing"
+            {"foo": ListConfig("???")}, {"foo": "???"}, id="nested_missing_listconfig"
         ),
     ],
 )

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -4,15 +4,15 @@ import sys
 from textwrap import dedent
 from typing import Any, Dict, List, Optional
 
-import pytest
 import yaml
+from pytest import mark, param, raises
 
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from omegaconf.errors import UnsupportedValueType
 from tests import ConcretePlugin, IllegalType, NonCopyableIllegalType, Plugin
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_,expected",
     [
         # No content
@@ -53,7 +53,7 @@ def test_create_value(input_: Any, expected: Any) -> None:
     assert OmegaConf.create(input_) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_",
     [
         # top level dict
@@ -81,7 +81,7 @@ def test_create_allow_objects(input_: Any) -> None:
     assert cfg == input_
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_",
     [
         # top level dict
@@ -109,11 +109,11 @@ def test_create_allow_objects_non_copyable(input_: Any) -> None:
     assert cfg == input_
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_",
     [
-        pytest.param({"foo": "bar"}, id="dict"),
-        pytest.param([1, 2, 3], id="list"),
+        param({"foo": "bar"}, id="dict"),
+        param([1, 2, 3], id="list"),
     ],
 )
 def test_create_flags_overriding(input_: Any) -> Any:
@@ -143,7 +143,7 @@ def test_cli_passing() -> None:
     assert {"a": 1, "b": {"c": 2}} == c
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_,expected",
     [
         # simple
@@ -160,23 +160,23 @@ def test_dotlist(input_: List[str], expected: Dict[str, Any]) -> None:
 
 
 def test_create_list_with_illegal_value_idx0() -> None:
-    with pytest.raises(UnsupportedValueType, match=re.escape("key: [0]")):
+    with raises(UnsupportedValueType, match=re.escape("key: [0]")):
         OmegaConf.create([IllegalType()])
 
 
 def test_create_list_with_illegal_value_idx1() -> None:
     lst = [1, IllegalType(), 3]
-    with pytest.raises(UnsupportedValueType, match=re.escape("key: [1]")):
+    with raises(UnsupportedValueType, match=re.escape("key: [1]")):
         OmegaConf.create(lst)
 
 
 def test_create_dict_with_illegal_value() -> None:
-    with pytest.raises(UnsupportedValueType, match=re.escape("key: a")):
+    with raises(UnsupportedValueType, match=re.escape("key: a")):
         OmegaConf.create({"a": IllegalType()})
 
 
 def test_create_nested_dict_with_illegal_value() -> None:
-    with pytest.raises(ValueError, match=re.escape("key: a.b")):
+    with raises(ValueError, match=re.escape("key: a.b")):
         OmegaConf.create({"a": {"b": IllegalType()}})
 
 
@@ -213,7 +213,7 @@ def test_create_from_listconfig_preserves_metadata() -> None:
     assert cfg1._metadata == cfg2._metadata
 
 
-@pytest.mark.parametrize("node", [({"bar": 10}), ([1, 2, 3])])
+@mark.parametrize("node", [({"bar": 10}), ([1, 2, 3])])
 def test_create_node_parent_retained_on_create(node: Any) -> None:
     cfg1 = OmegaConf.create({"foo": node})
     cfg2 = OmegaConf.create({"zonk": cfg1.foo})
@@ -222,7 +222,7 @@ def test_create_node_parent_retained_on_create(node: Any) -> None:
     assert cfg1.foo._get_parent() is cfg1
 
 
-@pytest.mark.parametrize("node", [({"bar": 10}), ([1, 2, 3])])
+@mark.parametrize("node", [({"bar": 10}), ([1, 2, 3])])
 def test_create_node_parent_retained_on_assign(node: Any) -> None:
     cfg1 = OmegaConf.create({"foo": node})
     cfg2 = OmegaConf.create()
@@ -231,7 +231,7 @@ def test_create_node_parent_retained_on_assign(node: Any) -> None:
     assert cfg2.zonk._get_parent() is cfg2
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "node",
     [
         {"a": 0},
@@ -245,7 +245,7 @@ def test_dict_assignment_deepcopy_semantics(node: Any) -> None:
     assert cfg.foo.a == 0
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "node",
     [
         [1, 2],
@@ -259,7 +259,7 @@ def test_list_assignment_deepcopy_semantics(node: Any) -> None:
     assert cfg.foo[1] == 2
 
 
-@pytest.mark.parametrize("d", [{"a": {"b": 10}}, {"a": {"b": {"c": 10}}}])
+@mark.parametrize("d", [{"a": {"b": 10}}, {"a": {"b": {"c": 10}}}])
 def test_assign_does_not_modify_src_config(d: Any) -> None:
     cfg1 = OmegaConf.create(d)
     cfg2 = OmegaConf.create({})
@@ -295,7 +295,7 @@ def test_create_untyped_dict() -> None:
     assert get_ref_type(cfg) == Optional[Dict]
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_",
     [
         dedent(
@@ -317,7 +317,7 @@ def test_create_untyped_dict() -> None:
     ],
 )
 def test_yaml_duplicate_keys(input_: str) -> None:
-    with pytest.raises(yaml.constructor.ConstructorError):
+    with raises(yaml.constructor.ConstructorError):
         OmegaConf.create(input_)
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,7 +4,7 @@ from enum import Enum
 from textwrap import dedent
 from typing import Any, Dict, List, Optional, Type
 
-import pytest
+from pytest import mark, param, raises
 
 import tests
 from omegaconf import (
@@ -104,7 +104,7 @@ params = [
     # DictConfig #
     ##############
     # update
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(StructuredWithMissing),
             op=lambda cfg: OmegaConf.update(cfg, "num", "hello", merge=True),
@@ -117,7 +117,7 @@ params = [
         ),
         id="structured:update_with_invalid_value",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(StructuredWithMissing),
             op=lambda cfg: OmegaConf.update(cfg, "num", None, merge=True),
@@ -130,7 +130,7 @@ params = [
         ),
         id="structured:update:none_to_non_optional",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({}),
             op=lambda cfg: OmegaConf.update(cfg, "a", IllegalType(), merge=True),
@@ -141,7 +141,7 @@ params = [
         id="dict:update:object_of_illegal_type",
     ),
     # pop
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly({"foo": "bar"}),
             op=lambda cfg: cfg.pop("foo"),
@@ -152,7 +152,7 @@ params = [
         ),
         id="dict,readonly:pop",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({"foo": "bar"}),
             op=lambda cfg: cfg.pop("not_found"),
@@ -162,7 +162,7 @@ params = [
         ),
         id="dict:pop_invalid",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({"foo": {}}),
             op=lambda cfg: cfg.foo.pop("not_found"),
@@ -174,7 +174,7 @@ params = [
         ),
         id="dict:pop_invalid_nested",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({"foo": "bar"}),
             op=lambda cfg: cfg.__delitem__("not_found"),
@@ -184,7 +184,7 @@ params = [
         ),
         id="dict:del_invalid",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({"foo": {}}),
             op=lambda cfg: cfg.foo.__delitem__("not_found"),
@@ -196,7 +196,7 @@ params = [
         ),
         id="dict:del_invalid_nested",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(ConcretePlugin),
             op=lambda cfg: getattr(cfg, "fail"),
@@ -208,7 +208,7 @@ params = [
         id="structured:access_invalid_attribute",
     ),
     # getattr
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_struct({"foo": "bar"}),
             op=lambda cfg: getattr(cfg, "fail"),
@@ -218,7 +218,7 @@ params = [
         ),
         id="dict,struct:access_invalid_attribute",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({"foo": "${missing}"}),
             op=lambda cfg: getattr(cfg, "foo"),
@@ -229,7 +229,7 @@ params = [
         ),
         id="dict,accessing_missing_interpolation",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({"foo": "foo_${missing}"}),
             op=lambda cfg: getattr(cfg, "foo"),
@@ -240,7 +240,7 @@ params = [
         ),
         id="dict,accessing_missing_str_interpolation",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({"foo": {"bar": "${.missing}"}}),
             op=lambda cfg: getattr(cfg.foo, "bar"),
@@ -253,7 +253,7 @@ params = [
         ),
         id="dict,accessing_missing_relative_interpolation",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({"foo": "${..missing}"}),
             op=lambda cfg: getattr(cfg, "foo"),
@@ -264,7 +264,7 @@ params = [
         ),
         id="dict,accessing_invalid_double_relative_interpolation",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create({"foo": "${int.missing}", "int": 0}),
             op=lambda cfg: getattr(cfg, "foo"),
@@ -278,7 +278,7 @@ params = [
         ),
         id="dict,accessing_non_container_interpolation",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create(
                 {"foo": "${${missing_val}}", "missing_val": "???"}
@@ -295,7 +295,7 @@ params = [
         id="dict,accessing_missing_nested_interpolation",
     ),
     # setattr
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_struct({"foo": "bar"}),
             op=lambda cfg: setattr(cfg, "zlonk", "zlank"),
@@ -305,7 +305,7 @@ params = [
         ),
         id="dict,struct:set_invalid_attribute",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(ConcretePlugin),
             op=lambda cfg: setattr(cfg, "params", 20),
@@ -317,7 +317,7 @@ params = [
         ),
         id="structured:setattr,invalid_type_assigned_to_structured",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly({"foo": "bar"}),
             op=lambda cfg: setattr(cfg, "foo", 20),
@@ -328,7 +328,7 @@ params = [
         ),
         id="dict,readonly:set_attribute",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create(
                 {"foo": DictConfig(is_optional=False, content={})}
@@ -342,7 +342,7 @@ params = [
         ),
         id="dict:setattr:not_optional:set_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(ConcretePlugin),
             op=lambda cfg: cfg.params.__setattr__("foo", "bar"),
@@ -358,7 +358,7 @@ params = [
         id="structured:setattr,invalid_type_assigned_to_field",
     ),
     # setitem
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_struct({"foo": "bar"}),
             op=lambda cfg: cfg.__setitem__("zoo", "zonk"),
@@ -368,7 +368,7 @@ params = [
         ),
         id="dict,struct:setitem_on_none_existing_key",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig(key_type=Color, element_type=str, content={}),
             op=lambda cfg: cfg.__setitem__("foo", "bar"),
@@ -379,7 +379,7 @@ params = [
         ),
         id="DictConfig[Color,str]:setitem_bad_key",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig(key_type=Color, element_type=str, content={}),
             op=lambda cfg: cfg.__setitem__(None, "bar"),
@@ -389,7 +389,7 @@ params = [
         ),
         id="DictConfig[Color,str]:setitem_bad_key",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig(key_type=str, element_type=Color, content={}),
             op=lambda cfg: cfg.__setitem__("foo", "bar"),
@@ -400,7 +400,7 @@ params = [
         ),
         id="DictConfig[str,Color]:setitem_bad_value",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(User),
             op=lambda cfg: cfg.__setitem__("name", [1, 2]),
@@ -413,7 +413,7 @@ params = [
         id="DictConfig[Any,Any]:setitem_stringnode_bad_value",
     ),
     # getitem
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_struct({"foo": "bar"}),
             op=lambda cfg: cfg.__getitem__("zoo"),
@@ -423,7 +423,7 @@ params = [
         ),
         id="dict,struct:getitem_key_not_in_struct",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig(key_type=Color, element_type=str, content={}),
             op=lambda cfg: cfg.__getitem__("foo"),
@@ -433,7 +433,7 @@ params = [
         ),
         id="DictConfig[Color,str]:getitem_str_key",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig(key_type=Color, element_type=str, content={}),
             op=lambda cfg: cfg.__getitem__(None),
@@ -443,7 +443,7 @@ params = [
         ),
         id="DictConfig[Color,str]:getitem_str_key_None",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig(key_type=str, element_type=str, content={}),
             op=lambda cfg: cfg.__getitem__(Color.RED),
@@ -454,7 +454,7 @@ params = [
         ),
         id="DictConfig[str,str]:getitem_color_key",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly({"foo1": "bar"}),
             op=lambda cfg: cfg.merge_with({"foo2": "bar"}),
@@ -464,7 +464,7 @@ params = [
         ),
         id="dict,readonly:merge_with",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(ConcretePlugin),
             op=lambda cfg: OmegaConf.merge(cfg, {"params": {"foo": "bar"}}),
@@ -479,7 +479,7 @@ params = [
         ),
         id="structured:merge,invalid_field_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(ConcretePlugin),
             op=lambda cfg: OmegaConf.merge(cfg, {"params": {"zlonk": 10}}),
@@ -493,7 +493,7 @@ params = [
         ),
         id="structured:merge,adding_an_invalid_key",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(Package),
             op=lambda cfg: OmegaConf.merge(cfg, {"modules": [{"foo": "var"}]}),
@@ -507,7 +507,7 @@ params = [
         id="structured:merge,bad_key_merge",
     ),
     # merge_with
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(ConcretePlugin),
             op=lambda cfg: cfg.merge_with(Plugin),
@@ -518,7 +518,7 @@ params = [
         id="structured:merge_invalid_dataclass",
     ),
     # get
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create(),
             op=lambda cfg: cfg.get(IllegalType),
@@ -529,7 +529,7 @@ params = [
         ),
         id="dict:get_illegal_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create(),
             op=lambda cfg: cfg.get(IllegalType()),
@@ -539,7 +539,7 @@ params = [
         ),
         id="dict:get_object_of_illegal_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig({}, key_type=int),
             op=lambda cfg: cfg.get("foo"),
@@ -550,7 +550,7 @@ params = [
         ),
         id="dict[int,Any]:mistyped_key",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig({}, key_type=float),
             op=lambda cfg: cfg.get("foo"),
@@ -561,7 +561,7 @@ params = [
         ),
         id="dict[float,Any]:mistyped_key",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig({}, key_type=bool),
             op=lambda cfg: cfg.get("foo"),
@@ -573,7 +573,7 @@ params = [
         id="dict[bool,Any]:mistyped_key",
     ),
     # dict:create
-    pytest.param(
+    param(
         Expected(
             create=lambda: None,
             op=lambda _: OmegaConf.structured(NotOptionalInt),
@@ -584,7 +584,7 @@ params = [
         ),
         id="dict:create_none_optional_with_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: None,
             op=lambda _: OmegaConf.structured(NotOptionalInt),
@@ -595,7 +595,7 @@ params = [
         ),
         id="dict:create:not_optional_int_field_with_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: None,
             op=lambda cfg: OmegaConf.structured(NotOptionalA),
@@ -609,7 +609,7 @@ params = [
         ),
         id="dict:create:not_optional_A_field_with_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: None,
             op=lambda cfg: OmegaConf.structured(IllegalType),
@@ -620,7 +620,7 @@ params = [
         ),
         id="dict_create_from_illegal_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: None,
             op=lambda _: OmegaConf.structured(
@@ -633,7 +633,7 @@ params = [
         ),
         id="structured:create_with_invalid_value",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: None,
             op=lambda cfg: OmegaConf.structured(IllegalType()),
@@ -644,7 +644,7 @@ params = [
         ),
         id="structured:create_from_unsupported_object",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: None,
             op=lambda cfg: OmegaConf.structured(UnionError),
@@ -655,7 +655,7 @@ params = [
         id="structured:create_with_union_error",
     ),
     # assign
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig(ref_type=ConcretePlugin, content="???"),
             op=lambda cfg: cfg._set_value(1),
@@ -666,7 +666,7 @@ params = [
         ),
         id="dict:set_value:reftype_mismatch",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: DictConfig(
                 key_type=str, element_type=int, content={"foo": 10, "bar": 20}
@@ -678,7 +678,7 @@ params = [
         ),
         id="DictConfig[str,int]:assigned_str_value",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(SubscriptedDict),
             op=lambda cfg: cfg.__setitem__("dict_str", 1),
@@ -690,7 +690,7 @@ params = [
         ),
         id="DictConfig[str,int]:assigned_primitive_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(SubscriptedDict),
             op=lambda cfg: cfg.__setitem__("dict_str", User(age=2, name="bar")),
@@ -702,7 +702,7 @@ params = [
         ),
         id="DictConfig[str,int]:assigned_structured_config",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(SubscriptedDict),
             op=lambda cfg: cfg.__setitem__("dict_int", "fail"),
@@ -714,7 +714,7 @@ params = [
         ),
         id="DictConfig[int,int]:assigned_primitive_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(SubscriptedDict),
             op=lambda cfg: cfg.__setitem__("dict_int", User(age=2, name="bar")),
@@ -727,7 +727,7 @@ params = [
         id="DictConfig[int,int]:assigned_structured_config",
     ),
     # delete
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly({"foo": "bar"}),
             op=lambda cfg: cfg.__delitem__("foo"),
@@ -738,7 +738,7 @@ params = [
         ),
         id="dict,readonly:del",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_struct({"foo": "bar"}),
             op=lambda cfg: cfg.__delitem__("foo"),
@@ -749,7 +749,7 @@ params = [
         ),
         id="dict,struct:del",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(User(name="bond")),
             op=lambda cfg: cfg.__delitem__("name"),
@@ -765,7 +765,7 @@ params = [
     # ListConfig #
     ##############
     # getattr
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([1, 2, 3]),
             op=lambda cfg: setattr(cfg, "foo", 10),
@@ -777,7 +777,7 @@ params = [
         id="list:setattr",
     ),
     # setattr
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([1, 2, 3]),
             op=lambda cfg: getattr(cfg, "foo"),
@@ -789,7 +789,7 @@ params = [
         id="list:setattr",
     ),
     # get node
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([1, 2, 3]),
             op=lambda cfg: cfg._get_node("foo"),
@@ -800,7 +800,7 @@ params = [
         ),
         id="list:get_nox_ex:invalid_index_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([1, 2, 3]),
             op=lambda cfg: cfg._get_node(20),
@@ -811,7 +811,7 @@ params = [
         ),
         id="list:get_node_ex:index_out_of_range",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content=None),
             op=lambda cfg: cfg._get_node(20),
@@ -822,7 +822,7 @@ params = [
         ),
         id="list:get_node_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content="???"),
             op=lambda cfg: cfg._get_node(20),
@@ -834,7 +834,7 @@ params = [
         id="list:get_node_missing",
     ),
     # list:create
-    pytest.param(
+    param(
         Expected(
             create=lambda: None,
             op=lambda cfg: ListConfig(is_optional=False, content=None),
@@ -847,7 +847,7 @@ params = [
         id="list:create:not_optional_with_none",
     ),
     # append
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([]),
             op=lambda cfg: cfg.append(IllegalType()),
@@ -859,7 +859,7 @@ params = [
         id="list:append_value_of_illegal_type",
     ),
     # pop
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly([1, 2, 3]),
             op=lambda cfg: cfg.pop(0),
@@ -871,7 +871,7 @@ params = [
         ),
         id="list:readonly:pop",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([1, 2, 3]),
             op=lambda cfg: cfg.pop("Invalid_key_type"),
@@ -882,7 +882,7 @@ params = [
         ),
         id="list:pop_invalid_key",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_struct({"foo": "bar"}),
             op=lambda cfg: cfg.pop("foo"),
@@ -893,7 +893,7 @@ params = [
         ),
         id="dict,struct:pop",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.structured(ConcretePlugin),
             op=lambda cfg: cfg.pop("name"),
@@ -904,7 +904,7 @@ params = [
         ),
         id="dict,structured:pop",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content=None),
             op=lambda cfg: cfg.pop(0),
@@ -915,7 +915,7 @@ params = [
         ),
         id="list:pop_from_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content="???"),
             op=lambda cfg: cfg.pop(0),
@@ -927,7 +927,7 @@ params = [
         id="list:pop_from_missing",
     ),
     # getitem
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create(["???"]),
             op=lambda cfg: cfg.__getitem__(slice(0, 1)),
@@ -939,7 +939,7 @@ params = [
         ),
         id="list:subscript_slice_with_missing",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([10, "???"]),
             op=lambda cfg: cfg.__getitem__(1),
@@ -951,7 +951,7 @@ params = [
         ),
         id="list:subscript_index_with_missing",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([1, 2, 3]),
             op=lambda cfg: cfg.__getitem__(20),
@@ -962,7 +962,7 @@ params = [
         ),
         id="list:subscript:index_out_of_range",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([1, 2, 3]),
             op=lambda cfg: cfg.__getitem__("foo"),
@@ -973,7 +973,7 @@ params = [
         ),
         id="list:getitem,illegal_key_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content=None),
             op=lambda cfg: cfg.__getitem__(0),
@@ -985,7 +985,7 @@ params = [
         id="list:getitem,illegal_key_type",
     ),
     # setitem
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([None]),
             op=lambda cfg: cfg.__setitem__(0, IllegalType()),
@@ -996,7 +996,7 @@ params = [
         ),
         id="list:setitem,illegal_value_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create([1, 2, 3]),
             op=lambda cfg: cfg.__setitem__("foo", 4),
@@ -1007,7 +1007,7 @@ params = [
         ),
         id="list:setitem,illegal_key_type",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly([1, 2, 3]),
             op=lambda cfg: cfg.__setitem__(0, 4),
@@ -1020,7 +1020,7 @@ params = [
         id="list,readonly:setitem",
     ),
     # _set_value
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(is_optional=False, element_type=int, content=[]),
             op=lambda cfg: cfg._set_value(None),
@@ -1031,7 +1031,7 @@ params = [
         ),
         id="list:create_not_optional:_set_value(None)",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content=[1, 2]),
             op=lambda cfg: cfg._set_value(True),
@@ -1044,7 +1044,7 @@ params = [
         id="list:create_not_optional:_set_value(True)",
     ),
     # assign
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(element_type=int, content=[1, 2, 3]),
             op=lambda cfg: cfg.__setitem__(0, "foo"),
@@ -1056,7 +1056,7 @@ params = [
         ),
         id="list,int_elements:assigned_str_element",
     ),
-    pytest.param(
+    param(
         Expected(
             # make sure OmegaConf.create is not losing critical metadata.
             create=lambda: OmegaConf.create(
@@ -1071,7 +1071,7 @@ params = [
         ),
         id="list,int_elements:assigned_str_element",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: OmegaConf.create(
                 [IntegerNode(is_optional=False, value=0), 2, 3]
@@ -1086,7 +1086,7 @@ params = [
         id="list,not_optional:null_assignment",
     ),
     # index
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly([1, 2, 3]),
             op=lambda cfg: cfg.index(99),
@@ -1096,7 +1096,7 @@ params = [
         id="list,readonly:index_not_found",
     ),
     # insert
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly([1, 2, 3]),
             op=lambda cfg: cfg.insert(1, 99),
@@ -1108,7 +1108,7 @@ params = [
         ),
         id="list,readonly:insert",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content=None),
             op=lambda cfg: cfg.insert(1, 99),
@@ -1119,7 +1119,7 @@ params = [
         ),
         id="list:insert_into_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content="???"),
             op=lambda cfg: cfg.insert(1, 99),
@@ -1132,7 +1132,7 @@ params = [
         id="list:insert_into_missing",
     ),
     # get
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content=None),
             op=lambda cfg: cfg.get(0),
@@ -1143,7 +1143,7 @@ params = [
         ),
         id="list:get_from_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content="???"),
             op=lambda cfg: cfg.get(0),
@@ -1155,7 +1155,7 @@ params = [
         id="list:get_from_missing",
     ),
     # sort
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly([1, 2, 3]),
             op=lambda cfg: cfg.sort(),
@@ -1164,7 +1164,7 @@ params = [
         ),
         id="list:readonly:sort",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content=None),
             op=lambda cfg: cfg.sort(),
@@ -1173,7 +1173,7 @@ params = [
         ),
         id="list:sort_from_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content="???"),
             op=lambda cfg: cfg.sort(),
@@ -1183,7 +1183,7 @@ params = [
         id="list:sort_from_missing",
     ),
     #     # iter
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly([1, 2, 3]),
             op=lambda cfg: cfg.sort(),
@@ -1192,7 +1192,7 @@ params = [
         ),
         id="list:readonly:sort",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content=None),
             op=lambda cfg: iter(cfg),
@@ -1201,7 +1201,7 @@ params = [
         ),
         id="list:iter_none",
     ),
-    pytest.param(
+    param(
         Expected(
             create=lambda: ListConfig(content="???"),
             op=lambda cfg: iter(cfg),
@@ -1211,7 +1211,7 @@ params = [
         id="list:iter_missing",
     ),
     # delete
-    pytest.param(
+    param(
         Expected(
             create=lambda: create_readonly([1, 2, 3]),
             op=lambda cfg: cfg.__delitem__(0),
@@ -1238,13 +1238,13 @@ def create_readonly(cfg: Any) -> Any:
     return cfg
 
 
-@pytest.mark.parametrize("expected", params)
+@mark.parametrize("expected", params)
 def test_errors(expected: Expected, monkeypatch: Any) -> None:
     monkeypatch.setenv("OC_CAUSE", "0")
     cfg = expected.create()
     expected.finalize(cfg)
     msg = expected.msg
-    with pytest.raises(expected.exception_type, match=re.escape(msg)) as einfo:
+    with raises(expected.exception_type, match=re.escape(msg)) as einfo:
         try:
             expected.op(cfg)
         except Exception as e:
@@ -1301,7 +1301,7 @@ def test_assertion_error() -> None:
             assert False
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "register_func", [OmegaConf.register_resolver, OmegaConf.register_new_resolver]
 )
 def test_resolver_error(restore_resolvers: Any, register_func: Any) -> None:
@@ -1316,11 +1316,11 @@ def test_resolver_error(restore_resolvers: Any, register_func: Any) -> None:
             full_key: div_by_zero
             object_type=dict"""
     )
-    with pytest.raises(InterpolationResolutionError, match=re.escape(expected_msg)):
+    with raises(InterpolationResolutionError, match=re.escape(expected_msg)):
         c.div_by_zero
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ["create_func", "arg"],
     [
         (OmegaConf.create, {"a": "${b"}),
@@ -1329,7 +1329,7 @@ def test_resolver_error(restore_resolvers: Any, register_func: Any) -> None:
     ],
 )
 def test_parse_error_on_creation(create_func: Any, arg: Any) -> None:
-    with pytest.raises(
+    with raises(
         GrammarParseError, match=re.escape("no viable alternative at input '${b'")
     ):
         create_func(arg)
@@ -1340,7 +1340,7 @@ def test_cycle_when_iterating_over_parents() -> None:
     x_node = c._get_node("x")
     assert isinstance(x_node, DictConfig)
     c._set_parent(x_node)
-    with pytest.raises(
+    with raises(
         OmegaConfBaseException,
         match=re.escape("Cycle when iterating over parents of key `x`"),
     ):
@@ -1365,5 +1365,5 @@ def test_get_full_key_failure_in_format_and_raise() -> None:
         "Cycle when iterating over parents of key `x`>"
     )
 
-    with pytest.raises(RecursionError, match=match):
+    with raises(RecursionError, match=match):
         c.x

--- a/tests/test_get_full_key.py
+++ b/tests/test_get_full_key.py
@@ -1,12 +1,12 @@
 from typing import Any
 
-import pytest
+from pytest import mark, param
 
 from omegaconf import DictConfig, IntegerNode, OmegaConf
 from tests import Color
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg, select, key, expected",
     [
         ({}, "", "a", "a"),
@@ -71,14 +71,14 @@ from tests import Color
         ({"foo": IntegerNode(value=10)}, "", "foo", "foo"),
         ({"foo": {"bar": IntegerNode(value=10)}}, "foo", "bar", "foo.bar"),
         # enum
-        pytest.param(
+        param(
             DictConfig(key_type=Color, element_type=str, content={Color.RED: "red"}),
             "RED",
             "",
             "RED",
             id="get_full_key_with_enum_key",
         ),
-        pytest.param(
+        param(
             {
                 "foo": DictConfig(
                     key_type=Color, element_type=str, content={Color.RED: "red"}

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -2,7 +2,7 @@ import copy
 import re
 from typing import Any, Optional
 
-import pytest
+from pytest import mark, raises, warns
 
 from omegaconf import (
     BooleanNode,
@@ -45,7 +45,7 @@ def verify(
         assert cfg.get(key) == exp
 
     assert OmegaConf.is_missing(cfg, key) == missing
-    with pytest.warns(UserWarning):
+    with warns(UserWarning):
         assert OmegaConf.is_none(cfg, key) == none_public
     assert OmegaConf.is_optional(cfg, key) == opt
     assert OmegaConf.is_interpolation(cfg, key) == inter
@@ -53,7 +53,7 @@ def verify(
 
 # for each type Node type : int, bool, str, float, Color (enum) and User (@dataclass), DictConfig, ListConfig
 #   for each MISSING, None, Optional and interpolation:
-@pytest.mark.parametrize(
+@mark.parametrize(
     "node_type, values",
     [
         (BooleanNode, [True, False]),
@@ -111,10 +111,10 @@ class TestNodeTypesMatrix:
             cfg = OmegaConf.create(obj=data)
             verify(cfg, "node", none=False, opt=False, missing=False, inter=False)
             msg = "child 'node' is not Optional"
-            with pytest.raises(ValidationError, match=re.escape(msg)):
+            with raises(ValidationError, match=re.escape(msg)):
                 cfg.node = None
 
-            with pytest.raises(ValidationError):
+            with raises(ValidationError):
                 OmegaConf.merge(cfg, {"node": None})
 
     def test_dict_non_none_assignment(self, node_type: Any, values: Any) -> None:
@@ -143,7 +143,7 @@ class TestNodeTypesMatrix:
             cfg = OmegaConf.create([d])
             verify(cfg, key, none=False, opt=False, missing=False, inter=False)
 
-            with pytest.raises(ValidationError):
+            with raises(ValidationError):
                 cfg[key] = None
 
     def test_list_non_none_assignment(self, node_type: Any, values: Any) -> None:
@@ -172,10 +172,10 @@ class TestNodeTypesMatrix:
             assert not node.__eq__(None)
             assert not node._is_none()
 
-        with pytest.raises(ValidationError):
+        with raises(ValidationError):
             node_type(value=None, is_optional=False)
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "register_func", [OmegaConf.register_resolver, OmegaConf.register_new_resolver]
     )
     def test_interpolation(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -2,7 +2,7 @@ import copy
 import sys
 from typing import Any, Dict, List, MutableMapping, MutableSequence, Tuple, Union
 
-import pytest
+from pytest import mark, param, raises
 
 from omegaconf import (
     MISSING,
@@ -35,23 +35,21 @@ from tests import (
 )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ("merge_function", "input_unchanged"),
     [
-        pytest.param(OmegaConf.merge, True, id="merge"),
-        pytest.param(OmegaConf.unsafe_merge, False, id="unsafe_merge"),
+        param(OmegaConf.merge, True, id="merge"),
+        param(OmegaConf.unsafe_merge, False, id="unsafe_merge"),
     ],
 )
-@pytest.mark.parametrize(
+@mark.parametrize(
     "inputs, expected",
     [
         # dictionaries
-        pytest.param([{}, {"a": 1}], {"a": 1}, id="dict"),
-        pytest.param(
-            [{"a": None}, {"b": None}], {"a": None, "b": None}, id="dict:none"
-        ),
-        pytest.param([{"a": 1}, {"b": 2}], {"a": 1, "b": 2}, id="dict"),
-        pytest.param(
+        param([{}, {"a": 1}], {"a": 1}, id="dict"),
+        param([{"a": None}, {"b": None}], {"a": None, "b": None}, id="dict:none"),
+        param([{"a": 1}, {"b": 2}], {"a": 1, "b": 2}, id="dict"),
+        param(
             [
                 {"a": {"a1": 1, "a2": 2}},
                 {"a": {"a1": 2}},
@@ -59,40 +57,38 @@ from tests import (
             {"a": {"a1": 2, "a2": 2}},
             id="dict",
         ),
-        pytest.param([{"a": 1, "b": 2}, {"b": 3}], {"a": 1, "b": 3}, id="dict"),
-        pytest.param(
+        param([{"a": 1, "b": 2}, {"b": 3}], {"a": 1, "b": 3}, id="dict"),
+        param(
             ({"a": 1}, {"a": {"b": 3}}), {"a": {"b": 3}}, id="dict:merge_dict_into_int"
         ),
-        pytest.param(({"b": {"c": 1}}, {"b": 1}), {"b": 1}, id="dict:merge_int_dict"),
-        pytest.param(({"list": [1, 2, 3]}, {"list": [4, 5, 6]}), {"list": [4, 5, 6]}),
-        pytest.param(({"a": 1}, {"a": IntegerNode(10)}), {"a": 10}),
-        pytest.param(({"a": 1}, {"a": IntegerNode(10)}), {"a": IntegerNode(10)}),
-        pytest.param(({"a": IntegerNode(10)}, {"a": 1}), {"a": 1}),
-        pytest.param(({"a": IntegerNode(10)}, {"a": 1}), {"a": IntegerNode(1)}),
-        pytest.param(
-            ({"a": "???"}, {"a": {}}), {"a": {}}, id="dict_merge_into_missing"
-        ),
-        pytest.param(
+        param(({"b": {"c": 1}}, {"b": 1}), {"b": 1}, id="dict:merge_int_dict"),
+        param(({"list": [1, 2, 3]}, {"list": [4, 5, 6]}), {"list": [4, 5, 6]}),
+        param(({"a": 1}, {"a": IntegerNode(10)}), {"a": 10}),
+        param(({"a": 1}, {"a": IntegerNode(10)}), {"a": IntegerNode(10)}),
+        param(({"a": IntegerNode(10)}, {"a": 1}), {"a": 1}),
+        param(({"a": IntegerNode(10)}, {"a": 1}), {"a": IntegerNode(1)}),
+        param(({"a": "???"}, {"a": {}}), {"a": {}}, id="dict_merge_into_missing"),
+        param(
             ({"a": "???"}, {"a": {"b": 10}}),
             {"a": {"b": 10}},
             id="dict_merge_into_missing",
         ),
-        pytest.param(
+        param(
             ({"a": {"b": 10}}, {"a": "???"}),
             {"a": {"b": 10}},
             id="dict_merge_missing_onto",
         ),
-        pytest.param(
+        param(
             ({"a": {"b": 10}}, {"a": DictConfig(content="???")}),
             {"a": {"b": 10}},
             id="dict_merge_missing_onto",
         ),
-        pytest.param(
+        param(
             ({}, {"a": "???"}),
             {"a": "???"},
             id="dict_merge_missing_onto_no_node",
         ),
-        pytest.param(
+        param(
             (
                 {"a": 0, "b": 1},
                 {"a": "${b}", "b": "???"},
@@ -100,7 +96,7 @@ from tests import (
             {"a": "${b}", "b": 1},
             id="dict_merge_inter_to_missing",
         ),
-        pytest.param(
+        param(
             (
                 {"a": [0], "b": [1]},
                 {"a": ListConfig(content="${b}"), "b": "???"},
@@ -112,83 +108,81 @@ from tests import (
         (([1, 2, 3], [4, 5, 6]), [4, 5, 6]),
         (([[1, 2, 3]], [[4, 5, 6]]), [[4, 5, 6]]),
         (([1, 2, {"a": 10}], [4, 5, {"b": 20}]), [4, 5, {"b": 20}]),
-        pytest.param(
-            ({"a": "???"}, {"a": []}), {"a": []}, id="list_merge_into_missing"
-        ),
-        pytest.param(
+        param(({"a": "???"}, {"a": []}), {"a": []}, id="list_merge_into_missing"),
+        param(
             ({"a": "???"}, {"a": [1, 2, 3]}),
             {"a": [1, 2, 3]},
             id="list_merge_into_missing",
         ),
-        pytest.param(
+        param(
             ({"a": [1, 2, 3]}, {"a": "???"}),
             {"a": [1, 2, 3]},
             id="list_merge_missing_onto",
         ),
-        pytest.param(
+        param(
             ([1, 2, 3], ListConfig(content=MISSING)),
             ListConfig(content=[1, 2, 3]),
             id="list_merge_missing_onto",
         ),
-        pytest.param(
+        param(
             ({"a": 10, "list": []}, {"list": ["${a}"]}),
             {"a": 10, "list": [10]},
             id="merge_list_with_interpolation",
         ),
         # Interpolations
         # value interpolation
-        pytest.param(
+        param(
             ({"d1": 1, "inter": "${d1}"}, {"d1": 2}),
             {"d1": 2, "inter": 2},
             id="inter:updating_data",
         ),
-        pytest.param(
+        param(
             ({"d1": 1, "d2": 2, "inter": "${d1}"}, {"inter": "${d2}"}),
             {"d1": 1, "d2": 2, "inter": 2},
             id="inter:value_inter_over_value_inter",
         ),
-        pytest.param(
+        param(
             ({"inter": "${d1}"}, {"inter": 123}),
             {"inter": 123},
             id="inter:data_over_value_inter",
         ),
-        pytest.param(
+        param(
             ({"inter": "${d1}", "d1": 1, "n1": {"foo": "bar"}}, {"inter": "${n1}"}),
             {"inter": {"foo": "bar"}, "d1": 1, "n1": {"foo": "bar"}},
             id="inter:node_inter_over_value_inter",
         ),
-        pytest.param(
+        param(
             ({"inter": 123}, {"inter": "${data}"}),
             {"inter": "${data}"},
             id="inter:inter_over_data",
         ),
         # node interpolation
-        pytest.param(
+        param(
             ({"n": {"a": 10}, "i": "${n}"}, {"n": {"a": 20}}),
             {"n": {"a": 20}, "i": {"a": 20}},
             id="node_inter:node_update",
         ),
-        pytest.param(
+        param(
             ({"d": 20, "n": {"a": 10}, "i": "${n}"}, {"i": "${d}"}),
             {"d": 20, "n": {"a": 10}, "i": 20},
             id="node_inter:value_inter_over_node_inter",
         ),
-        pytest.param(
+        param(
             ({"n": {"a": 10}, "i": "${n}"}, {"i": 30}),
             {"n": {"a": 10}, "i": 30},
             id="node_inter:data_over_node_inter",
         ),
-        pytest.param(
+        param(
             ({"n1": {"a": 10}, "n2": {"b": 20}, "i": "${n1}"}, {"i": "${n2}"}),
             {"n1": {"a": 10}, "n2": {"b": 20}, "i": {"b": 20}},
             id="node_inter:node_inter_over_node_inter",
         ),
-        pytest.param(
+        param(
             ({"v": 10, "n": {"a": 20}}, {"v": "${n}"}),
             {"v": {"a": 20}, "n": {"a": 20}},
             id="inter:node_inter_over_data",
         ),
-        pytest.param(
+        param(
             (
                 {"n": {"a": 10}, "i": "${n}"},
                 {"i": {"b": 20}},
@@ -218,46 +212,46 @@ from tests import (
             [Users, {"name2user": {"joe": User(name="joe")}}],
             {"name2user": {"joe": {"name": "joe", "age": MISSING}}},
         ),
-        pytest.param(
+        param(
             [Users, {"name2user": {"joe": {"name": "joe"}}}],
             {"name2user": {"joe": {"name": "joe", "age": MISSING}}},
             id="users_merge_with_missing_age",
         ),
-        pytest.param(
+        param(
             [ConfWithMissingDict, {"dict": {"foo": "bar"}}],
             {"dict": {"foo": "bar"}},
             id="conf_missing_dict",
         ),
-        pytest.param(
+        param(
             [{}, ConfWithMissingDict],
             {"dict": "???"},
             id="merge_missing_dict_into_missing_dict",
         ),
-        pytest.param(
+        param(
             [{"user": User}, {"user": Group}],
-            pytest.raises(ValidationError),
+            raises(ValidationError),
             id="merge_group_onto_user_error",
         ),
-        pytest.param(
+        param(
             [Plugin, ConcretePlugin], ConcretePlugin, id="merge_subclass_on_superclass"
         ),
-        pytest.param(
+        param(
             [{"user": "???"}, {"user": Group}],
             {"user": Group},
             id="merge_into_missing_node",
         ),
-        pytest.param(
+        param(
             [{"admin": {"name": "joe", "age": 42}}, Group(admin=None)],
             {"admin": None},
             id="merge_none_into_existing_node",
         ),
-        pytest.param(
+        param(
             [{"user": User()}, {"user": {"foo": "bar"}}],
-            pytest.raises(ConfigKeyError),
+            raises(ConfigKeyError),
             id="merge_unknown_key_into_structured_node",
         ),
         # DictConfig with element_type of Structured Config
-        pytest.param(
+        param(
             (
                 DictConfig({}, element_type=User),
                 {"user007": {"age": 99}},
@@ -265,7 +259,7 @@ from tests import (
             {"user007": {"name": "???", "age": 99}},
             id="dict:merge_into_sc_element_type:expanding_new_element",
         ),
-        pytest.param(
+        param(
             (
                 DictConfig({"user007": "???"}, element_type=User),
                 {"user007": {"age": 99}},
@@ -273,7 +267,7 @@ from tests import (
             {"user007": {"name": "???", "age": 99}},
             id="dict:merge_into_sc_element_type:into_missing_element",
         ),
-        pytest.param(
+        param(
             (
                 DictConfig({"user007": User("bond", 7)}, element_type=User),
                 {"user007": {"age": 99}},
@@ -281,7 +275,7 @@ from tests import (
             {"user007": {"name": "bond", "age": 99}},
             id="dict:merge_into_sc_element_type:merging_with_existing_element",
         ),
-        pytest.param(
+        param(
             (
                 DictConfig({"user007": None}, element_type=User),
                 {"user007": {"age": 99}},
@@ -290,51 +284,49 @@ from tests import (
             id="dict:merge_into_sc_element_type:merging_into_none",
         ),
         # missing DictConfig
-        pytest.param(
+        param(
             [{"dict": DictConfig(content="???")}, {"dict": {"foo": "bar"}}],
             {"dict": {"foo": "bar"}},
             id="merge_into_missing_DictConfig",
         ),
         # missing Dict[str, str]
-        pytest.param(
+        param(
             [MissingDict, {"dict": {"foo": "bar"}}],
             {"dict": {"foo": "bar"}},
             id="merge_into_missing_Dict[str,str]",
         ),
         # missing ListConfig
-        pytest.param(
+        param(
             [{"list": ListConfig(content="???")}, {"list": [1, 2, 3]}],
             {"list": [1, 2, 3]},
             id="merge_into_missing_ListConfig",
         ),
         # missing List[str]
-        pytest.param(
+        param(
             [MissingList, {"list": ["a", "b", "c"]}],
             {"list": ["a", "b", "c"]},
             id="merge_into_missing_List[str]",
         ),
         # merging compatible dict into MISSING structured config expands it
         # to ensure the resulting node follows the protocol set by the underlying type
-        pytest.param(
-            [B, {"x": {}}], {"x": {"a": 10}}, id="structured_merge_into_missing"
-        ),
-        pytest.param(
+        param([B, {"x": {}}], {"x": {"a": 10}}, id="structured_merge_into_missing"),
+        param(
             [B, {"x": {"a": 20}}], {"x": {"a": 20}}, id="structured_merge_into_missing"
         ),
-        pytest.param([C, {"x": A}], {"x": {"a": 10}}, id="structured_merge_into_none"),
-        pytest.param([C, C], {"x": None}, id="none_not_expanding"),
+        param([C, {"x": A}], {"x": {"a": 10}}, id="structured_merge_into_none"),
+        param([C, C], {"x": None}, id="none_not_expanding"),
         # Merge into list with Structured Config
-        pytest.param(
+        param(
             [ListConfig(content=[], element_type=User), [{}]],
             [User()],
             id="list_sc_element_merge_dict",
         ),
-        pytest.param(
+        param(
             [ListConfig(content=[], element_type=User), [{"name": "Bond", "age": 7}]],
             [User(name="Bond", age=7)],
             id="list_sc_element_merge_dict",
         ),
-        pytest.param(
+        param(
             [ListConfig(content=[], element_type=User), [{"name": "Bond"}]],
             [User(name="Bond", age=MISSING)],
             id="list_sc_element_merge_dict",
@@ -369,12 +361,12 @@ def test_merge(
 
 def test_merge_error_retains_type() -> None:
     cfg = OmegaConf.structured(ConcretePlugin)
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         cfg.merge_with({"params": {"foo": "error"}})
     assert OmegaConf.get_type(cfg) == ConcretePlugin
 
 
-@pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
 def test_primitive_dicts(merge: Any) -> None:
     c1 = {"a": 10}
     c2 = {"b": 20}
@@ -382,8 +374,8 @@ def test_primitive_dicts(merge: Any) -> None:
     assert merged == {"a": 10, "b": 20}
 
 
-@pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
-@pytest.mark.parametrize("a_, b_, expected", [((1, 2, 3), (4, 5, 6), [4, 5, 6])])
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize("a_, b_, expected", [((1, 2, 3), (4, 5, 6), [4, 5, 6])])
 def test_merge_no_eq_verify(
     merge: Any, a_: Tuple[int], b_: Tuple[int], expected: Tuple[int]
 ) -> None:
@@ -394,7 +386,7 @@ def test_merge_no_eq_verify(
     assert expected == c
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "c1,c2,expected",
     [({}, {"a": 1, "b": 2}, {"a": 1, "b": 2}), ({"a": 1}, {"b": 2}, {"a": 1, "b": 2})],
 )
@@ -405,7 +397,7 @@ def test_merge_with(c1: Any, c2: Any, expected: Any) -> None:
     assert a == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "c1,c2,expected",
     [({}, {"a": 1, "b": 2}, {"a": 1, "b": 2}), ({"a": 1}, {"b": 2}, {"a": 1, "b": 2})],
 )
@@ -418,7 +410,7 @@ def test_merge_with_c2_readonly(c1: Any, c2: Any, expected: Any) -> None:
     assert OmegaConf.is_readonly(a)
 
 
-@pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
 def test_3way_dict_merge(merge: Any) -> None:
     c1 = OmegaConf.create("{a: 1, b: 2}")
     c2 = OmegaConf.create("{b: 3}")
@@ -434,8 +426,8 @@ def test_merge_list_list() -> None:
     assert a == b
 
 
-@pytest.mark.parametrize("merge_func", [OmegaConf.merge, OmegaConf.unsafe_merge])
-@pytest.mark.parametrize(
+@mark.parametrize("merge_func", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize(
     "base, merge, exception",
     [
         ({}, [], TypeError),
@@ -448,16 +440,16 @@ def test_merge_list_list() -> None:
 def test_merge_error(merge_func: Any, base: Any, merge: Any, exception: Any) -> None:
     base = OmegaConf.create(base)
     merge = None if merge is None else OmegaConf.create(merge)
-    with pytest.raises(exception):
+    with raises(exception):
         merge_func(base, merge)
 
 
-@pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
-@pytest.mark.parametrize(
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize(
     "c1, c2",
     [
-        pytest.param({"foo": "bar"}, {"zoo": "foo"}, id="dict"),
-        pytest.param([1, 2, 3], [4, 5, 6], id="list"),
+        param({"foo": "bar"}, {"zoo": "foo"}, id="dict"),
+        param([1, 2, 3], [4, 5, 6], id="list"),
     ],
 )
 def test_with_readonly_c1(merge: Any, c1: Any, c2: Any) -> None:
@@ -468,12 +460,12 @@ def test_with_readonly_c1(merge: Any, c1: Any, c2: Any) -> None:
     assert OmegaConf.is_readonly(cfg3)
 
 
-@pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
-@pytest.mark.parametrize(
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize(
     "c1, c2",
     [
-        pytest.param({"foo": "bar"}, {"zoo": "foo"}, id="dict"),
-        pytest.param([1, 2, 3], [4, 5, 6], id="list"),
+        param({"foo": "bar"}, {"zoo": "foo"}, id="dict"),
+        param([1, 2, 3], [4, 5, 6], id="list"),
     ],
 )
 def test_with_readonly_c2(merge: Any, c1: Any, c2: Any) -> None:
@@ -484,18 +476,16 @@ def test_with_readonly_c2(merge: Any, c1: Any, c2: Any) -> None:
     assert OmegaConf.is_readonly(cfg3)
 
 
-@pytest.mark.parametrize(
-    "c1, c2", [({"foo": "bar"}, {"zoo": "foo"}), ([1, 2, 3], [4, 5, 6])]
-)
+@mark.parametrize("c1, c2", [({"foo": "bar"}, {"zoo": "foo"}), ([1, 2, 3], [4, 5, 6])])
 def test_into_readonly(c1: Any, c2: Any) -> None:
     cfg = OmegaConf.create(c1)
     OmegaConf.set_readonly(cfg, True)
-    with pytest.raises(ReadonlyConfigError):
+    with raises(ReadonlyConfigError):
         cfg.merge_with(c2)
 
 
-@pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
-@pytest.mark.parametrize(
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize(
     "c1, c2, expected",
     [
         (
@@ -511,14 +501,14 @@ def test_dict_merge_readonly_into_readwrite(
     c1 = OmegaConf.create(c1)
     c2 = OmegaConf.create(c2)
     OmegaConf.set_readonly(c2.node, True)
-    with pytest.raises(ReadonlyConfigError):
+    with raises(ReadonlyConfigError):
         c2.node.foo = 10
     assert OmegaConf.merge(c1, c2) == expected
     c1.merge_with(c2)
     assert c1 == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "c1, c2, expected",
     [({"node": [1, 2, 3]}, {"node": [4, 5, 6]}, {"node": [4, 5, 6]})],
 )
@@ -526,7 +516,7 @@ def test_list_merge_readonly_into_readwrite(c1: Any, c2: Any, expected: Any) -> 
     c1 = OmegaConf.create(c1)
     c2 = OmegaConf.create(c2)
     OmegaConf.set_readonly(c2.node, True)
-    with pytest.raises(ReadonlyConfigError):
+    with raises(ReadonlyConfigError):
         c2.node.append(10)
     assert OmegaConf.merge(c1, c2) == expected
     c1.merge_with(c2)
@@ -546,7 +536,7 @@ def test_parent_maintained() -> None:
     assert c3.a._get_parent() is c3
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg,overrides,expected",
     [
         ([1, 2, 3], ["0=bar", "2.a=100"], ["bar", 2, dict(a=100)]),
@@ -571,7 +561,7 @@ def test_merge_with_cli() -> None:
     assert c == ["bar", 2, dict(a=100)]
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "dotlist, expected",
     [([], {}), (["foo=1"], {"foo": 1}), (["foo=1", "bar"], {"foo": 1, "bar": None})],
 )
@@ -581,18 +571,18 @@ def test_merge_empty_with_dotlist(dotlist: List[str], expected: Dict[str, Any]) 
     assert c == expected
 
 
-@pytest.mark.parametrize("dotlist", ["foo=10", ["foo=1", 10]])
+@mark.parametrize("dotlist", ["foo=10", ["foo=1", 10]])
 def test_merge_with_dotlist_errors(dotlist: List[str]) -> None:
     c = OmegaConf.create()
-    with pytest.raises(ValueError):
+    with raises(ValueError):
         c.merge_with_dotlist(dotlist)
 
 
-@pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
 def test_merge_allow_objects(merge: Any) -> None:
     iv = IllegalType()
     cfg = OmegaConf.create({"a": 10})
-    with pytest.raises(UnsupportedValueType):
+    with raises(UnsupportedValueType):
         merge(cfg, {"foo": iv})
 
     cfg._set_flag("allow_objects", True)
@@ -606,18 +596,18 @@ def test_merge_with_allow_Dataframe() -> None:
     assert isinstance(ret.a, Dataframe)
 
 
-@pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
-@pytest.mark.parametrize(
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize(
     "dst, other, expected, node",
     [
-        pytest.param(
+        param(
             OmegaConf.structured(InterpolationList),
             OmegaConf.create({"list": [0.1]}),
             {"list": [0.1]},
             "list",
             id="merge_interpolation_list_with_list",
         ),
-        pytest.param(
+        param(
             OmegaConf.structured(InterpolationDict),
             OmegaConf.create({"dict": {"a": 4}}),
             {"dict": {"a": 4}},
@@ -633,17 +623,17 @@ def test_merge_with_src_as_interpolation(
     assert res == expected
 
 
-@pytest.mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
-@pytest.mark.parametrize(
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize(
     "dst, other, node",
     [
-        pytest.param(
+        param(
             OmegaConf.structured(InterpolationDict),
             OmegaConf.structured(InterpolationDict),
             "dict",
             id="merge_interpolation_dict_with_interpolation_dict",
         ),
-        pytest.param(
+        param(
             OmegaConf.structured(InterpolationList),
             OmegaConf.structured(InterpolationList),
             "list",
@@ -658,10 +648,10 @@ def test_merge_with_other_as_interpolation(
     assert OmegaConf.is_interpolation(res, node)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ("c1", "c2"),
     [
-        pytest.param(
+        param(
             ListConfig(content=[1, 2, 3], element_type=int),
             ["a", "b", "c"],
             id="merge_with_list",
@@ -670,12 +660,12 @@ def test_merge_with_other_as_interpolation(
 )
 def test_merge_with_error_not_changing_target(c1: Any, c2: Any) -> Any:
     backup = copy.deepcopy(c1)
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         c1.merge_with(c2)
     assert c1 == backup
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "register_func", [OmegaConf.register_resolver, OmegaConf.register_new_resolver]
 )
 def test_into_custom_resolver_that_throws(

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -3,7 +3,7 @@ import re
 from enum import Enum
 from typing import Any, Dict, Tuple, Type
 
-import pytest
+from pytest import mark, raises
 
 from omegaconf import (
     AnyNode,
@@ -27,7 +27,7 @@ from tests import Color, IllegalType, User
 
 
 # testing valid conversions
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_,input_,output_",
     [
         # string
@@ -86,7 +86,7 @@ def test_valid_inputs(type_: type, input_: Any, output_: Any) -> None:
 
 
 # testing invalid conversions
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_,input_",
     [
         (IntegerNode, "abc"),
@@ -122,13 +122,13 @@ def test_valid_inputs(type_: type, input_: Any, output_: Any) -> None:
 def test_invalid_inputs(type_: type, input_: Any) -> None:
     empty_node = type_()
 
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         empty_node._set_value(input_)
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         type_(input_)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, expected_type",
     [
         ({}, DictConfig),
@@ -197,14 +197,14 @@ def test_list_integer_rejects_string() -> None:
     assert isinstance(c, ListConfig)
     c.append(IntegerNode(10))
     assert c.get(0) == 10
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         c[0] = "string"
     assert c[0] == 10
     assert type(c._get_node(0)) == IntegerNode
 
 
 # Test merge raises validation error
-@pytest.mark.parametrize(
+@mark.parametrize(
     "c1, c2",
     [
         (dict(a=IntegerNode(10)), dict(a="str")),
@@ -216,14 +216,14 @@ def test_list_integer_rejects_string() -> None:
 def test_merge_validation_error(c1: Dict[str, Any], c2: Dict[str, Any]) -> None:
     conf1 = OmegaConf.create(c1)
     conf2 = OmegaConf.create(c2)
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         OmegaConf.merge(conf1, conf2)
     # make sure that conf1 and conf2 were not modified
     assert conf1 == OmegaConf.create(c1)
     assert conf2 == OmegaConf.create(c2)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_,valid_value, invalid_value",
     [
         (IntegerNode, 1, "invalid"),
@@ -252,7 +252,7 @@ def test_accepts_mandatory_missing(
     assert conf.foo == valid_value
 
     if invalid_value is not None:
-        with pytest.raises(ValidationError):
+        with raises(ValidationError):
             conf.foo = invalid_value
 
 
@@ -266,10 +266,10 @@ class Enum2(Enum):
     NOT_BAR = 2
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "type_", [BooleanNode, EnumNode, FloatNode, IntegerNode, StringNode, AnyNode]
 )
-@pytest.mark.parametrize(
+@mark.parametrize(
     "values, success_map",
     [
         (
@@ -333,11 +333,11 @@ def test_legal_assignment(
             node = type_(value)
             assert node._value() == expected
         else:
-            with pytest.raises(ValidationError):
+            with raises(ValidationError):
                 type_(value)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "node,value",
     [
         (IntegerNode(), "foo"),
@@ -347,14 +347,14 @@ def test_legal_assignment(
     ],
 )
 def test_illegal_assignment(node: ValueNode, value: Any) -> None:
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         node._set_value(value)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "node_type", [BooleanNode, EnumNode, FloatNode, IntegerNode, StringNode, AnyNode]
 )
-@pytest.mark.parametrize(
+@mark.parametrize(
     "enum_type, values, success_map",
     [
         (
@@ -381,7 +381,7 @@ def test_legal_assignment_enum(
             node._set_value(value)
             assert node._value() == expected
         else:
-            with pytest.raises(ValidationError):
+            with raises(ValidationError):
                 node_type(enum_type)
 
 
@@ -389,8 +389,8 @@ class DummyEnum(Enum):
     FOO = 1
 
 
-@pytest.mark.parametrize("is_optional", [True, False])
-@pytest.mark.parametrize(
+@mark.parametrize("is_optional", [True, False])
+@mark.parametrize(
     "ref_type, type_, value, expected_type",
     [
         (Any, Any, 10, AnyNode),
@@ -438,13 +438,13 @@ def test_node_wrap_illegal_type() -> None:
 
     from omegaconf.omegaconf import _node_wrap
 
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         _node_wrap(
             type_=UserClass, value=UserClass(), is_optional=False, parent=None, key=None
         )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "obj",
     [
         StringNode(),
@@ -467,7 +467,7 @@ def test_deepcopy(obj: Any) -> None:
         assert obj.__dict__[k] == cp.__dict__[k]
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "node, value, expected",
     [
         (StringNode(), None, True),
@@ -508,7 +508,7 @@ def test_eq(node: ValueNode, value: Any, expected: Any) -> None:
     assert (node.__hash__() == value.__hash__()) == expected
 
 
-@pytest.mark.parametrize("value", [1, 3.14, True, None, Enum1.FOO])
+@mark.parametrize("value", [1, 3.14, True, None, Enum1.FOO])
 def test_set_anynode_with_primitive_type(value: Any) -> None:
     cfg = OmegaConf.create({"a": 5})
     a_before = cfg._get_node("a")
@@ -518,7 +518,7 @@ def test_set_anynode_with_primitive_type(value: Any) -> None:
     assert cfg.a == value
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "value, container_type",
     [
         (ListConfig(content=[1, 2]), ListConfig),
@@ -539,7 +539,7 @@ def test_set_anynode_with_container(value: Any, container_type: Any) -> None:
 
 def test_set_anynode_with_illegal_type() -> None:
     cfg = OmegaConf.create({"a": 5})
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         cfg.a = IllegalType()
 
 
@@ -548,13 +548,13 @@ def test_set_valuenode() -> None:
     a_before = cfg._get_node("age")
     cfg.age = 12
     assert id(cfg._get_node("age")) == id(a_before)
-    with pytest.raises(ValidationError):
+    with raises(ValidationError):
         cfg.age = []
 
 
 def test_allow_objects() -> None:
     c = OmegaConf.create({"foo": AnyNode()})
-    with pytest.raises(UnsupportedValueType):
+    with raises(UnsupportedValueType):
         c.foo = IllegalType()
     c._set_flag("allow_objects", True)
     iv = IllegalType()
@@ -569,7 +569,7 @@ def test_dereference_missing() -> None:
     assert x_node._dereference_node() is x_node
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "make_func",
     [
         StringNode,
@@ -583,7 +583,7 @@ def test_dereference_missing() -> None:
 )
 def test_validate_and_convert_none(make_func: Any) -> None:
     node = make_func("???", is_optional=False)
-    with pytest.raises(
+    with raises(
         ValidationError, match=re.escape("Non optional field cannot be assigned None")
     ):
         node.validate_and_convert(None)
@@ -594,5 +594,5 @@ def test_dereference_interpolation_to_missing() -> None:
     x_node = cfg._get_node("x")
     assert isinstance(x_node, Node)
     assert x_node._dereference_node(throw_on_resolution_failure=False) is None
-    with pytest.raises(InterpolationToMissingValueError):
+    with raises(InterpolationToMissingValueError):
         cfg.x

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -1,7 +1,6 @@
 from typing import Any
 
-import pytest
-from pytest import raises
+from pytest import mark, param, raises, warns
 
 from omegaconf import (
     MISSING,
@@ -31,42 +30,42 @@ from tests import (
 )
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg, key, expected_is_missing, expectation",
     [
         ({}, "foo", False, raises(ConfigKeyError)),
         ({"foo": True}, "foo", False, does_not_raise()),
         ({"foo": "${no_such_key}"}, "foo", False, raises(InterpolationKeyError)),
         ({"foo": MISSING}, "foo", True, raises(MissingMandatoryValue)),
-        pytest.param(
+        param(
             {"foo": "${bar}", "bar": DictConfig(content=MISSING)},
             "foo",
             False,
             raises(InterpolationToMissingValueError),
             id="missing_interpolated_dict",
         ),
-        pytest.param(
+        param(
             {"foo": ListConfig(content="???")},
             "foo",
             True,
             raises(MissingMandatoryValue),
             id="missing_list",
         ),
-        pytest.param(
+        param(
             {"foo": DictConfig(content="???")},
             "foo",
             True,
             raises(MissingMandatoryValue),
             id="missing_dict",
         ),
-        pytest.param(
+        param(
             {"foo": ListConfig(content="${missing}"), "missing": "???"},
             "foo",
             False,
             raises(InterpolationToMissingValueError),
             id="missing_list_interpolation",
         ),
-        pytest.param(
+        param(
             {"foo": DictConfig(content="${missing}"), "missing": "???"},
             "foo",
             False,
@@ -153,7 +152,7 @@ def test_is_missing_resets() -> None:
     assert OmegaConf.is_missing(cfg, "list")
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg, expected",
     [
         (None, False),
@@ -176,7 +175,7 @@ def test_is_config(cfg: Any, expected: bool) -> None:
     assert OmegaConf.is_config(cfg) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg, expected",
     [
         (None, False),
@@ -199,7 +198,7 @@ def test_is_list(cfg: Any, expected: bool) -> None:
     assert OmegaConf.is_list(cfg) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg, expected",
     [
         (None, False),
@@ -222,8 +221,8 @@ def test_is_dict(cfg: Any, expected: bool) -> None:
     assert OmegaConf.is_dict(cfg) == expected
 
 
-@pytest.mark.parametrize("is_optional", [True, False])
-@pytest.mark.parametrize(
+@mark.parametrize("is_optional", [True, False])
+@mark.parametrize(
     "fac",
     [
         (
@@ -287,8 +286,8 @@ def test_is_optional(fac: Any, is_optional: bool) -> None:
     assert OmegaConf.is_optional(cfg, "node") == is_optional
 
 
-@pytest.mark.parametrize("is_none", [True, False])
-@pytest.mark.parametrize(
+@mark.parametrize("is_none", [True, False])
+@mark.parametrize(
     "fac",
     [
         (lambda none: StringNode(value="foo" if not none else None, is_optional=True)),
@@ -329,7 +328,7 @@ def test_is_none(fac: Any, is_none: bool) -> None:
     assert (cfg.node is None) == is_none
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     ("cfg", "key", "is_none"),
     [
         ({"foo": "${none}", "none": None}, "foo", True),
@@ -340,7 +339,7 @@ def test_is_none(fac: Any, is_none: bool) -> None:
 )
 def test_is_none_interpolation(cfg: Any, key: str, is_none: bool) -> None:
     cfg = OmegaConf.create(cfg)
-    with pytest.warns(UserWarning):
+    with warns(UserWarning):
         assert OmegaConf.is_none(cfg, key) == is_none
     check = _is_none(
         cfg._get_node(key), resolve=True, throw_on_resolution_failure=False
@@ -350,11 +349,11 @@ def test_is_none_interpolation(cfg: Any, key: str, is_none: bool) -> None:
 
 def test_is_none_invalid_node() -> None:
     cfg = OmegaConf.create({})
-    with pytest.warns(UserWarning):
+    with warns(UserWarning):
         assert OmegaConf.is_none(cfg, "invalid")
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "fac",
     [
         (
@@ -428,7 +427,7 @@ def test_is_interpolation(fac: Any) -> Any:
         assert OmegaConf.is_interpolation(cfg, "node")
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg, type_",
     [
         ({"foo": 10}, int),
@@ -449,7 +448,7 @@ def test_get_type(cfg: Any, type_: Any) -> None:
     assert OmegaConf.get_type(cfg, "foo") == type_
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "obj, type_",
     [
         (10, int),

--- a/tests/test_readonly.py
+++ b/tests/test_readonly.py
@@ -1,74 +1,71 @@
 import re
 from typing import Any, Callable, Dict, List, Union
 
-import pytest
-from pytest import raises
+from pytest import mark, param, raises
 
 from omegaconf import DictConfig, ListConfig, OmegaConf, ReadonlyConfigError
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "src, func, expectation",
     [
-        pytest.param(
+        param(
             {},
             lambda c: c.__setitem__("a", 1),
             raises(ReadonlyConfigError, match="a"),
             id="dict_setitem",
         ),
-        pytest.param(
+        param(
             {"a": None},
             lambda c: c.__setitem__("a", {"b": 10}),
             raises(ReadonlyConfigError, match="a"),
             id="dict_setitem",
         ),
-        pytest.param(
+        param(
             {"a": {"b": {"c": 1}}},
             lambda c: c.__getattr__("a").__getattr__("b").__setitem__("c", 1),
             raises(ReadonlyConfigError, match="a.b.c"),
             id="dict_nested_setitem",
         ),
-        pytest.param(
+        param(
             {},
             lambda c: OmegaConf.update(c, "a.b", 10, merge=True),
             raises(ReadonlyConfigError, match="a"),
             id="dict_update",
         ),
-        pytest.param(
+        param(
             {"a": 10},
             lambda c: c.__setattr__("a", 1),
             raises(ReadonlyConfigError, match="a"),
             id="dict_setattr",
         ),
-        pytest.param(
+        param(
             {"a": 10},
             lambda c: c.pop("a"),
             raises(ReadonlyConfigError, match="a"),
             id="dict_pop",
         ),
-        pytest.param(
+        param(
             {"a": 10},
             lambda c: c.__delitem__("a"),
             raises(ReadonlyConfigError, match="a"),
             id="dict_delitem",
         ),
         # list
-        pytest.param(
+        param(
             [],
             lambda c: c.__setitem__(0, 1),
             raises(ReadonlyConfigError, match="0"),
             id="list_setitem",
         ),
-        pytest.param(
+        param(
             [],
             lambda c: OmegaConf.update(c, "0.b", 10, merge=True),
             raises(ReadonlyConfigError, match="[0]"),
             id="list_update",
         ),
-        pytest.param(
-            [10], lambda c: c.pop(), raises(ReadonlyConfigError), id="list_pop"
-        ),
-        pytest.param(
+        param([10], lambda c: c.pop(), raises(ReadonlyConfigError), id="list_pop"),
+        param(
             [0],
             lambda c: c.__delitem__(0),
             raises(ReadonlyConfigError, match="[0]"),
@@ -86,7 +83,7 @@ def test_readonly(
     assert c == src
 
 
-@pytest.mark.parametrize("src", [{}, []])
+@mark.parametrize("src", [{}, []])
 def test_readonly_flag(src: Union[Dict[str, Any], List[Any]]) -> None:
     c = OmegaConf.create(src)
     assert not OmegaConf.is_readonly(c)
@@ -189,13 +186,13 @@ def test_readonly_from_cli() -> None:
     assert OmegaConf.is_readonly(cfg2)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg1, cfg2",
     [
-        pytest.param({"foo": {"bar": 10}}, {"foo": {"bar": 20}}, id="override_value"),
-        pytest.param({"foo": {"bar": 10}}, {"foo": {"yup": 20}}, id="adding_key"),
-        pytest.param({"a": 1}, {"b": 2}, id="adding_key"),
-        pytest.param({"a": 1}, OmegaConf.create({"b": 2}), id="adding_key"),
+        param({"foo": {"bar": 10}}, {"foo": {"bar": 20}}, id="override_value"),
+        param({"foo": {"bar": 10}}, {"foo": {"yup": 20}}, id="adding_key"),
+        param({"a": 1}, {"b": 2}, id="adding_key"),
+        param({"a": 1}, OmegaConf.create({"b": 2}), id="adding_key"),
     ],
 )
 def test_merge_with_readonly(cfg1: Dict[str, Any], cfg2: Dict[str, Any]) -> None:
@@ -205,17 +202,17 @@ def test_merge_with_readonly(cfg1: Dict[str, Any], cfg2: Dict[str, Any]) -> None
         c.merge_with(cfg2)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "readonly_key, cfg1, cfg2, expected",
     [
-        pytest.param(
+        param(
             "",
             {"foo": {"bar": 10}},
             {"foo": {}},
             {"foo": {"bar": 10}},
             id="merge_empty_dict",
         ),
-        pytest.param(
+        param(
             "foo",
             {"foo": {"bar": 10}},
             {"xyz": 10},

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,46 +1,43 @@
 import re
 from typing import Any, Optional
 
-import pytest
 from _pytest.python_api import RaisesContext
-from pytest import raises
+from pytest import mark, param, raises, warns
 
 from omegaconf import MissingMandatoryValue, OmegaConf
 from omegaconf._utils import _ensure_container
 from omegaconf.errors import ConfigKeyError, InterpolationKeyError
 
 
-@pytest.mark.parametrize("struct", [False, True, None])
+@mark.parametrize("struct", [False, True, None])
 class TestSelect:
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "register_func", [OmegaConf.register_resolver, OmegaConf.register_new_resolver]
     )
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         "cfg, key, expected",
         [
-            pytest.param({}, "nope", None, id="dict:none"),
-            pytest.param({}, "not.there", None, id="dict:none"),
-            pytest.param({}, "still.not.there", None, id="dict:none"),
-            pytest.param({"c": 1}, "c", 1, id="dict:int"),
-            pytest.param({"a": {"v": 1}}, "a.v", 1, id="dict:int"),
-            pytest.param({"a": {"v": 1}}, "a", {"v": 1}, id="dict:dict"),
-            pytest.param({"missing": "???"}, "missing", None, id="dict:missing"),
-            pytest.param([], "0", None, id="list:oob"),
-            pytest.param([1, "2"], "0", 1, id="list:int"),
-            pytest.param([1, "2"], "1", "2", id="list:str"),
-            pytest.param(["???"], "0", None, id="list:missing"),
-            pytest.param([1, {"a": 10, "c": ["foo", "bar"]}], "0", 1),
-            pytest.param([1, {"a": 10, "c": ["foo", "bar"]}], "1.a", 10),
-            pytest.param([1, {"a": 10, "c": ["foo", "bar"]}], "1.b", None),
-            pytest.param([1, {"a": 10, "c": ["foo", "bar"]}], "1.c.0", "foo"),
-            pytest.param([1, {"a": 10, "c": ["foo", "bar"]}], "1.c.1", "bar"),
-            pytest.param([1, 2, 3], "a", raises(TypeError)),
-            pytest.param({"a": {"v": 1}}, "", {"a": {"v": 1}}, id="select_root"),
-            pytest.param({"a": {"b": 1}, "c": "one=${a.b}"}, "c", "one=1", id="inter"),
-            pytest.param({"a": {"b": "one=${n}"}, "n": 1}, "a.b", "one=1", id="inter"),
-            pytest.param(
-                {"a": {"b": "one=${func:1}"}}, "a.b", "one=_1_", id="resolver"
-            ),
+            param({}, "nope", None, id="dict:none"),
+            param({}, "not.there", None, id="dict:none"),
+            param({}, "still.not.there", None, id="dict:none"),
+            param({"c": 1}, "c", 1, id="dict:int"),
+            param({"a": {"v": 1}}, "a.v", 1, id="dict:int"),
+            param({"a": {"v": 1}}, "a", {"v": 1}, id="dict:dict"),
+            param({"missing": "???"}, "missing", None, id="dict:missing"),
+            param([], "0", None, id="list:oob"),
+            param([1, "2"], "0", 1, id="list:int"),
+            param([1, "2"], "1", "2", id="list:str"),
+            param(["???"], "0", None, id="list:missing"),
+            param([1, {"a": 10, "c": ["foo", "bar"]}], "0", 1),
+            param([1, {"a": 10, "c": ["foo", "bar"]}], "1.a", 10),
+            param([1, {"a": 10, "c": ["foo", "bar"]}], "1.b", None),
+            param([1, {"a": 10, "c": ["foo", "bar"]}], "1.c.0", "foo"),
+            param([1, {"a": 10, "c": ["foo", "bar"]}], "1.c.1", "bar"),
+            param([1, 2, 3], "a", raises(TypeError)),
+            param({"a": {"v": 1}}, "", {"a": {"v": 1}}, id="select_root"),
+            param({"a": {"b": 1}, "c": "one=${a.b}"}, "c", "one=1", id="inter"),
+            param({"a": {"b": "one=${n}"}, "n": 1}, "a.b", "one=1", id="inter"),
+            param({"a": {"b": "one=${func:1}"}}, "a.b", "one=_1_", id="resolver"),
         ],
     )
     def test_select(
@@ -61,13 +58,13 @@ class TestSelect:
         else:
             assert OmegaConf.select(cfg, key) == expected
 
-    @pytest.mark.parametrize("default", [10, None])
-    @pytest.mark.parametrize(
+    @mark.parametrize("default", [10, None])
+    @mark.parametrize(
         ("cfg", "key"),
         [
-            pytest.param({}, "not_found", id="empty"),
-            pytest.param({"missing": "???"}, "missing", id="missing"),
-            pytest.param({"int": 0}, "int.y", id="non_container"),
+            param({}, "not_found", id="empty"),
+            param({"missing": "???"}, "missing", id="missing"),
+            param({"int": 0}, "int.y", id="non_container"),
         ],
     )
     def test_select_default(
@@ -81,12 +78,12 @@ class TestSelect:
         OmegaConf.set_struct(cfg, struct)
         assert OmegaConf.select(cfg, key, default=default) == default
 
-    @pytest.mark.parametrize("default", [10, None])
-    @pytest.mark.parametrize(
+    @mark.parametrize("default", [10, None])
+    @mark.parametrize(
         "cfg, key",
         [
-            pytest.param({"missing": "???"}, "missing", id="missing_dict"),
-            pytest.param(["???"], "0", id="missing_list"),
+            param({"missing": "???"}, "missing", id="missing_dict"),
+            param(["???"], "0", id="missing_list"),
         ],
     )
     def test_select_default_throw_on_missing(
@@ -100,16 +97,16 @@ class TestSelect:
         OmegaConf.set_struct(cfg, struct)
 
         # throw on missing still throws if default is provided
-        with pytest.raises(MissingMandatoryValue):
+        with raises(MissingMandatoryValue):
             OmegaConf.select(cfg, key, default=default, throw_on_missing=True)
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         ("cfg", "key", "exc"),
         [
-            pytest.param(
+            param(
                 {"int": 0},
                 "int.y",
-                pytest.raises(
+                raises(
                     ConfigKeyError,
                     match=re.escape(
                         "Error trying to access int.y: node `int` is not a container "
@@ -128,10 +125,10 @@ class TestSelect:
         with exc:
             OmegaConf.select(cfg, key)
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         ("cfg", "key"),
         [
-            pytest.param({"inter": "${bad_key}"}, "inter", id="inter_bad_key"),
+            param({"inter": "${bad_key}"}, "inter", id="inter_bad_key"),
         ],
     )
     def test_select_default_throw_on_resolution_failure(
@@ -141,18 +138,16 @@ class TestSelect:
         OmegaConf.set_struct(cfg, struct)
 
         # throw on resolution failure still throws if default is provided
-        with pytest.raises(InterpolationKeyError):
+        with raises(InterpolationKeyError):
             OmegaConf.select(cfg, key, default=123, throw_on_resolution_failure=True)
 
-    @pytest.mark.parametrize(
+    @mark.parametrize(
         ("cfg", "node_key", "expected"),
         [
-            pytest.param({"foo": "${bar}", "bar": 10}, "foo", 10, id="simple"),
-            pytest.param({"foo": "${bar}"}, "foo", None, id="no_key"),
-            pytest.param(
-                {"foo": "${bar}", "bar": "???"}, "foo", None, id="key_missing"
-            ),
-            pytest.param(
+            param({"foo": "${bar}", "bar": 10}, "foo", 10, id="simple"),
+            param({"foo": "${bar}"}, "foo", None, id="no_key"),
+            param({"foo": "${bar}", "bar": "???"}, "foo", None, id="key_missing"),
+            param(
                 {"foo": "${bar}", "bar": "${zoo}", "zoo": "???"},
                 "foo",
                 None,
@@ -176,7 +171,7 @@ class TestSelect:
     def test_select_from_dict(self, struct: Optional[bool]) -> None:
         cfg = OmegaConf.create({"missing": "???"})
         OmegaConf.set_struct(cfg, struct)
-        with pytest.raises(MissingMandatoryValue):
+        with raises(MissingMandatoryValue):
             OmegaConf.select(cfg, "missing", throw_on_missing=True)
         assert OmegaConf.select(cfg, "missing", throw_on_missing=False) is None
         assert OmegaConf.select(cfg, "missing") is None
@@ -184,7 +179,7 @@ class TestSelect:
     def test_select_deprecated(self, struct: Optional[bool]) -> None:
         cfg = OmegaConf.create({"foo": "bar"})
         OmegaConf.set_struct(cfg, struct)
-        with pytest.warns(
+        with warns(
             expected_warning=UserWarning,
             match=re.escape(
                 "select() is deprecated, use OmegaConf.select(). (Since 2.0)"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -7,7 +7,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type
 
-import pytest
+from pytest import mark, param, raises
 
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
 from omegaconf._utils import get_ref_type
@@ -54,11 +54,11 @@ def save_load_from_filename(
 
 
 def test_load_from_invalid() -> None:
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         OmegaConf.load(3.1415)  # type: ignore
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_,resolve,expected,file_class",
     [
         ({"a": 10}, False, None, str),
@@ -90,7 +90,7 @@ class TestSaveLoad:
         save_load_from_filename(cfg, resolve, expected, file_class)
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_,resolve,expected,file_class",
     [
         (PersonA, False, {"age": 18, "registered": True}, str),
@@ -120,13 +120,11 @@ class TestSaveLoadStructured:
 
 
 def test_save_illegal_type() -> None:
-    with pytest.raises(TypeError):
+    with raises(TypeError):
         OmegaConf.save(OmegaConf.create(), 1000)  # type: ignore
 
 
-@pytest.mark.parametrize(
-    "obj", [pytest.param({"a": "b"}, id="dict"), pytest.param([1, 2, 3], id="list")]
-)
+@mark.parametrize("obj", [param({"a": "b"}, id="dict"), param([1, 2, 3], id="list")])
 def test_pickle(obj: Any) -> None:
     with tempfile.TemporaryFile() as fp:
         c = OmegaConf.create(obj)
@@ -152,7 +150,7 @@ def test_load_empty_file(tmpdir: str) -> None:
         assert OmegaConf.load(f) == {}
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_,node,element_type,key_type,optional,ref_type",
     [
         (UntypedList, "list", Any, Any, False, List[Any]),

--- a/tests/test_to_yaml.py
+++ b/tests/test_to_yaml.py
@@ -2,13 +2,13 @@ import re
 from textwrap import dedent
 from typing import Any
 
-import pytest
+from pytest import mark, warns
 
 from omegaconf import DictConfig, EnumNode, ListConfig, OmegaConf, _utils
 from tests import Enum1, User
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, expected",
     [
         (["item1", "item2", {"key3": "value3"}], "- item1\n- item2\n- key3: value3\n"),
@@ -25,7 +25,7 @@ def test_to_yaml(input_: Any, expected: str) -> None:
     assert OmegaConf.create(OmegaConf.to_yaml(c)) == c
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, expected",
     [
         (["item一", "item二", dict(key三="value三")], "- item一\n- item二\n- key三: value三\n"),
@@ -38,7 +38,7 @@ def test_to_yaml_unicode(input_: Any, expected: str) -> None:
     assert OmegaConf.create(OmegaConf.to_yaml(c)) == c
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, expected, type_",
     [
         (["1", 1], "- '1'\n- 1\n", int),
@@ -60,7 +60,7 @@ def test_to_yaml_string_primitive_types_list(
         assert OmegaConf.to_yaml(c) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, expected, type_",
     [
         ({"b": "1", "a": 1}, "b: '1'\na: 1\n", int),
@@ -80,7 +80,7 @@ def test_to_yaml_string_primitive_types_dict(
         assert OmegaConf.to_yaml(c) == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "input_, resolve, expected",
     [
         (dict(a1="${ref}", ref="bar"), True, "bar"),
@@ -138,7 +138,7 @@ def test_to_yaml_with_enum_key() -> None:
 
 def test_pretty_deprecated() -> None:
     c = OmegaConf.create({"foo": "bar"})
-    with pytest.warns(
+    with warns(
         expected_warning=UserWarning,
         match=re.escape(
             dedent(
@@ -152,7 +152,7 @@ def test_pretty_deprecated() -> None:
         assert c.pretty() == "foo: bar\n"
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "user",
     [
         User(name="Bond", age=7),

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,52 +2,49 @@ import re
 from textwrap import dedent
 from typing import Any
 
-import pytest
-from pytest import raises
+from pytest import mark, param, raises, warns
 
 from omegaconf import ListConfig, OmegaConf, ValidationError
 from omegaconf._utils import _ensure_container, is_primitive_container
 from tests import Package
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg,key,value,expected",
     [
         # dict
-        pytest.param({"a": "b"}, "a", "c", {"a": "c"}, id="replace:string"),
-        pytest.param({"a": "b"}, "c", "d", {"a": "b", "c": "d"}, id="add:string"),
-        pytest.param({"a": "b"}, "c", None, {"a": "b", "c": None}, id="none_value"),
-        pytest.param({}, "a", {}, {"a": {}}, id="dict:value:empty_dict"),
-        pytest.param({}, "a", {"b": 1}, {"a": {"b": 1}}, id="value:dict"),
-        pytest.param({}, "a.b", 1, {"a": {"b": 1}}, id="dict:deep"),
-        pytest.param(
-            {"a": "b"}, "a.b", {"c": 1}, {"a": {"b": {"c": 1}}}, id="dict:deep:map"
-        ),
-        pytest.param({}, "a", 1, {"a": 1}, id="dict:value"),
-        pytest.param({}, "a.b", 1, {"a": {"b": 1}}, id="dict:deep:value"),
-        pytest.param({"a": 1}, "b.c", 2, {"a": 1, "b": {"c": 2}}, id="dict:deep:value"),
-        pytest.param(
+        param({"a": "b"}, "a", "c", {"a": "c"}, id="replace:string"),
+        param({"a": "b"}, "c", "d", {"a": "b", "c": "d"}, id="add:string"),
+        param({"a": "b"}, "c", None, {"a": "b", "c": None}, id="none_value"),
+        param({}, "a", {}, {"a": {}}, id="dict:value:empty_dict"),
+        param({}, "a", {"b": 1}, {"a": {"b": 1}}, id="value:dict"),
+        param({}, "a.b", 1, {"a": {"b": 1}}, id="dict:deep"),
+        param({"a": "b"}, "a.b", {"c": 1}, {"a": {"b": {"c": 1}}}, id="dict:deep:map"),
+        param({}, "a", 1, {"a": 1}, id="dict:value"),
+        param({}, "a.b", 1, {"a": {"b": 1}}, id="dict:deep:value"),
+        param({"a": 1}, "b.c", 2, {"a": 1, "b": {"c": 2}}, id="dict:deep:value"),
+        param(
             {"a": {"b": {"c": 1}}},
             "a.b.d",
             2,
             {"a": {"b": {"c": 1, "d": 2}}},
             id="deep_map_update",
         ),
-        pytest.param({"a": "???"}, "a", 123, {"a": 123}, id="update_missing"),
-        pytest.param({"a": None}, "a", None, {"a": None}, id="same_value"),
-        pytest.param({"a": 123}, "a", 123, {"a": 123}, id="same_value"),
-        pytest.param({}, "a", {}, {"a": {}}, id="dict_value"),
-        pytest.param({}, "a", {"b": 1}, {"a": {"b": 1}}, id="dict_value"),
-        pytest.param({"a": {"b": 2}}, "a", {"b": 1}, {"a": {"b": 1}}, id="dict_value"),
+        param({"a": "???"}, "a", 123, {"a": 123}, id="update_missing"),
+        param({"a": None}, "a", None, {"a": None}, id="same_value"),
+        param({"a": 123}, "a", 123, {"a": 123}, id="same_value"),
+        param({}, "a", {}, {"a": {}}, id="dict_value"),
+        param({}, "a", {"b": 1}, {"a": {"b": 1}}, id="dict_value"),
+        param({"a": {"b": 2}}, "a", {"b": 1}, {"a": {"b": 1}}, id="dict_value"),
         # dict value (merge or set)
-        pytest.param(
+        param(
             {"a": None},
             "a",
             {"c": 2},
             {"a": {"c": 2}},
             id="dict_value:merge",
         ),
-        pytest.param(
+        param(
             {"a": {"b": 1}},
             "a",
             {"c": 2},
@@ -55,25 +52,25 @@ from tests import Package
             id="dict_value:merge",
         ),
         # list
-        pytest.param({"a": [1, 2]}, "a", [2, 3], {"a": [2, 3]}, id="list:replace"),
-        pytest.param([1, 2, 3], "1", "abc", [1, "abc", 3], id="list:update"),
-        pytest.param([1, 2, 3], "-1", "abc", [1, 2, "abc"], id="list:update"),
-        pytest.param(
+        param({"a": [1, 2]}, "a", [2, 3], {"a": [2, 3]}, id="list:replace"),
+        param([1, 2, 3], "1", "abc", [1, "abc", 3], id="list:update"),
+        param([1, 2, 3], "-1", "abc", [1, 2, "abc"], id="list:update"),
+        param(
             {"a": {"b": [1, 2, 3]}},
             "a.b.1",
             "abc",
             {"a": {"b": [1, "abc", 3]}},
             id="list:nested:update",
         ),
-        pytest.param(
+        param(
             {"a": {"b": [1, 2, 3]}},
             "a.b.-1",
             "abc",
             {"a": {"b": [1, 2, "abc"]}},
             id="list:nested:update",
         ),
-        pytest.param([{"a": 1}], "0", {"b": 2}, [{"a": 1, "b": 2}], id="list:merge"),
-        pytest.param(
+        param([{"a": 1}], "0", {"b": 2}, [{"a": 1, "b": 2}], id="list:merge"),
+        param(
             {"list": [{"a": 1}]},
             "list",
             [{"b": 2}],
@@ -88,10 +85,10 @@ def test_update(cfg: Any, key: str, value: Any, expected: Any) -> None:
     assert cfg == expected
 
 
-@pytest.mark.parametrize(
+@mark.parametrize(
     "cfg,key,value,merge,expected",
     [
-        pytest.param(
+        param(
             {"a": {"b": 1}},
             "a",
             {"c": 2},
@@ -99,7 +96,7 @@ def test_update(cfg: Any, key: str, value: Any, expected: Any) -> None:
             {"a": {"b": 1, "c": 2}},
             id="dict_value:merge",
         ),
-        pytest.param(
+        param(
             {"a": {"b": 1}},
             "a",
             {"c": 2},
@@ -109,7 +106,7 @@ def test_update(cfg: Any, key: str, value: Any, expected: Any) -> None:
         ),
         # merging lists is replacing.
         # this is useful when we mix it Structured Configs
-        pytest.param(
+        param(
             {"a": {"b": [1, 2]}},
             "a.b",
             [3, 4],
@@ -117,7 +114,7 @@ def test_update(cfg: Any, key: str, value: Any, expected: Any) -> None:
             {"a": {"b": [3, 4]}},
             id="list:merge",
         ),
-        pytest.param(
+        param(
             {"a": {"b": [1, 2]}},
             "a.b",
             [3, 4],
@@ -125,7 +122,7 @@ def test_update(cfg: Any, key: str, value: Any, expected: Any) -> None:
             {"a": {"b": [3, 4]}},
             id="list:set",
         ),
-        pytest.param(
+        param(
             Package,
             "modules",
             [{"name": "foo"}],
@@ -133,12 +130,12 @@ def test_update(cfg: Any, key: str, value: Any, expected: Any) -> None:
             {"modules": [{"name": "foo", "classes": "???"}]},
             id="structured_list:merge",
         ),
-        pytest.param(
+        param(
             Package,
             "modules",
             [{"name": "foo"}],
             False,
-            pytest.raises(ValidationError),
+            raises(ValidationError),
             id="structured_list:set",
         ),
     ],
@@ -167,7 +164,7 @@ def test_update_list_make_dict() -> None:
 
 def test_update_node_deprecated() -> None:
     c = OmegaConf.create()
-    with pytest.warns(
+    with warns(
         expected_warning=UserWarning,
         match=re.escape(
             "update_node() is deprecated, use OmegaConf.update(). (Since 2.0)"
@@ -194,6 +191,6 @@ def test_merge_deprecation() -> None:
             For more details, see https://github.com/omry/omegaconf/issues/367"""
     )
 
-    with pytest.warns(UserWarning, match=re.escape(msg)):
+    with warns(UserWarning, match=re.escape(msg)):
         OmegaConf.update(cfg, "a", {"c": 20})  # default to set, and issue a warning.
         assert cfg == {"a": {"c": 20}}


### PR DESCRIPTION
- Diff 1 : No functional changes. fixing the pytest imports for all tests. Expect minor conflicts because of this for outstanding diffs. 
- Diff 2: Adding better testing to DictConfig items
- calling items() on DictConfig("???") and DictConfig(None) now results in exception similar to what you get when iterating on corresponding ListConfigs. the rest of the changes are tests and updating other code in response to this change.

I think this is not user facing for people using the public API so there is no need for a news fragment or doc change.
