### PR TITLE
OmegaConf.select is relative to the node it's called on

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -679,6 +679,10 @@ class OmegaConf:
     ) -> Any:
         try:
             try:
+                if cfg._parent is not None:
+                    # select is relative to the node its called on.
+                    # if called on none-root, prepend dot.
+                    key = f".{key}"
                 cfg, key = cfg._resolve_key_and_root(key)
                 _root, _last_key, value = cfg._select_impl(
                     key,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -679,10 +679,11 @@ class OmegaConf:
     ) -> Any:
         try:
             try:
-                if cfg._parent is not None:
-                    # select is relative to the node its called on.
-                    # if called on none-root, prepend dot.
+                # keys are interpreted relative by default.
+                # If provided key is not relative, prepend the first .
+                if not key.startswith("."):
                     key = f".{key}"
+
                 cfg, key = cfg._resolve_key_and_root(key)
                 _root, _last_key, value = cfg._select_impl(
                     key,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -678,12 +678,24 @@ class OmegaConf:
         throw_on_missing: bool = False,
         absolute_key: bool = False,
     ) -> Any:
+        """
+        :param cfg: Config node to select from
+        :param key: Key to select
+        :param default: Default value to return if key is not found
+        :param throw_on_resolution_failure: Raise an exception if an interpolation
+               resolution error occurs, otherwise return None
+        :param throw_on_missing: Raise an exception if an attempt to select a missing key (with the value '???')
+               is made, otherwise return None
+        :param absolute_key: True to treat non-relative keys as relative to the config root
+                             False (default) to treat non-relative keys as relative to cfg
+        :return: selected value or None if not found.
+        """
         try:
             try:
