### PR TITLE
Fixed OmegaConf.select() with relative keys

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -679,6 +679,7 @@ class OmegaConf:
     ) -> Any:
         try:
             try:
+                cfg, key = cfg._resolve_key_and_root(key)
                 _root, _last_key, value = cfg._select_impl(
                     key,
                     throw_on_missing=throw_on_missing,

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -3,7 +3,6 @@ import re
 from textwrap import dedent
 from typing import Any, Tuple
 
-from _pytest.python_api import RaisesContext
 from pytest import mark, param, raises
 
 from omegaconf import (
@@ -30,65 +29,6 @@ from tests import MissingDict, MissingList, StructuredWithMissing, SubscriptedLi
 # lines that do equality checks of the form
 #       c.k == c.k
 from tests.interpolation import dereference_node
-
-
-@mark.parametrize(
-    "cfg,key,expected",
-    [
-        param({"a": "${b}", "b": 10}, "a", 10, id="simple"),
-        param(
-            {"a": "${x}"},
-            "a",
-            raises(InterpolationKeyError),
-            id="not_found",
-        ),
-        param(
-            {"a": "${x.y}"},
-            "a",
-            raises(InterpolationKeyError),
-            id="not_found",
-        ),
-        param({"a": "foo_${b}", "b": "bar"}, "a", "foo_bar", id="str_inter"),
-        param(
-            {"a": "${x}_${y}", "x": "foo", "y": "bar"},
-            "a",
-            "foo_bar",
-            id="multi_str_inter",
-        ),
-        param({"a": "foo_${b.c}", "b": {"c": 10}}, "a", "foo_10", id="str_deep_inter"),
-        param({"a": 10, "b": [1, "${a}"]}, "b.1", 10, id="from_list"),
-        param({"a": "${b}", "b": {"c": 10}}, "a", {"c": 10}, id="dict_val"),
-        param({"a": "${b}", "b": [1, 2]}, "a", [1, 2], id="list_val"),
-        param({"a": "${b.1}", "b": [1, 2]}, "a", 2, id="list_index"),
-        param({"a": "X_${b}", "b": [1, 2]}, "a", "X_[1, 2]", id="liststr"),
-        param({"a": "X_${b}", "b": {"c": 1}}, "a", "X_{'c': 1}", id="dict_str"),
-        param({"a": "${b}", "b": "${c}", "c": 10}, "a", 10, id="two_steps"),
-        param({"bar": 10, "foo": ["${bar}"]}, "foo.0", 10, id="inter_in_list"),
-        param({"foo": None, "bar": "${foo}"}, "bar", None, id="none"),
-        param({"list": ["bar"], "foo": "${list.0}"}, "foo", "bar", id="list"),
-        param(
-            {"user@domain": 10, "foo": "${user@domain}"}, "foo", 10, id="user@domain"
-        ),
-        # relative interpolations
-        param({"a": "${.b}", "b": 10}, "a", 10, id="relative"),
-        param({"a": {"z": "${.b}", "b": 10}}, "a.z", 10, id="relative"),
-        param({"a": {"z": "${..b}"}, "b": 10}, "a.z", 10, id="relative"),
-        param({"a": {"z": "${..a.b}", "b": 10}}, "a.z", 10, id="relative"),
-        param(
-            {"a": "${..b}", "b": 10},
-            "a",
-            raises(InterpolationKeyError),
-            id="relative",
-        ),
-    ],
-)
-def test_interpolation(cfg: Any, key: str, expected: Any) -> None:
-    cfg = _ensure_container(cfg)
-    if isinstance(expected, RaisesContext):
-        with expected:
-            OmegaConf.select(cfg, key)
-    else:
-        assert OmegaConf.select(cfg, key) == expected
 
 
 def test_interpolation_with_missing() -> None:


### PR DESCRIPTION
I am not including a news fragment because relative interpolations are new in 2.1.