### PR TITLE
`OmegaConf.create()` now properly sets the parent for string inputs

### DIFF
--- a/news/648.bugfix
+++ b/news/648.bugfix
@@ -1,0 +1,1 @@
+OmegaConf.create() was ignoring the `parent` argument when taking a string as input

--- a/news/648.bugfix
+++ b/news/648.bugfix
@@ -1,1 +1,1 @@
-OmegaConf.create() was ignoring the `parent` argument when taking a string as input
+Fix OmegaConf.create() to set the provided `parent` when creating a config from a YAML string.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -825,12 +825,12 @@ class OmegaConf:
             if isinstance(obj, str):
                 obj = yaml.load(obj, Loader=get_yaml_loader())
                 if obj is None:
-                    return OmegaConf.create({}, flags=flags)
+                    return OmegaConf.create({}, parent=parent, flags=flags)
                 elif isinstance(obj, str):
-                    return OmegaConf.create({obj: None}, flags=flags)
+                    return OmegaConf.create({obj: None}, parent=parent, flags=flags)
                 else:
                     assert isinstance(obj, (list, dict))
-                    return OmegaConf.create(obj, flags=flags)
+                    return OmegaConf.create(obj, parent=parent, flags=flags)
 
             else:
                 if (

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -338,3 +338,18 @@ def test_yaml_merge() -> None:
         )
     )
     assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 3, "y": 2, "z": 1}}
+
+
+@mark.parametrize(
+    "data",
+    [
+        param("", id="empty"),
+        param("hello", id="name_only"),
+        param("a: b", id="dictconfig"),
+        param("- a", id="listconfig"),
+    ],
+)
+def test_create_from_str_check_parent(data: str) -> None:
+    parent = OmegaConf.create({})
+    cfg = OmegaConf.create(data, parent=parent)
+    assert cfg._get_parent() is parent


### PR DESCRIPTION
Fixes #648