### PR TITLE
Fixed container inspection through interpolating

### DIFF
--- a/pydevd_plugins/extensions/pydevd_plugin_omegaconf.py
+++ b/pydevd_plugins/extensions/pydevd_plugin_omegaconf.py
@@ -1,7 +1,7 @@
 # based on https://github.com/fabioz/PyDev.Debugger/tree/main/pydevd_plugins/extensions
 import os
 import sys
-from typing import Any, Dict, Sequence
+from typing import Any, Dict
 
 from _pydevd_bundle.pydevd_extension_api import (  # type: ignore
     StrPresentationProvider,
@@ -47,11 +47,11 @@ class OmegaConfUserResolver(StrPresentationProvider):  # type: ignore
         return self.Node is not None and issubclass(type_object, self.Node)
 
     def resolve(self, obj: Any, attribute: Any) -> Any:
-        if isinstance(obj, Sequence) and isinstance(attribute, str):
+        if isinstance(obj, self.ListConfig) and isinstance(attribute, str):
             attribute = int(attribute)
 
         if isinstance(obj, self.Node):
-            obj = obj._dereference_node(throw_on_resolution_failure=False)
+            obj = obj._dereference_node()
 
         val = obj.__dict__["_content"][attribute]
 

--- a/pydevd_plugins/extensions/pydevd_plugin_omegaconf.py
+++ b/pydevd_plugins/extensions/pydevd_plugin_omegaconf.py
@@ -1,7 +1,6 @@
 # based on https://github.com/fabioz/PyDev.Debugger/tree/main/pydevd_plugins/extensions
 import os
 import sys
-from functools import lru_cache
 from typing import Any, Dict, Sequence
 
 from _pydevd_bundle.pydevd_extension_api import (  # type: ignore
@@ -9,8 +8,14 @@ from _pydevd_bundle.pydevd_extension_api import (  # type: ignore
     TypeResolveProvider,
 )
 
+DEBUG = False
 
-@lru_cache(maxsize=128)
+
+def print_debug(msg: str) -> None:  # pragma: no cover
+    if DEBUG:
+        print(msg)
+
+
 def find_mod_attr(mod_name: str, attr: str) -> Any:
     mod = sys.modules.get(mod_name)
     return getattr(mod, attr, None)
@@ -29,43 +34,59 @@ class OmegaConfDeveloperResolver(object):
 
 
 class OmegaConfUserResolver(StrPresentationProvider):  # type: ignore
+    def __init__(self) -> None:
+        self.Node = find_mod_attr("omegaconf", "Node")
+        self.ValueNode = find_mod_attr("omegaconf", "ValueNode")
+        self.ListConfig = find_mod_attr("omegaconf", "ListConfig")
+        self.DictConfig = find_mod_attr("omegaconf", "DictConfig")
+        self.InterpolationResolutionError = find_mod_attr(
+            "omegaconf.errors", "InterpolationResolutionError"
+        )
+
     def can_provide(self, type_object: Any, type_name: str) -> bool:
-        Node = find_mod_attr("omegaconf", "Node")
-        return Node is not None and issubclass(type_object, Node)
+        return self.Node is not None and issubclass(type_object, self.Node)
 
     def resolve(self, obj: Any, attribute: Any) -> Any:
         if isinstance(obj, Sequence) and isinstance(attribute, str):
             attribute = int(attribute)
+
+        if isinstance(obj, self.Node):
+            obj = obj._dereference_node(throw_on_resolution_failure=False)
+
         val = obj.__dict__["_content"][attribute]
+
+        print_debug(
+            f"resolving {obj} ({type(obj).__name__}), {attribute} -> {val} ({type(val).__name__})"
+        )
 
         return val
 
     def _is_simple_value(self, val: Any) -> bool:
-        ValueNode = find_mod_attr("omegaconf", "ValueNode")
         return (
-            isinstance(val, ValueNode)
+            isinstance(val, self.ValueNode)
             and not val._is_none()
             and not val._is_missing()
             and not val._is_interpolation()
         )
 
     def get_dictionary(self, obj: Any) -> Dict[str, Any]:
-        ListConfig = find_mod_attr("omegaconf", "ListConfig")
-        DictConfig = find_mod_attr("omegaconf", "DictConfig")
-        Node = find_mod_attr("omegaconf", "Node")
+        d = self._get_dictionary(obj)
+        print_debug(f"get_dictionary {obj}, ({type(obj).__name__}) -> {d}")
+        return d
 
-        if isinstance(obj, Node):
+    def _get_dictionary(self, obj: Any) -> Dict[str, Any]:
+        if isinstance(obj, self.Node):
             obj = obj._dereference_node(throw_on_resolution_failure=False)
             if obj is None or obj._is_none() or obj._is_missing():
                 return {}
 
-        if isinstance(obj, DictConfig):
+        if isinstance(obj, self.DictConfig):
             d = {}
             for k, v in obj.__dict__["_content"].items():
                 if self._is_simple_value(v):
                     v = v._value()
                 d[k] = v
-        elif isinstance(obj, ListConfig):
+        elif isinstance(obj, self.ListConfig):
             d = {}
             for idx, v in enumerate(obj.__dict__["_content"]):
                 if self._is_simple_value(v):
@@ -77,14 +98,12 @@ class OmegaConfUserResolver(StrPresentationProvider):  # type: ignore
         return d
 
     def get_str(self, val: Any) -> str:
-        IRE = find_mod_attr("omegaconf.errors", "InterpolationResolutionError")
-
         if val._is_missing():
             return "??? <MISSING>"
         if val._is_interpolation():
             try:
                 dr = val._dereference_node()
-            except IRE as e:
+            except self.InterpolationResolutionError as e:
                 dr = f"ERR: {e}"
             return f"{val._value()} -> {dr}"
         else:

--- a/tests/test_pydev_resolver_plugin.py
+++ b/tests/test_pydev_resolver_plugin.py
@@ -157,6 +157,30 @@ def test_get_dictionary_dictconfig(
 @mark.parametrize(
     ("obj", "attribute", "expected"),
     [
+        param(
+            ListConfig("${list}", parent=DictConfig({"list": [{"a": 10}]})),
+            "0",
+            {"a": 10},
+            id="inter_list:dict_element",
+        ),
+        param(
+            DictConfig("${dict}", parent=DictConfig({"dict": {"a": {"b": 10}}})),
+            "a",
+            {"b": 10},
+            id="inter_dict:dict_element",
+        ),
+    ],
+)
+def test_resolve_through_container_interpolation(
+    resolver: Any, obj: Any, attribute: str, expected: Any
+) -> None:
+    res = resolver.resolve(obj, attribute)
+    assert res == expected
+
+
+@mark.parametrize(
+    ("obj", "attribute", "expected"),
+    [
         param(OmegaConf.create(["${.1}", 10]), "0", {}, id="list:inter_value"),
         param(
             OmegaConf.create({"a": ListConfig(None)}),


### PR DESCRIPTION
Example:
```python
foo = OmegaConf.create({
        "list": ListConfig([{"a": 10}]),
        "inter": ListConfig("${list}"),
    },
)
```
Expanding `foo.inter`, the first element in the list was incorrect.