### PR TITLE
Grammar: allow question marks in unquoted strings

### DIFF
--- a/omegaconf/grammar/OmegaConfGrammarLexer.g4
+++ b/omegaconf/grammar/OmegaConfGrammarLexer.g4
@@ -54,7 +54,7 @@ BOOL:
 
 NULL: [Nn][Uu][Ll][Ll];
 
-UNQUOTED_CHAR: [/\-\\+.$%*@];  // other characters allowed in unquoted strings
+UNQUOTED_CHAR: [/\-\\+.$%*@?];  // other characters allowed in unquoted strings
 ID: (CHAR|'_') (CHAR|DIGIT|'_')*;
 ESC: (ESC_BACKSLASH | '\\(' | '\\)' | '\\[' | '\\]' | '\\{' | '\\}' |
       '\\:' | '\\=' | '\\,' | '\\ ' | '\\\t')+;

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -100,7 +100,7 @@ PARAMS_SINGLE_ELEMENT_NO_INTERPOLATION: List[Tuple[str, str, Any]] = [
     ("float_plus_nan", "+nan", math.nan),
     ("float_minus_nan", "-nan", math.nan),
     # Unquoted strings.
-    ("str_legal", "a/-\\+.$*@\\\\", "a/-\\+.$*@\\"),
+    ("str_legal", "a/-\\+.$*@?\\\\", "a/-\\+.$*@?\\"),
     ("str_illegal_1", "a,=b", GrammarParseError),
     ("str_illegal_2", f"{chr(200)}", GrammarParseError),
     ("str_illegal_3", f"{chr(129299)}", GrammarParseError),


### PR DESCRIPTION
Related to #634
(though not fixing the exact example from that issue, that also includes an `=` sign that will not be allowed in unquoted strings)