### PR TITLE
Cosmetic: remove some whitespaces before colons

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,5 +21,5 @@ A clear and concise description of what you expected to happen.
 **Additional context**
 - [ ] OmegaConf version: <__FILL__>
 - [ ] Python version: <__FILL__>
-- [ ] Operating system : <__FILL__>
+- [ ] Operating system: <__FILL__>
 - [ ] Please provide a minimal repro

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ OmegaConf 2.0 stable version.
 Install with `pip install --upgrade omegaconf`
 
 ## Live tutorial
-Run the live tutorial : [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/omry/omegaconf/master?filepath=docs%2Fnotebook%2FTutorial.ipynb)
+Run the live tutorial: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/omry/omegaconf/master?filepath=docs%2Fnotebook%2FTutorial.ipynb)

--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -30,11 +30,11 @@ in the input class.
 Simple types
 ^^^^^^^^^^^^
 Simple types include
- - int : numeric integers
- - float : numeric floating point values
- - bool : boolean values (True, False, On, Off etc)
- - str : Any string
- - Enums : User defined enums
+ - int: numeric integers
+ - float: numeric floating point values
+ - bool: boolean values (True, False, On, Off etc)
+ - str: Any string
+ - Enums: User defined enums
 
 The following class defines fields with all simple types:
 
@@ -91,7 +91,7 @@ You can create a config with specified fields that can also accept arbitrary val
 
     >>> @dataclass
     ... class DictWithFields(Dict[str, Any]):
-    ...     num : int = 10
+    ...     num: int = 10
     >>>
     >>> conf = OmegaConf.structured(DictWithFields)
     >>> assert conf.num == 10
@@ -188,7 +188,7 @@ Structured configs can be nested.
     ...     # You can also specify different defaults for nested classes
     ...     manager: User = User(name="manager", height=Height.TALL)
 
-    >>> conf : Group = OmegaConf.structured(Group)
+    >>> conf: Group = OmegaConf.structured(Group)
     >>> print(OmegaConf.to_yaml(conf))
     name: ???
     admin:
@@ -242,7 +242,7 @@ OmegaConf verifies at runtime that your Lists contains only values of the correc
 
 .. doctest::
 
-    >>> conf : Lists = OmegaConf.structured(Lists)
+    >>> conf: Lists = OmegaConf.structured(Lists)
 
     >>> # Okay, 10 is an int
     >>> conf.ints.append(10)
@@ -276,7 +276,7 @@ OmegaConf supports field modifiers such as MISSING and Optional.
     ...     optional_num: Optional[int] = 10
     ...     another_num: int = MISSING
 
-    >>> conf : Modifiers = OmegaConf.structured(Modifiers)
+    >>> conf: Modifiers = OmegaConf.structured(Modifiers)
 
 Mandatory missing values
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -327,7 +327,7 @@ To work around it, use SI and II described below.
     ...     # wrapped with ${} automatically.
     ...     c: int = II("val")
 
-    >>> conf : Interpolation = OmegaConf.structured(Interpolation)
+    >>> conf: Interpolation = OmegaConf.structured(Interpolation)
     >>> assert conf.a == 100
     >>> assert conf.b == 100
     >>> assert conf.c == 100
@@ -407,18 +407,18 @@ A Schema for the above config can be defined like this.
 
     >>> @dataclass
     ... class Server:
-    ...     port : int = MISSING
+    ...     port: int = MISSING
 
     >>> @dataclass
     ... class Log:
-    ...     file : str = MISSING
+    ...     file: str = MISSING
     ...     rotation: int = MISSING
 
     >>> @dataclass
     ... class MyConfig:
-    ...     server : Server = Server()
-    ...     log : Log = Log()
-    ...     users : List[int] = field(default_factory=list)
+    ...     server: Server = Server()
+    ...     log: Log = Log()
+    ...     users: List[int] = field(default_factory=list)
 
 
 I intentionally made an error in the type of the users list (List[int] should be List[str]).

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -757,7 +757,7 @@ Utility functions
 OmegaConf.to_container
 ^^^^^^^^^^^^^^^^^^^^^^
 OmegaConf config objects looks very similar to python dict and list, but in fact are not.
