### PR TITLE
Additional optimization to update() without force_add

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any, Dict, List
 
 from pytest import lazy_fixture  # type: ignore
@@ -53,12 +54,6 @@ def dict_config_with_list_leaf(dict_with_list_leaf: Any) -> Any:
 
 @fixture(scope="module")
 def large_dict_config(large_dict: Any) -> Any:
-    return OmegaConf.create(large_dict)
-
-
-# Use this version if you intend to modify the config in a test.
-@fixture(scope="function")
-def large_dict_config_by_test(large_dict: Any) -> Any:
     return OmegaConf.create(large_dict)
 
 
@@ -160,9 +155,9 @@ def test_is_missing_literal(benchmark: Any) -> None:
 @mark.parametrize("force_add", [False, True])
 @mark.parametrize("key", ["a", "a.a.a.a.a.a.a.a.a.a.a"])
 def test_update_force_add(
-    large_dict_config_by_test: Any, key: str, force_add: bool, benchmark: Any
+    large_dict_config: Any, key: str, force_add: bool, benchmark: Any
 ) -> None:
-    cfg = large_dict_config_by_test
+    cfg = copy.deepcopy(large_dict_config)  # this test modifies the config
     if force_add:
         OmegaConf.set_struct(cfg, True)
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -3,9 +3,20 @@ import os
 import re
 import string
 import sys
+from contextlib import contextmanager
 from enum import Enum
 from textwrap import dedent
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, get_type_hints
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    get_type_hints,
+)
 
 import yaml
 
@@ -901,3 +912,10 @@ def split_key(key: str) -> List[str]:
     tokens += [dot_key if dot_key else bracket_key for dot_key, bracket_key in others]
 
     return tokens
+
+
+# Similar to Python 3.7+'s `contextlib.nullcontext` (which should be used instead,
+# once support for Python 3.6 is dropped).
+@contextmanager
+def nullcontext(enter_result: Any = None) -> Iterator[Any]:
+    yield enter_result

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -47,6 +47,7 @@ from ._utils import (
     is_primitive_list,
     is_structured_config,
     is_tuple_annotation,
+    nullcontext,
     split_key,
     type_str,
 )
@@ -748,8 +749,8 @@ class OmegaConf:
         if isinstance(root, ListConfig):
             last_key = int(last)
 
-        struct_override = False if force_add else root._get_node_flag("struct")
-        with flag_override(root, "struct", struct_override):
+        ctx = flag_override(root, "struct", False) if force_add else nullcontext()
+        with ctx:
             if merge and (OmegaConf.is_config(value) or is_primitive_container(value)):
                 assert isinstance(root, BaseContainer)
                 node = root._get_node(last_key)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,6 @@
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import attr
 
@@ -47,11 +46,6 @@ class Dataframe:
     def __bool__(self) -> None:
         """Mimic pandas DataFrame __bool__, which raises a ValueError"""
         raise ValueError
-
-
-@contextmanager
-def does_not_raise(enter_result: Any = None) -> Iterator[Any]:
-    yield enter_result
 
 
 class Color(Enum):

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -17,8 +17,9 @@ from omegaconf import (
     open_dict,
     read_write,
 )
+from omegaconf._utils import nullcontext
 from omegaconf.errors import ConfigAttributeError, ConfigKeyError, MissingMandatoryValue
