### PR TITLE
Refactoring: `_maybe_dereference_node`

### DIFF
--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -13,7 +13,6 @@ def _resolve_container_value(cfg: Container, key: Any) -> None:
         except InterpolationToMissingValueError:
             node._set_value(MISSING)
         else:
-            assert resolved is not None
             if isinstance(resolved, Container):
                 _resolve(resolved)
             if isinstance(resolved, Container) and isinstance(node, ValueNode):
@@ -32,7 +31,6 @@ def _resolve(cfg: Node) -> Node:
         except InterpolationToMissingValueError:
             cfg._set_value(MISSING)
         else:
-            assert resolved is not None
             cfg._set_value(resolved._value())
 
     if isinstance(cfg, DictConfig):

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -390,7 +390,7 @@ def _is_none(
         return value is None
 
     if resolve:
-        value = value._dereference_node(
+        value = value._maybe_dereference_node(
             throw_on_resolution_failure=throw_on_resolution_failure
         )
         if not throw_on_resolution_failure and value is None:

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -201,13 +201,10 @@ class Node(ABC):
     def _get_full_key(self, key: Optional[Union[DictKeyType, int]]) -> str:
         ...
 
-    def _dereference_node(
-        self,
-        throw_on_resolution_failure: bool = True,
-    ) -> Optional["Node"]:
-        return self._dereference_node_impl(
-            throw_on_resolution_failure=throw_on_resolution_failure
-        )
+    def _dereference_node(self) -> "Node":
+        node = self._dereference_node_impl(throw_on_resolution_failure=True)
+        assert node is not None
+        return node
 
     def _maybe_dereference_node(
         self,

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -209,6 +209,14 @@ class Node(ABC):
             throw_on_resolution_failure=throw_on_resolution_failure
         )
 
+    def _maybe_dereference_node(
+        self,
+        throw_on_resolution_failure: bool = False,
+    ) -> Optional["Node"]:
+        return self._dereference_node_impl(
+            throw_on_resolution_failure=throw_on_resolution_failure
+        )
+
     def _dereference_node_impl(
         self,
         throw_on_resolution_failure: bool = True,
@@ -390,7 +398,7 @@ class Container(Node):
                 throw_on_type_error=throw_on_resolution_failure,
             )
             if isinstance(ret, Node):
-                ret = ret._dereference_node(
+                ret = ret._maybe_dereference_node(
                     throw_on_resolution_failure=throw_on_resolution_failure,
                 )
 

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -215,8 +215,7 @@ class Node(ABC):
         )
 
     def _dereference_node_impl(
-        self,
-        throw_on_resolution_failure: bool = True,
+        self, throw_on_resolution_failure: bool
     ) -> Optional["Node"]:
         if not self._is_interpolation():
             return self

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -205,6 +205,14 @@ class Node(ABC):
         self,
         throw_on_resolution_failure: bool = True,
     ) -> Optional["Node"]:
+        return self._dereference_node_impl(
+            throw_on_resolution_failure=throw_on_resolution_failure
+        )
+
+    def _dereference_node_impl(
+        self,
+        throw_on_resolution_failure: bool = True,
+    ) -> Optional["Node"]:
         if not self._is_interpolation():
             return self
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -349,9 +349,7 @@ class BaseContainer(Container, ABC):
                 expand(dest_node)
 
             if dest_node is not None and dest_node._is_interpolation():
-                target_node = dest_node._dereference_node(
-                    throw_on_resolution_failure=False
-                )
+                target_node = dest_node._maybe_dereference_node()
                 if isinstance(target_node, Container):
                     dest[key] = target_node
                     dest_node = dest._get_node(key)
@@ -630,9 +628,9 @@ class BaseContainer(Container, ABC):
         dv2: Optional[Node] = v2
 
         if v1_inter:
-            dv1 = v1._dereference_node(throw_on_resolution_failure=False)
+            dv1 = v1._maybe_dereference_node()
         if v2_inter:
-            dv2 = v2._dereference_node(throw_on_resolution_failure=False)
+            dv2 = v2._maybe_dereference_node()
 
         if v1_inter and v2_inter:
             if dv1 is None or dv2 is None:

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -223,9 +223,8 @@ class BaseContainer(Container, ABC):
                 node = conf._get_node(key)
                 assert isinstance(node, Node)
                 if resolve:
-                    node = node._dereference_node(throw_on_resolution_failure=True)
+                    node = node._dereference_node()
 
-                assert node is not None
                 if enum_to_str and isinstance(key, Enum):
                     key = f"{key.name}"
                 if isinstance(node, Container):
@@ -244,8 +243,7 @@ class BaseContainer(Container, ABC):
                 node = conf._get_node(index)
                 assert isinstance(node, Node)
                 if resolve:
-                    node = node._dereference_node(throw_on_resolution_failure=True)
-                assert node is not None
+                    node = node._dereference_node()
                 if isinstance(node, Container):
                     item = BaseContainer._to_content(
                         node,

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -700,8 +700,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         for k in self.keys():
             node = self._get_node(k)
             assert isinstance(node, Node)
-            node = node._dereference_node(throw_on_resolution_failure=True)
-            assert node is not None
+            node = node._dereference_node()
             if isinstance(node, Container):
                 v = BaseContainer._to_content(
                     node,

--- a/pydevd_plugins/extensions/pydevd_plugin_omegaconf.py
+++ b/pydevd_plugins/extensions/pydevd_plugin_omegaconf.py
@@ -76,7 +76,7 @@ class OmegaConfUserResolver(StrPresentationProvider):  # type: ignore
 
     def _get_dictionary(self, obj: Any) -> Dict[str, Any]:
         if isinstance(obj, self.Node):
-            obj = obj._dereference_node(throw_on_resolution_failure=False)
+            obj = obj._maybe_dereference_node()
             if obj is None or obj._is_none() or obj._is_missing():
                 return {}
 

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -208,7 +208,7 @@ def test_resolve_interpolation_without_parent() -> None:
 
 def test_resolve_interpolation_without_parent_no_throw() -> None:
     cfg = DictConfig(content="${foo}")
-    assert cfg._dereference_node(throw_on_resolution_failure=False) is None
+    assert cfg._maybe_dereference_node() is None
 
 
 def test_optional_after_interpolation() -> None:
@@ -227,7 +227,8 @@ def test_invalid_intermediate_result_when_not_throwing(
 
     The main goal of this test is to make sure that the resolution of an interpolation
     is stopped immediately when a missing / resolution failure occurs, even if
-    `throw_on_resolution_failure` is set to False.
+    `_maybe_dereference_node(throw_on_resolution_failure=False)` is used
+    instead of `_dereference_node`.
     When this happens while dereferencing a node, the result should be `None`.
     """
 
@@ -243,7 +244,7 @@ def test_invalid_intermediate_result_when_not_throwing(
     )
     x_node = cfg._get_node("x")
     assert isinstance(x_node, Node)
-    assert x_node._dereference_node(throw_on_resolution_failure=False) is None
+    assert x_node._maybe_dereference_node(throw_on_resolution_failure=False) is None
 
 
 def test_none_value_in_quoted_string(restore_resolvers: Any) -> None:
@@ -442,4 +443,4 @@ def test_interpolation_readonly_node() -> None:
 def test_type_validation_error_no_throw() -> None:
     cfg = OmegaConf.structured(User(name="Bond", age=SI("${name}")))
     bad_node = cfg._get_node("age")
-    assert bad_node._dereference_node(throw_on_resolution_failure=False) is None
+    assert bad_node._maybe_dereference_node() is None

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -593,6 +593,6 @@ def test_dereference_interpolation_to_missing() -> None:
     cfg = OmegaConf.create({"x": "${y}", "y": "???"})
     x_node = cfg._get_node("x")
     assert isinstance(x_node, Node)
-    assert x_node._dereference_node(throw_on_resolution_failure=False) is None
+    assert x_node._maybe_dereference_node() is None
     with raises(InterpolationToMissingValueError):
         cfg.x


### PR DESCRIPTION
On `master`, the `Node._dereference_node` method returns `Optional[Node]`. This leads to some `assert node is not None` statements in the code (for the benefit of `mypy`).

This PR does two things:
  - introduce a new method, `Node._maybe_dereference_node`, which returns `Optional[Node]`
  - change the type signature of `_dereference_node` to retrurn `Node` (not optional).

This change lets us delete some of the `node is not None` assertions.

This PR is a followup to https://github.com/omry/omegaconf/pull/502#discussion_r608711688.