-Use OmegaConf.to_container(cfg : Container, resolve : bool) to convert to a primitive container.
+Use OmegaConf.to_container(cfg: Container, resolve: bool) to convert to a primitive container.
 If resolve is set to True, interpolations will be resolved during conversion.
 
 .. doctest::

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -139,7 +139,7 @@ def get_yaml_loader() -> Any:
             re.X,
         ),
         list("-+0123456789."),
-    )  # type : ignore
+    )
     loader.yaml_implicit_resolvers = {
         key: [
             (tag, regexp)
@@ -388,8 +388,8 @@ def get_value_kind(
     """
     Determine the kind of a value
     Examples:
-    VALUE : "10", "20", True
-    MANDATORY_MISSING : "???"
+    VALUE: "10", "20", True
+    MANDATORY_MISSING: "???"
     INTERPOLATION: "${foo.bar}", "${foo.${bar}}", "${foo:bar}", "[${foo}, ${bar}]",
                    "ftp://${host}/path", "${foo:${bar}, [true], {'baz': ${baz}}}"
 

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -86,7 +86,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             if not valid_value_annotation_type(
                 element_type
             ) and not is_structured_config(element_type):
-                raise ValidationError(f"Unsupported value type : {element_type}")
+                raise ValidationError(f"Unsupported value type: {element_type}")
 
             if not _valid_dict_key_annotation_type(key_type):
                 raise KeyValidationError(f"Unsupported key type {key_type}")
@@ -233,7 +233,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         )
         if validation_error:
             msg = (
-                f"Merge error : {type_str(src_obj_type)} is not a "
+                f"Merge error: {type_str(src_obj_type)} is not a "
                 f"subclass of {type_str(dest_obj_type)}. value: {src}"
             )
             raise ValidationError(msg)
@@ -264,7 +264,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         assert value_type is not None
         assert target_type is not None
         msg = (
-            f"Invalid type assigned : {type_str(value_type)} is not a "
+            f"Invalid type assigned: {type_str(value_type)} is not a "
             f"subclass of {type_str(target_type)}. value: {value}"
         )
         raise ValidationError(msg)
@@ -591,7 +591,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         if type_or_prototype is None:
             return
         if not is_structured_config(type_or_prototype):
-            raise ValueError(f"Expected structured config class : {type_or_prototype}")
+            raise ValueError(f"Expected structured config class: {type_or_prototype}")
 
         from omegaconf import OmegaConf
 
@@ -655,7 +655,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
                         self.__setitem__(k, v)
 
             else:  # pragma: no cover
-                msg = f"Unsupported value type : {value}"
+                msg = f"Unsupported value type: {value}"
                 raise ValidationError(msg)
 
     @staticmethod

--- a/omegaconf/grammar/OmegaConfGrammarLexer.g4
+++ b/omegaconf/grammar/OmegaConfGrammarLexer.g4
@@ -61,8 +61,8 @@ ESC: (ESC_BACKSLASH | '\\(' | '\\)' | '\\[' | '\\]' | '\\{' | '\\}' |
 WS: [ \t]+;
 
 QUOTED_VALUE:
-      '\'' ('\\\''|.)*? '\'' // Single quotes, can contain escaped single quote : /'
-    | '"' ('\\"'|.)*? '"' ;  // Double quotes, can contain escaped double quote : /"
+      '\'' ('\\\''|.)*? '\'' // Single quotes, can contain escaped single quote: /'
+    | '"' ('\\"'|.)*? '"' ;  // Double quotes, can contain escaped double quote: /"
 
 ////////////////////////
 // INTERPOLATION_MODE //

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -70,7 +70,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
             )
             if not (valid_value_annotation_type(self._metadata.element_type)):
                 raise ValidationError(
-                    f"Unsupported value type : {self._metadata.element_type}"
+                    f"Unsupported value type: {self._metadata.element_type}"
                 )
 
             self.__dict__["_content"] = None
@@ -110,7 +110,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                 and not issubclass(value_type, target_type)
             ):
                 msg = (
-                    f"Invalid type assigned : {type_str(value_type)} is not a "
+                    f"Invalid type assigned: {type_str(value_type)} is not a "
                     f"subclass of {type_str(target_type)}. value: {value}"
                 )
                 raise ValidationError(msg)
@@ -588,7 +588,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
         else:
             if not (is_primitive_list(value) or isinstance(value, ListConfig)):
                 type_ = type(value)
-                msg = f"Invalid value assigned : {type_.__name__} is not a ListConfig, list or tuple."
+                msg = f"Invalid value assigned: {type_.__name__} is not a ListConfig, list or tuple."
                 raise ValidationError(msg)
 
             self.__dict__["_content"] = []

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -158,7 +158,7 @@ class StringNode(ValueNode):
         from omegaconf import OmegaConf
 
         if OmegaConf.is_config(value) or is_primitive_container(value):
-            raise ValidationError("Cannot convert '$VALUE_TYPE' to string : '$VALUE'")
+            raise ValidationError("Cannot convert '$VALUE_TYPE' to string: '$VALUE'")
         return str(value)
 
     def __deepcopy__(self, memo: Dict[int, Any]) -> "StringNode":

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -237,7 +237,7 @@ class OmegaConf:
 
         if obj is not None and not isinstance(obj, (list, dict, str)):
             raise IOError(  # pragma: no cover
-                f"Invalid loaded object type : {type(obj).__name__}"
+                f"Invalid loaded object type: {type(obj).__name__}"
             )
 
         ret: Union[DictConfig, ListConfig]
@@ -748,7 +748,7 @@ class OmegaConf:
 
         assert isinstance(
             root, Container
-        ), f"Unexpected type for root : {type(root).__name__}"
+        ), f"Unexpected type for root: {type(root).__name__}"
 
         last_key: Union[str, int] = last
         if isinstance(root, ListConfig):
@@ -1034,7 +1034,7 @@ def _node_wrap(
         if parent is not None and parent._get_flag("allow_objects") is True:
             node = AnyNode(value=value, key=key, parent=parent)
         else:
-            raise ValidationError(f"Unexpected object type : {type_str(type_)}")
+            raise ValidationError(f"Unexpected object type: {type_str(type_)}")
     return node
 
 
@@ -1069,7 +1069,7 @@ def _select_one(
     from .listconfig import ListConfig
 
     ret_key: Union[str, int] = key
-    assert isinstance(c, (DictConfig, ListConfig)), f"Unexpected type : {c}"
+    assert isinstance(c, (DictConfig, ListConfig)), f"Unexpected type: {c}"
     if isinstance(c, DictConfig):
         assert isinstance(ret_key, str)
         val = c._get_node(ret_key, validate_access=False)
@@ -1096,7 +1096,7 @@ def _select_one(
         if val._is_missing():
             if throw_on_missing:
                 raise MissingMandatoryValue(
-                    f"Missing mandatory value : {c._get_full_key(ret_key)}"
+                    f"Missing mandatory value: {c._get_full_key(ret_key)}"
                 )
             else:
                 return val, ret_key

--- a/tests/structured_conf/test_structured_basic.py
+++ b/tests/structured_conf/test_structured_basic.py
@@ -38,7 +38,7 @@ class TestStructured:
         def test_error_on_non_structured_nested_config_class(self, module: Any) -> None:
             with raises(
                 ValidationError,
-                match=re.escape("Unexpected object type : NotStructuredConfig"),
+                match=re.escape("Unexpected object type: NotStructuredConfig"),
             ):
                 OmegaConf.structured(module.StructuredWithInvalidField)
 

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -351,7 +351,7 @@ def test_list_append() -> None:
             raises(
                 ValidationError,
                 match=re.escape(
-                    "Invalid type assigned : str is not a subclass of User. value: foo"
+                    "Invalid type assigned: str is not a subclass of User. value: foo"
                 ),
             ),
             id="append_str_to_list[User]",
@@ -362,7 +362,7 @@ def test_list_append() -> None:
             raises(
                 ValidationError,
                 match=re.escape(
-                    "Invalid type assigned : dict is not a subclass of User. value: {'name': 'Bond', 'age': 7}"
+                    "Invalid type assigned: dict is not a subclass of User. value: {'name': 'Bond', 'age': 7}"
                 ),
             ),
             id="list:convert_dict_to_user",
@@ -373,7 +373,7 @@ def test_list_append() -> None:
             raises(
                 ValidationError,
                 match=re.escape(
-                    "Invalid type assigned : dict is not a subclass of User. value: {}"
+                    "Invalid type assigned: dict is not a subclass of User. value: {}"
                 ),
             ),
             id="list:convert_empty_dict_to_user",

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -298,7 +298,7 @@ params = [
             exception_type=InterpolationToMissingValueError,
             msg=(
                 "MissingMandatoryValue while resolving interpolation: "
-                "Missing mandatory value : missing_val"
+                "Missing mandatory value: missing_val"
             ),
             key="foo",
             child_node=lambda cfg: cfg._get_node("foo"),
@@ -321,7 +321,7 @@ params = [
             create=lambda: OmegaConf.structured(ConcretePlugin),
             op=lambda cfg: setattr(cfg, "params", 20),
             exception_type=ValidationError,
-            msg="Invalid type assigned : int is not a subclass of FoobarParams. value: 20",
+            msg="Invalid type assigned: int is not a subclass of FoobarParams. value: 20",
             key="params",
             object_type=ConcretePlugin,
             child_node=lambda cfg: cfg.params,
@@ -416,7 +416,7 @@ params = [
             create=lambda: OmegaConf.structured(User),
             op=lambda cfg: cfg.__setitem__("name", [1, 2]),
             exception_type=ValidationError,
-            msg="Cannot convert 'list' to string : '[1, 2]'",
+            msg="Cannot convert 'list' to string: '[1, 2]'",
             full_key="name",
             key="name",
             low_level=True,
@@ -671,7 +671,7 @@ params = [
             create=lambda: DictConfig(ref_type=ConcretePlugin, content="???"),
             op=lambda cfg: cfg._set_value(1),
             exception_type=ValidationError,
-            msg="Invalid type assigned : int is not a subclass of ConcretePlugin. value: 1",
+            msg="Invalid type assigned: int is not a subclass of ConcretePlugin. value: 1",
             low_level=True,
             ref_type=Optional[ConcretePlugin],
         ),
@@ -1048,7 +1048,7 @@ params = [
             op=lambda cfg: cfg._set_value(True),
             exception_type=ValidationError,
             object_type=None,
-            msg="Invalid value assigned : bool is not a ListConfig, list or tuple.",
+            msg="Invalid value assigned: bool is not a ListConfig, list or tuple.",
             ref_type=List[int],
             low_level=True,
         ),

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -51,7 +51,7 @@ def verify(
     assert OmegaConf.is_interpolation(cfg, key) == inter
 
 
-# for each type Node type : int, bool, str, float, Color (enum) and User (@dataclass), DictConfig, ListConfig
+# for each type Node type: int, bool, str, float, Color (enum) and User (@dataclass), DictConfig, ListConfig
 #   for each MISSING, None, Optional and interpolation:
 @mark.parametrize(
     "node_type, values",


### PR DESCRIPTION
There were a bunch of them, thought it'd be good to do a pass.

This uncovered an invalid `# type : ignore` comment which I removed.