-                if not absolute_key:
-                    # keys are interpreted relative. If provided key is not relative, prepend the first `.`
-                    if not key.startswith("."):
-                        key = f".{key}"
+                # keys are interpreted relative. If provided key is not relative, prepend the first `.`
+                if not absolute_key and not key.startswith("."):
+                    key = f".{key}"
+
                 cfg, key = cfg._resolve_key_and_root(key)
                 _root, _last_key, value = cfg._select_impl(
                     key,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -692,7 +692,10 @@ class OmegaConf:
         """
         try:
             try:
-                # keys are interpreted relative. If provided key is not relative, prepend the first `.`
+                # for non relative keys, the interpretation can be:
+                # 1. relative to cfg
+                # 2. relative to the config root
+                # This is controlled by the absolute_key flag. By default, such keys are relative to cfg.
                 if not absolute_key and not key.startswith("."):
                     key = f".{key}"
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -676,14 +676,14 @@ class OmegaConf:
         default: Any = _DEFAULT_MARKER_,
         throw_on_resolution_failure: bool = True,
         throw_on_missing: bool = False,
+        absolute_key: bool = False,
     ) -> Any:
         try:
             try:
-                # keys are interpreted relative by default.
-                # If provided key is not relative, prepend the first .
-                if not key.startswith("."):
-                    key = f".{key}"
-
+                if not absolute_key:
+                    # keys are interpreted relative. If provided key is not relative, prepend the first `.`
+                    if not key.startswith("."):
+                        key = f".{key}"
                 cfg, key = cfg._resolve_key_and_root(key)
                 _root, _last_key, value = cfg._select_impl(
                     key,

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -194,15 +194,21 @@ class TestSelect:
             cfg.select("foo")
 
     def test_select_relative_from_nested_node(self, struct: Optional[bool]) -> None:
-        cfg = OmegaConf.create(
-            {"a": {"b": {"c": 10}}, "z": 10},
-        )
+        input_cfg: Any = {"a": {"b": {"c": 10}}, "z": 10}
+        cfg = OmegaConf.create(input_cfg)
         OmegaConf.set_struct(cfg, struct)
-        assert OmegaConf.select(cfg.a, "") == {"b": {"c": 10}}
-        assert OmegaConf.select(cfg.a, "b") == {"c": 10}
-        assert OmegaConf.select(cfg.a, ".") == {"a": {"b": {"c": 10}}, "z": 10}
-        assert OmegaConf.select(cfg.a, ".a") == {"b": {"c": 10}}
-        assert OmegaConf.select(cfg.a, ".z") == 10
+        # absolute keys are relative to the calling node
+        assert OmegaConf.select(cfg.a, "") == input_cfg["a"]
+        assert OmegaConf.select(cfg.a, "b") == input_cfg["a"]["b"]
+        assert OmegaConf.select(cfg.a, "b.c") == input_cfg["a"]["b"]["c"]
+        # relative keys
+        assert OmegaConf.select(cfg.a, ".") == input_cfg["a"]
+        assert OmegaConf.select(cfg.a, ".b") == input_cfg["a"]["b"]
+        assert OmegaConf.select(cfg.a, ".b.c") == input_cfg["a"]["b"]["c"]
+        assert OmegaConf.select(cfg.a, "..") == input_cfg
+        assert OmegaConf.select(cfg.a, "..a") == input_cfg["a"]
+        assert OmegaConf.select(cfg.a, "..a.b") == input_cfg["a"]["b"]
+        assert OmegaConf.select(cfg.a, "..z") == input_cfg["z"]
 
 
 @mark.parametrize(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -257,10 +257,10 @@ inp: Any = {"a": {"b": {"c": 10}}, "z": 10}
 
 
 class TestSelectFromNestedNode:
-    # all selects are performed on cfg.a:
     @mark.parametrize(
         ("key", "expected"),
         [
+            # all selects are performed on cfg.a:
             # relative keys
             (".", inp["a"]),
             (".b", inp["a"]["b"]),
@@ -279,10 +279,10 @@ class TestSelectFromNestedNode:
         assert OmegaConf.select(cfg.a, key, absolute_key=False) == expected
         assert OmegaConf.select(cfg.a, key, absolute_key=True) == expected
 
-    # all selects are performed on cfg.a:
     @mark.parametrize(
         ("key", "expected"),
         [
+            # all selects are performed on cfg.a:
             # absolute keys are relative to the calling node
             ("", inp["a"]),
             ("b", inp["a"]["b"]),
@@ -298,6 +298,7 @@ class TestSelectFromNestedNode:
     @mark.parametrize(
         ("key", "expected"),
         [
+            # all selects are performed on cfg.a:
             # absolute keys are relative to the config root
             ("", inp),
             ("a", inp["a"]),

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -193,22 +193,59 @@ class TestSelect:
         ):
             cfg.select("foo")
 
-    def test_select_relative_from_nested_node(self, struct: Optional[bool]) -> None:
-        input_cfg: Any = {"a": {"b": {"c": 10}}, "z": 10}
-        cfg = OmegaConf.create(input_cfg)
+    def test_select_from_nested_node_relative_key_interpretation(
+        self, struct: Optional[bool]
+    ) -> None:
+        inp: Any = {
+            "a": {
+                "b": {
+                    "c": 10,
+                }
+            },
+            "z": 10,
+        }
+        cfg = OmegaConf.create(inp)
         OmegaConf.set_struct(cfg, struct)
         # absolute keys are relative to the calling node
-        assert OmegaConf.select(cfg.a, "") == input_cfg["a"]
-        assert OmegaConf.select(cfg.a, "b") == input_cfg["a"]["b"]
-        assert OmegaConf.select(cfg.a, "b.c") == input_cfg["a"]["b"]["c"]
+        assert OmegaConf.select(cfg.a, "") == inp["a"]
+        assert OmegaConf.select(cfg.a, "b") == inp["a"]["b"]
+        assert OmegaConf.select(cfg.a, "b.c") == inp["a"]["b"]["c"]
         # relative keys
-        assert OmegaConf.select(cfg.a, ".") == input_cfg["a"]
-        assert OmegaConf.select(cfg.a, ".b") == input_cfg["a"]["b"]
-        assert OmegaConf.select(cfg.a, ".b.c") == input_cfg["a"]["b"]["c"]
-        assert OmegaConf.select(cfg.a, "..") == input_cfg
-        assert OmegaConf.select(cfg.a, "..a") == input_cfg["a"]
-        assert OmegaConf.select(cfg.a, "..a.b") == input_cfg["a"]["b"]
-        assert OmegaConf.select(cfg.a, "..z") == input_cfg["z"]
+        assert OmegaConf.select(cfg.a, ".") == inp["a"]
+        assert OmegaConf.select(cfg.a, ".b") == inp["a"]["b"]
+        assert OmegaConf.select(cfg.a, ".b.c") == inp["a"]["b"]["c"]
+        assert OmegaConf.select(cfg.a, "..") == inp
+        assert OmegaConf.select(cfg.a, "..a") == inp["a"]
+        assert OmegaConf.select(cfg.a, "..a.b") == inp["a"]["b"]
+        assert OmegaConf.select(cfg.a, "..z") == inp["z"]
+
+    def test_select_from_nested_node_absolute_key_interpretation(
+        self, struct: Optional[bool]
+    ) -> None:
+        inp: Any = {
+            "a": {
+                "b": {
+                    "c": 10,
+                }
+            },
+            "z": 10,
+        }
+        cfg = OmegaConf.create(inp)
+        OmegaConf.set_struct(cfg, struct)
+        # absolute keys are relative to the config root
+        assert OmegaConf.select(cfg.a, "", absolute_key=True) == inp
+        assert OmegaConf.select(cfg.a, "a", absolute_key=True) == inp["a"]
+        assert OmegaConf.select(cfg.a, "a.b", absolute_key=True) == inp["a"]["b"]
+        assert OmegaConf.select(cfg.a, "a.b.c", absolute_key=True) == inp["a"]["b"]["c"]
+        assert OmegaConf.select(cfg.a, "z", absolute_key=True) == inp["z"]
+        # relative keys
+        assert OmegaConf.select(cfg.a, ".", absolute_key=True) == inp["a"]
+        assert OmegaConf.select(cfg.a, ".b", absolute_key=True) == inp["a"]["b"]
+        assert OmegaConf.select(cfg.a, ".b.c", absolute_key=True) == inp["a"]["b"]["c"]
+        assert OmegaConf.select(cfg.a, "..", absolute_key=True) == inp
+        assert OmegaConf.select(cfg.a, "..a", absolute_key=True) == inp["a"]
+        assert OmegaConf.select(cfg.a, "..a.b", absolute_key=True) == inp["a"]["b"]
+        assert OmegaConf.select(cfg.a, "..z", absolute_key=True) == inp["z"]
 
 
 @mark.parametrize(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -193,60 +193,6 @@ class TestSelect:
         ):
             cfg.select("foo")
 
-    def test_select_from_nested_node_relative_key_interpretation(
-        self, struct: Optional[bool]
-    ) -> None:
-        inp: Any = {
-            "a": {
-                "b": {
-                    "c": 10,
-                }
-            },
-            "z": 10,
-        }
-        cfg = OmegaConf.create(inp)
-        OmegaConf.set_struct(cfg, struct)
-        # absolute keys are relative to the calling node
-        assert OmegaConf.select(cfg.a, "") == inp["a"]
-        assert OmegaConf.select(cfg.a, "b") == inp["a"]["b"]
-        assert OmegaConf.select(cfg.a, "b.c") == inp["a"]["b"]["c"]
-        # relative keys
-        assert OmegaConf.select(cfg.a, ".") == inp["a"]
-        assert OmegaConf.select(cfg.a, ".b") == inp["a"]["b"]
-        assert OmegaConf.select(cfg.a, ".b.c") == inp["a"]["b"]["c"]
-        assert OmegaConf.select(cfg.a, "..") == inp
-        assert OmegaConf.select(cfg.a, "..a") == inp["a"]
-        assert OmegaConf.select(cfg.a, "..a.b") == inp["a"]["b"]
-        assert OmegaConf.select(cfg.a, "..z") == inp["z"]
-
-    def test_select_from_nested_node_absolute_key_interpretation(
-        self, struct: Optional[bool]
-    ) -> None:
-        inp: Any = {
-            "a": {
-                "b": {
-                    "c": 10,
-                }
-            },
-            "z": 10,
-        }
-        cfg = OmegaConf.create(inp)
-        OmegaConf.set_struct(cfg, struct)
-        # absolute keys are relative to the config root
-        assert OmegaConf.select(cfg.a, "", absolute_key=True) == inp
-        assert OmegaConf.select(cfg.a, "a", absolute_key=True) == inp["a"]
-        assert OmegaConf.select(cfg.a, "a.b", absolute_key=True) == inp["a"]["b"]
-        assert OmegaConf.select(cfg.a, "a.b.c", absolute_key=True) == inp["a"]["b"]["c"]
-        assert OmegaConf.select(cfg.a, "z", absolute_key=True) == inp["z"]
-        # relative keys
-        assert OmegaConf.select(cfg.a, ".", absolute_key=True) == inp["a"]
-        assert OmegaConf.select(cfg.a, ".b", absolute_key=True) == inp["a"]["b"]
-        assert OmegaConf.select(cfg.a, ".b.c", absolute_key=True) == inp["a"]["b"]["c"]
-        assert OmegaConf.select(cfg.a, "..", absolute_key=True) == inp
-        assert OmegaConf.select(cfg.a, "..a", absolute_key=True) == inp["a"]
-        assert OmegaConf.select(cfg.a, "..a.b", absolute_key=True) == inp["a"]["b"]
-        assert OmegaConf.select(cfg.a, "..z", absolute_key=True) == inp["z"]
-
 
 @mark.parametrize(
     "cfg,key,expected",
@@ -305,3 +251,63 @@ def test_select_resolves_interpolation(cfg: Any, key: str, expected: Any) -> Non
             OmegaConf.select(cfg, key)
     else:
         assert OmegaConf.select(cfg, key) == expected
+
+
+inp: Any = {"a": {"b": {"c": 10}}, "z": 10}
+
+
+class TestSelectFromNestedNode:
+    # all selects are performed on cfg.a:
+    @mark.parametrize(
+        ("key", "expected"),
+        [
+            # relative keys
+            (".", inp["a"]),
+            (".b", inp["a"]["b"]),
+            (".b.c", inp["a"]["b"]["c"]),
+            ("..", inp),
+            ("..a", inp["a"]),
+            ("..a.b", inp["a"]["b"]),
+            ("..z", inp["z"]),
+        ],
+    )
+    def test_select_from_nested_node_with_a_relative_key(
+        self, key: str, expected: Any
+    ) -> None:
+        cfg = OmegaConf.create(inp)
+        # select returns the same result when a key is relative independent of absolute_key flag.
+        assert OmegaConf.select(cfg.a, key, absolute_key=False) == expected
+        assert OmegaConf.select(cfg.a, key, absolute_key=True) == expected
+
+    # all selects are performed on cfg.a:
+    @mark.parametrize(
+        ("key", "expected"),
+        [
+            # absolute keys are relative to the calling node
+            ("", inp["a"]),
+            ("b", inp["a"]["b"]),
+            ("b.c", inp["a"]["b"]["c"]),
+        ],
+    )
+    def test_select_from_nested_node_relative_key_interpretation(
+        self, key: str, expected: Any
+    ) -> None:
+        cfg = OmegaConf.create(inp)
+        assert OmegaConf.select(cfg.a, key, absolute_key=False) == expected
+
+    @mark.parametrize(
+        ("key", "expected"),
+        [
+            # absolute keys are relative to the config root
+            ("", inp),
+            ("a", inp["a"]),
+            ("a.b", inp["a"]["b"]),
+            ("a.b.c", inp["a"]["b"]["c"]),
+            ("z", inp["z"]),
+        ],
+    )
+    def test_select_from_nested_node_absolute_key_interpretation(
+        self, key: str, expected: Any
+    ) -> None:
+        cfg = OmegaConf.create(inp)
+        assert OmegaConf.select(cfg.a, key, absolute_key=True) == expected

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -198,10 +198,11 @@ class TestSelect:
             {"a": {"b": {"c": 10}}, "z": 10},
         )
         OmegaConf.set_struct(cfg, struct)
-        assert OmegaConf.select(cfg.a, ".") == {"b": {"c": 10}}
-        assert OmegaConf.select(cfg.a, "..") == {"a": {"b": {"c": 10}}, "z": 10}
-        assert OmegaConf.select(cfg.a, "..a") == {"b": {"c": 10}}
-        assert OmegaConf.select(cfg.a, "..z") == 10
+        assert OmegaConf.select(cfg.a, "") == {"b": {"c": 10}}
+        assert OmegaConf.select(cfg.a, "b") == {"c": 10}
+        assert OmegaConf.select(cfg.a, ".") == {"a": {"b": {"c": 10}}, "z": 10}
+        assert OmegaConf.select(cfg.a, ".a") == {"b": {"c": 10}}
+        assert OmegaConf.select(cfg.a, ".z") == 10
 
 
 @mark.parametrize(
@@ -261,13 +262,3 @@ def test_select_resolves_interpolation(cfg: Any, key: str, expected: Any) -> Non
             OmegaConf.select(cfg, key)
     else:
         assert OmegaConf.select(cfg, key) == expected
-
-
-def test_select_relative_from_nested_node() -> None:
-    cfg = OmegaConf.create(
-        {"a": {"b": {"c": 10}}, "z": 10},
-    )
-    assert OmegaConf.select(cfg.a, ".") == {"b": {"c": 10}}
-    assert OmegaConf.select(cfg.a, "..") == {"a": {"b": {"c": 10}}, "z": 10}
-    assert OmegaConf.select(cfg.a, "..a") == {"b": {"c": 10}}
-    assert OmegaConf.select(cfg.a, "..z") == 10


### PR DESCRIPTION
The support added for relative keys in select (#656) was a breaking change.
in 2.0, when select is called on a nested node, it's already relative.
#656 made that select absolute, which is a breaking change.

A non breaking fix is to keep nested selects relative, but add support for relative syntax (specifically for going up the hierarchy).
The resulting behavior is shown below and can be a bit surprising:
```python
from omegaconf import OmegaConf

cfg = OmegaConf.create(
    {
        "a": {
            "b": {
                "c": 10,
            }
        },
        "z": 10,
    },
)
# works on 2.0
assert OmegaConf.select(cfg.a, "") == {"b": {"c": 10}}
assert OmegaConf.select(cfg.a, "b") == {"c": 10}
# new behavior, going up one level (as an example):
assert OmegaConf.select(cfg.a, ".") == {"a": {"b": {"c": 10}}, "z": 10}
assert OmegaConf.select(cfg.a, ".a") == {"b": {"c": 10}}
assert OmegaConf.select(cfg.a, ".z") == 10
```

In most scenarios, going up a level requires two dots. but since OmegaConf.select on a nested node is already relative to that node, only one dot is needed.

The API is establishing the non-breaking implementation.
An alternative is to make this breaking (the behavior from #656).

The non-breaking behavior will look weird when using select inside custom resolvers using select as an alternative way to access nodes (this is using a planned oc.select resolver that will just call OmegaConf.select):
```yaml
a: 10
foo:
  a: 20
  b: ${oc.select: .a) # relative to foo, one level up: 10
  b: ${oc.select: a) # relative to foo: 20
  # as opposed to:
  c: ${a}  # absolute: 10
  c: ${.a}  # relative: 20
```
I am not particularly happy with this.
On the one hand, select being relative to the node it's called on is intuitive and is the current behavior.
On the other hand, it's inconsistent with interpolations.
Thoughts?

I am planning to merge this because this is fixing an unintentional breaking change, but let's decide if we actually want to make this an intentional breaking change (and at the point, users will need to use relative select syntax to get relative behavior, like in interpolations.

EDIT:
Final solution is different than anything above.
read the code and look at the tests to understand it.