-from tests import StructuredWithMissing, does_not_raise
+from tests import StructuredWithMissing
 
 
 @mark.parametrize(
@@ -313,7 +314,7 @@ def test_flag_override(
     with expectation:
         func(c)
 
-    with does_not_raise():
+    with nullcontext():
         with flag_override(c, flag_name, False):
             func(c)
 
@@ -359,7 +360,7 @@ def test_read_write_override(src: Any, func: Any, expectation: Any) -> None:
     with expectation:
         func(c)
 
-    with does_not_raise():
+    with nullcontext():
         with read_write(c):
             func(c)
 
@@ -375,7 +376,7 @@ def test_struct_override(src: Any, func: Any, expectation: Any) -> None:
     with expectation:
         func(c)
 
-    with does_not_raise():
+    with nullcontext():
         with open_dict(c):
             func(c)
 

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional
 from pytest import mark, param, raises
 
 from omegaconf import MISSING, AnyNode, DictConfig, ListConfig, OmegaConf, flag_override
+from omegaconf._utils import nullcontext
 from omegaconf.errors import (
     ConfigTypeError,
     InterpolationKeyError,
@@ -16,7 +17,7 @@ from omegaconf.errors import (
     ValidationError,
 )
 from omegaconf.nodes import IntegerNode, StringNode
-from tests import Color, IllegalType, User, does_not_raise
+from tests import Color, IllegalType, User
 
 
 def test_list_value() -> None:
@@ -522,10 +523,10 @@ def test_extend(src: List[Any], append: List[Any], result: List[Any]) -> None:
 @mark.parametrize(
     "src, remove, result, expectation",
     [
-        ([10], 10, [], does_not_raise()),
+        ([10], 10, [], nullcontext()),
         ([], "oops", None, raises(ValueError)),
-        ([0, dict(a="blah"), 10], dict(a="blah"), [0, 10], does_not_raise()),
-        ([1, 2, 1, 2], 2, [1, 1, 2], does_not_raise()),
+        ([0, dict(a="blah"), 10], dict(a="blah"), [0, 10], nullcontext()),
+        ([1, 2, 1, 2], 2, [1, 1, 2], nullcontext()),
     ],
 )
 def test_remove(src: List[Any], remove: Any, result: Any, expectation: Any) -> None:
@@ -549,8 +550,8 @@ def test_clear(src: List[Any], num_clears: int) -> None:
     "src, item, expected_index, expectation",
     [
         ([], 20, -1, raises(ValueError)),
-        ([10, 20], 10, 0, does_not_raise()),
-        ([10, 20], 20, 1, does_not_raise()),
+        ([10, 20], 10, 0, nullcontext()),
+        ([10, 20], 20, 1, nullcontext()),
     ],
 )
 def test_index(

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -14,13 +14,13 @@ from omegaconf import (
     grammar_parser,
     grammar_visitor,
 )
+from omegaconf._utils import nullcontext
 from omegaconf.errors import (
     GrammarParseError,
     InterpolationKeyError,
     InterpolationResolutionError,
     UnsupportedInterpolationType,
 )
-from tests import does_not_raise
 
 # Characters that are not allowed by the grammar in config key names.
 INVALID_CHARS_IN_KEY_NAMES = "\\{}()[].: '\""
@@ -596,7 +596,7 @@ class TestDoNotMatchSimpleInterpolationPattern:
         assert grammar_parser.SIMPLE_INTERPOLATION_PATTERN.match(expression) is None
 
     def test_grammar_consistency(self, expression: str, is_valid_grammar: bool) -> None:
-        ctx: Any = does_not_raise() if is_valid_grammar else raises(GrammarParseError)
+        ctx: Any = nullcontext() if is_valid_grammar else raises(GrammarParseError)
         with ctx:
             grammar_parser.parse(
                 value=expression,

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -14,27 +14,21 @@ from omegaconf import (
     OmegaConf,
     StringNode,
 )
-from omegaconf._utils import _is_none
+from omegaconf._utils import _is_none, nullcontext
 from omegaconf.errors import (
     ConfigKeyError,
     InterpolationKeyError,
     InterpolationToMissingValueError,
     UnsupportedInterpolationType,
 )
-from tests import (
-    Color,
-    ConcretePlugin,
-    IllegalType,
-    StructuredWithMissing,
-    does_not_raise,
-)
+from tests import Color, ConcretePlugin, IllegalType, StructuredWithMissing
 
 
 @mark.parametrize(
     "cfg, key, expected_is_missing, expectation",
     [
         ({}, "foo", False, raises(ConfigKeyError)),
-        ({"foo": True}, "foo", False, does_not_raise()),
+        ({"foo": True}, "foo", False, nullcontext()),
         ({"foo": "${no_such_key}"}, "foo", False, raises(InterpolationKeyError)),
         ({"foo": MISSING}, "foo", True, raises(MissingMandatoryValue)),
         param(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from omegaconf._utils import (
     _get_value,
     is_dict_annotation,
     is_list_annotation,
+    nullcontext,
     split_key,
 )
 from omegaconf.errors import UnsupportedValueType, ValidationError
@@ -637,3 +638,12 @@ def test_marker_string_representation() -> None:
 )
 def test_split_key(key: str, expected: List[str]) -> None:
     assert split_key(key) == expected
+
+
+def test_nullcontext() -> None:
+    with nullcontext() as x:
+        assert x is None
+
+    obj = object()
+    with nullcontext(obj) as x:
+        assert x is obj


### PR DESCRIPTION
This avoids invalidating the flags cache with `force_add=False`.

This gives a ~10% speed-up on the benchmark test_update_force_add that
updates the key ""a.a.a.a.a.a.a.a.a.a.a" (previous benchmark), and a
~50% speed-up on the new (and faster) benchmark that just updates "a".

This commit also fixes an issue with this benchmark, where re-using the
same config across tests was introducing dependencies between tests.

======================

This is the other optimization I had suggested in https://github.com/omry/omegaconf/pull/665#discussion_r608611363

Note: there is still an issue with this benchmark because the large dictconfig is only created once for each test, and re-used across the multiple calls to the function within `benchmark()`. As a result both the flags cache and the config itself aren't the same between the first call and subsequent calls.

I tried to play with the pedantic mode (https://pytest-benchmark.readthedocs.io/en/latest/pedantic.html) to have a proper setup always providing the same config as input, but I got very surprising timing results. I wasn't sure if there was an issue with my code, my understanding of the pedantic mode, or if these results were actually correct, so I didn't investigate further at this time.