### PR TITLE
Avoid crash when registering a non-inspectable resolver

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -430,10 +430,13 @@ class OmegaConf:
             name not in BaseContainer._resolvers
         ), "resolver {} is already registered".format(name)
 
-        sig = inspect.signature(resolver)
+        try:
+            sig: Optional[inspect.Signature] = inspect.signature(resolver)
+        except ValueError:
+            sig = None
 
         def _should_pass(special: str) -> bool:
-            ret = special in sig.parameters
+            ret = sig is not None and special in sig.parameters
             if ret and use_cache:
                 raise ValueError(
                     f"use_cache=True is incompatible with functions that receive the {special}"

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -1,5 +1,4 @@
 import copy
-import inspect
 import random
 import re
 from textwrap import dedent
@@ -7,7 +6,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 from _pytest.python_api import RaisesContext
-from pytest import mark
 
 from omegaconf import (
     II,
@@ -501,18 +499,16 @@ def test_register_resolver_twice_error_legacy(restore_resolvers: Any) -> None:
         OmegaConf.register_new_resolver("foo", lambda: 10)
 
 
-try:
-    inspect.signature(print)
-    print_is_inspectable = False
-except ValueError:
-    print_is_inspectable = False
+def test_register_non_inspectable_resolver(mocker: Any, restore_resolvers: Any) -> None:
+    # When a function `f()` is not inspectable (e.g., some built-in CPython functions),
+    # `inspect.signature(f)` will raise a `ValueError`. We want to make sure this does
+    # not prevent us from using `f()` as a resolver.
+    def signature_not_inspectable(*args: Any, **kw: Any) -> None:
+        raise ValueError
 
-
-# This test requires a non-inspectable function to be meaningful. Thus we skip it in
-# case the current Python implementation actually makes `print()` inspectable.
-@mark.skipif(print_is_inspectable, reason="print() must not be inspectable")
-def test_register_non_inspectable_resolver(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver("print", print)  # should not raise an error
+    mocker.patch("inspect.signature", signature_not_inspectable)
+    OmegaConf.register_new_resolver("not_inspectable", lambda: 123)
+    assert OmegaConf.create({"x": "${not_inspectable:}"}).x == 123
 
 
 def test_clear_resolvers_and_has_resolver(restore_resolvers: Any) -> None:

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import random
 import re
 from textwrap import dedent
@@ -6,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 from _pytest.python_api import RaisesContext
+from pytest import mark
 
 from omegaconf import (
     II,
@@ -497,6 +499,20 @@ def test_register_resolver_twice_error_legacy(restore_resolvers: Any) -> None:
     OmegaConf.legacy_register_resolver("foo", foo)
     with pytest.raises(AssertionError):
         OmegaConf.register_new_resolver("foo", lambda: 10)
+
+
+try:
+    inspect.signature(print)
+    print_is_inspectable = False
+except ValueError:
+    print_is_inspectable = False
+
+
+# This test requires a non-inspectable function to be meaningful. Thus we skip it in
+# case the current Python implementation actually makes `print()` inspectable.
+@mark.skipif(print_is_inspectable, reason="print() must not be inspectable")
+def test_register_non_inspectable_resolver(restore_resolvers: Any) -> None:
+    OmegaConf.register_new_resolver("print", print)  # should not raise an error
 
 
 def test_clear_resolvers_and_has_resolver(restore_resolvers: Any) -> None:


### PR DESCRIPTION
Some builtin functions like `print()` cannot be inspected.