### PR TITLE
Enable the deprecation warning for `register_resolver()`

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -352,16 +352,15 @@ class OmegaConf:
 
     @staticmethod
     def register_resolver(name: str, resolver: Resolver) -> None:
-        # TODO re-enable warning message before 2.1 release (see also test_resolver_deprecated_behavior)
-        # warnings.warn(
-        #     dedent(
-        #         """\
-        #     register_resolver() is deprecated.
-        #     See https://github.com/omry/omegaconf/issues/426 for migration instructions.
-        #     """
-        #     ),
-        #     stacklevel=2,
-        # )
+        warnings.warn(
+            dedent(
+                """\
+            register_resolver() is deprecated.
+            See https://github.com/omry/omegaconf/issues/426 for migration instructions.
+            """
+            ),
+            stacklevel=2,
+        )
         return OmegaConf.legacy_register_resolver(name, resolver)
 
     # This function will eventually be deprecated and removed.

--- a/tests/interpolation/test_custom_resolvers.py
+++ b/tests/interpolation/test_custom_resolvers.py
@@ -292,8 +292,8 @@ def test_resolver_deprecated_behavior(restore_resolvers: Any) -> None:
     # behave as expected.
 
     # The registration should trigger a deprecation warning.
-    # with warns(UserWarning):  # TODO re-enable this check with the warning
-    OmegaConf.register_resolver("my_resolver", lambda *args: args)
+    with warns(UserWarning):
+        OmegaConf.register_resolver("my_resolver", lambda *args: args)
 
     c = OmegaConf.create(
         {

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1302,7 +1302,8 @@ def test_assertion_error() -> None:
 
 
 @mark.parametrize(
-    "register_func", [OmegaConf.register_resolver, OmegaConf.register_new_resolver]
+    "register_func",
+    [OmegaConf.legacy_register_resolver, OmegaConf.register_new_resolver],
 )
 def test_resolver_error(restore_resolvers: Any, register_func: Any) -> None:
     def div(x: Any, y: Any) -> float:

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -176,7 +176,8 @@ class TestNodeTypesMatrix:
             node_type(value=None, is_optional=False)
 
     @mark.parametrize(
-        "register_func", [OmegaConf.register_resolver, OmegaConf.register_new_resolver]
+        "register_func",
+        [OmegaConf.legacy_register_resolver, OmegaConf.register_new_resolver],
     )
     def test_interpolation(
         self, node_type: Any, values: Any, restore_resolvers: Any, register_func: Any

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -666,7 +666,8 @@ def test_merge_with_error_not_changing_target(c1: Any, c2: Any) -> Any:
 
 
 @mark.parametrize(
-    "register_func", [OmegaConf.register_resolver, OmegaConf.register_new_resolver]
+    "register_func",
+    [OmegaConf.legacy_register_resolver, OmegaConf.register_new_resolver],
 )
 def test_into_custom_resolver_that_throws(
     restore_resolvers: Any, register_func: Any

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -12,7 +12,8 @@ from omegaconf.errors import ConfigKeyError, InterpolationKeyError
 @mark.parametrize("struct", [False, True, None])
 class TestSelect:
     @mark.parametrize(
-        "register_func", [OmegaConf.register_resolver, OmegaConf.register_new_resolver]
+        "register_func",
+        [OmegaConf.legacy_register_resolver, OmegaConf.register_new_resolver],
     )
     @mark.parametrize(
         "cfg, key, expected",


### PR DESCRIPTION
Should be a good time to re-enable this warning now that the `register_new_resolver()` API is finalized.

Note that I updated #426, @omry please have a look to check that it's clear enough. Thanks!