### PR TITLE
oc.deprecated

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -158,7 +158,7 @@ texinfo_documents = [
         "OmegaConf Documentation",
         author,
         "OmegaConf",
-        "Flexible python configuration system.",
+        "Flexible Python configuration system. The last one you will ever need.",
         "Miscellaneous",
     )
 ]

--- a/docs/source/custom_resolvers.rst
+++ b/docs/source/custom_resolvers.rst
@@ -1,0 +1,262 @@
+.. testsetup:: *
+
+    from omegaconf import OmegaConf, DictConfig
+    import os
+    def show(x):
+      print(f"type: {type(x).__name__}, value: {repr(x)}")
+
+.. _custom_resolvers:
+
+Custom resolvers
+----------------
+
+You can add additional interpolation types by registering custom resolvers with ``OmegaConf.register_new_resolver()``:
+
+.. code-block:: python
+
+    def register_new_resolver(
+        name: str,
+        resolver: Resolver,
+        *,
+        replace: bool = False,
+        use_cache: bool = False,
+    ) -> None
+
+Attempting to register the same resolver twice will raise a ``ValueError`` unless using ``replace=True``.
+
+The example below creates a resolver that adds 10 to the given value.
+
+.. doctest::
+
+    >>> OmegaConf.register_new_resolver("plus_10", lambda x: x + 10)
+    >>> c = OmegaConf.create({'key': '${plus_10:990}'})
+    >>> c.key
+    1000
+
+Custom resolvers support variadic argument lists in the form of a comma separated list of zero or more values.
+Whitespaces are stripped from both ends of each value ("foo,bar" is the same as "foo, bar ").
+You can use literal commas and spaces anywhere by escaping (:code:`\,` and :code:`\ `), or
+simply use quotes to bypass character limitations in strings.
+
+.. doctest::
+
+    >>> OmegaConf.register_new_resolver("concat", lambda x, y: x+y)
+    >>> c = OmegaConf.create({
+    ...     'key1': '${concat:Hello,World}',
+    ...     'key_trimmed': '${concat:Hello , World}',
+    ...     'escape_whitespace': '${concat:Hello,\ World}',
+    ...     'quoted': '${concat:"Hello,", " World"}',
+    ... })
+    >>> c.key1
+    'HelloWorld'
+    >>> c.key_trimmed
+    'HelloWorld'
+    >>> c.escape_whitespace
+    'Hello World'
+    >>> c.quoted
+    'Hello, World'
+
+
+Custom resolvers can return lists or dictionaries, that are automatically converted into DictConfig and ListConfig:
+
+.. doctest::
+
+    >>> OmegaConf.register_new_resolver(
+    ...     "min_max", lambda *a: {"min": min(a), "max": max(a)}
+    ... )
+    >>> c = OmegaConf.create({'stats': '${min_max: -1, 3, 2, 5, -10}'})
+    >>> assert isinstance(c.stats, DictConfig)
+    >>> c.stats.min, c.stats.max
+    (-10, 5)
+
+
+You can take advantage of nested interpolations to perform custom operations over variables:
+
+.. doctest::
+
+    >>> OmegaConf.register_new_resolver("sum", lambda x, y: x + y)
+    >>> c = OmegaConf.create({"a": 1,
+    ...                       "b": 2,
+    ...                       "a_plus_b": "${sum:${a},${b}}"})
+    >>> c.a_plus_b
+    3
+
+More advanced resolver naming features include the ability to prefix a resolver name with a
+namespace, and to use interpolations in the name itself. The following example demonstrates both:
+
+.. doctest::
+
+    >>> OmegaConf.register_new_resolver("mylib.plus1", lambda x: x + 1)
+    >>> c = OmegaConf.create(
+    ...     {
+    ...         "func": "plus1",
+    ...         "x": "${mylib.${func}:3}",
+    ...     }
+    ... )
+    >>> c.x
+    4
+
+
+By default a custom resolver is called on every access, but it is possible to cache its output
+by registering it with ``use_cache=True``.
+This may be useful either for performance reasons or to ensure the same value is always returned.
+Note that the cache is based on the string literals representing the resolver's inputs, and not
+the inputs themselves:
+
+.. doctest::
+
+    >>> import random
+    >>> random.seed(1234)
+    >>> OmegaConf.register_new_resolver(
+    ...    "cached", random.randint, use_cache=True
+    ... )
+    >>> OmegaConf.register_new_resolver("uncached", random.randint)
+    >>> c = OmegaConf.create(
+    ...     {
+    ...         "uncached": "${uncached:0,10000}",
+    ...         "cached_1": "${cached:0,10000}",
+    ...         "cached_2": "${cached:0, 10000}",
+    ...         "cached_3": "${cached:0,${uncached}}",
+    ...     }
+    ... )
+    >>> # not the same since the cache is disabled by default
+    >>> assert c.uncached != c.uncached
+    >>> # same value on repeated access thanks to the cache
+    >>> assert c.cached_1 == c.cached_1 == 122
+    >>> # same input as `cached_1` => same value
+    >>> assert c.cached_2 == c.cached_1 == 122
+    >>> # same string literal "${uncached}" => same value
+    >>> assert c.cached_3 == c.cached_3 == 1192
+
+
+Custom interpolations can also receive the following special parameters:
+
+- ``_parent_`` : the parent node of an interpolation.
+- ``_root_``: The config root.
+
+This can be achieved by adding the special parameters to the resolver signature.
+Note that special parameters must be defined as named keywords (after the `*`):
+
+In this example, we use ``_parent_`` to implement a sum function that defaults to 0 if the node does not exist.
+(In contrast to the sum we defined earlier where accessing an invalid key, e.g. ``"a_plus_z": ${sum:${a}, ${z}}`` will result in an error).
+
+.. doctest::
+
+    >>> def sum2(a, b, *, _parent_):
+    ...     return _parent_.get(a, 0) + _parent_.get(b, 0)
+    >>> OmegaConf.register_new_resolver("sum2", sum2, use_cache=False)
+    >>> cfg = OmegaConf.create(
+    ...     {
+    ...         "node": {
+    ...             "a": 1,
+    ...             "b": 2,
+    ...             "a_plus_b": "${sum2:a,b}",
+    ...             "a_plus_z": "${sum2:a,z}",
+    ...         },
+    ...     }
+    ... )
+    >>> cfg.node.a_plus_b
+    3
+    >>> cfg.node.a_plus_z
+    1
+
+
+Built-in resolvers
+------------------
+
+.. _oc.env:
+
+oc.env 
+^^^^^^
+
+Access to environment variables is supported using ``oc.env``:
+
+Input YAML file:
+
+.. include:: env_interpolation.yaml
+   :code: yaml
+
+.. doctest::
+
+    >>> conf = OmegaConf.load('source/env_interpolation.yaml')
+    >>> conf.user.name
+    'omry'
+    >>> conf.user.home
+    '/home/omry'
+
+You can specify a default value to use in case the environment variable is not set.
+In such a case, the default value is converted to a string using ``str(default)``, unless it is ``null`` (representing Python ``None``) - in which case ``None`` is returned. 
+
+The following example falls back to default passwords when ``DB_PASSWORD`` is not defined:
+
+
+.. _oc.decode:
+
+oc.decode
+^^^^^^^^^
+
+Strings may be converted using ``oc.decode``:
+
+- Primitive values (e.g., ``"true"``, ``"1"``, ``"1e-3"``) are automatically converted to their corresponding type (bool, int, float)
+- Dictionaries and lists (e.g., ``"{a: b}"``, ``"[a, b, c]"``)  are returned as transient config nodes (DictConfig and ListConfig)
+- Interpolations (e.g., ``"${foo}"``) are automatically resolved
+- ``None`` is the only valid non-string input to ``oc.decode`` (returning ``None`` in that case)
+
+This can be useful for instance to parse environment variables:
+
+.. doctest::
+
+    >>> cfg = OmegaConf.create(
+    ...     {
+    ...         "database": {
+    ...             "port": '${oc.decode:${oc.env:DB_PORT}}',
+    ...             "nodes": '${oc.decode:${oc.env:DB_NODES}}',
+    ...             "timeout": '${oc.decode:${oc.env:DB_TIMEOUT,null}}',
+    ...         }
+    ...     }
+    ... )
+    >>> os.environ["DB_PORT"] = "3308"
+    >>> show(cfg.database.port)  # converted to int
+    type: int, value: 3308
+    >>> os.environ["DB_NODES"] = "[host1, host2, host3]"
+    >>> show(cfg.database.nodes)  # converted to a ListConfig
+    type: ListConfig, value: ['host1', 'host2', 'host3']
+    >>> show(cfg.database.timeout)  # keeping `None` as is
+    type: NoneType, value: None
+    >>> os.environ["DB_TIMEOUT"] = "${.port}"
+    >>> show(cfg.database.timeout)  # resolving interpolation
+    type: int, value: 3308
+
+
+.. _oc.dict.{keys,values}:
+
+oc.dict.{keys,value}
+^^^^^^^^^^^^^^^^^^^^
+
+Some config options that are stored as a ``DictConfig`` may sometimes be easier to manipulate as lists,
+when we care only about the keys or the associated values.
+
+The resolvers ``oc.dict.keys`` and ``oc.dict.values`` simplify such operations by offering an alternative
+view of a dictionary's keys or values as a list.
+They take as input a string that is the path to another config node (using the same syntax
+as interpolations) and return a ``ListConfig`` with its keys / values.
+
+.. doctest::
+
+    >>> cfg = OmegaConf.create(
+    ...     {
+    ...         "workers": {
+    ...             "node3": "10.0.0.2",
+    ...             "node7": "10.0.0.9",
+    ...         },
+    ...         "nodes": "${oc.dict.keys: workers}",
+    ...         "ips": "${oc.dict.values: workers}",
+    ...     }
+    ... )
+    >>> # Keys are copied from the DictConfig:
+    >>> show(cfg.nodes)
+    type: ListConfig, value: ['node3', 'node7']
+    >>> # Values are dynamically fetched through interpolations:
+    >>> show(cfg.ips)
+    type: ListConfig, value: ['${workers.node3}', '${workers.node7}']
+    >>> assert cfg.ips == ["10.0.0.2", "10.0.0.9"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,9 @@ OmegaConf also offers runtime type safety via Structured Configs.
    :maxdepth: 2
 
    usage
+   custom_resolvers
    structured_config
+
 
 
 Indices and tables

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -5,7 +5,6 @@
     import sys
     import tempfile
     import pickle
-    os.environ['USER'] = 'omry'
     # ensures that DB_TIMEOUT is not set in the doc.
     os.environ.pop('DB_TIMEOUT', None)
 
@@ -385,9 +384,9 @@ Interpolated nodes can be any node in the config, not just leaf nodes:
 
 Resolvers
 ^^^^^^^^^
-You can add additional interpolation types by registering resolvers using ``OmegaConf.register_new_resolver()``.
+Add new interpolation types by registering resolvers using ``OmegaConf.register_new_resolver()``.
 Such resolvers are called when the config node is accessed.
-See :doc:`custom_resolvers` for more details, or keep reading for a minimal example.
+The minimal example below shows its most basic usage, see :doc:`custom_resolvers` for more details.
 
 .. doctest::
 
@@ -403,7 +402,8 @@ Built-in resolvers
 OmegaConf comes with a set of built-in custom resolvers:
 
 * :ref:`oc.decode`: Parsing an input string using interpolation grammar
-* :ref:`oc.env`: Accessing environment variables.
+* :ref:`oc.deprecated`: Deprecate a key in your config
+* :ref:`oc.env`: Accessing environment variables
 * :ref:`oc.dict.{keys,values}`: Viewing the keys or the values of a dictionary as a list
 
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -383,272 +383,28 @@ Interpolated nodes can be any node in the config, not just leaf nodes:
     >>> (cfg.player.height, cfg.player.weight)
     (180, 75)
 
-
-Environment variable interpolation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Access to environment variables is supported using ``oc.env``:
-
-Input YAML file:
-
-.. include:: env_interpolation.yaml
-   :code: yaml
-
-.. doctest::
-
-    >>> conf = OmegaConf.load('source/env_interpolation.yaml')
-    >>> conf.user.name
-    'omry'
-    >>> conf.user.home
-    '/home/omry'
-
-You can specify a default value to use in case the environment variable is not set.
-In such a case, the default value is converted to a string using ``str(default)``, unless it is ``null`` (representing Python ``None``) - in which case ``None`` is returned. 
-
-The following example falls back to default passwords when ``DB_PASSWORD`` is not defined:
-
-.. doctest::
-
-    >>> cfg = OmegaConf.create(
-    ...     {
-    ...         "database": {
-    ...             "password1": "${oc.env:DB_PASSWORD,password}",
-    ...             "password2": "${oc.env:DB_PASSWORD,12345}",
-    ...             "password3": "${oc.env:DB_PASSWORD,null}",
-    ...         },
-    ...     }
-    ... )
-    >>> # default is already a string
-    >>> show(cfg.database.password1)
-    type: str, value: 'password'
-    >>> # default is converted to a string automatically
-    >>> show(cfg.database.password2)
-    type: str, value: '12345'
-    >>> # unless it's None
-    >>> show(cfg.database.password3)
-    type: NoneType, value: None
-
-
-Decoding strings with interpolations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Strings may be converted using ``oc.decode``:
-
-- Primitive values (e.g., ``"true"``, ``"1"``, ``"1e-3"``) are automatically converted to their corresponding type (bool, int, float)
-- Dictionaries and lists (e.g., ``"{a: b}"``, ``"[a, b, c]"``)  are returned as transient config nodes (DictConfig and ListConfig)
-- Interpolations (e.g., ``"${foo}"``) are automatically resolved
-- ``None`` is the only valid non-string input to ``oc.decode`` (returning ``None`` in that case)
-
-This can be useful for instance to parse environment variables:
-
-.. doctest::
-
-    >>> cfg = OmegaConf.create(
-    ...     {
-    ...         "database": {
-    ...             "port": '${oc.decode:${oc.env:DB_PORT}}',
-    ...             "nodes": '${oc.decode:${oc.env:DB_NODES}}',
-    ...             "timeout": '${oc.decode:${oc.env:DB_TIMEOUT,null}}',
-    ...         }
-    ...     }
-    ... )
-    >>> os.environ["DB_PORT"] = "3308"
-    >>> show(cfg.database.port)  # converted to int
-    type: int, value: 3308
-    >>> os.environ["DB_NODES"] = "[host1, host2, host3]"
-    >>> show(cfg.database.nodes)  # converted to a ListConfig
-    type: ListConfig, value: ['host1', 'host2', 'host3']
-    >>> show(cfg.database.timeout)  # keeping `None` as is
-    type: NoneType, value: None
-    >>> os.environ["DB_TIMEOUT"] = "${.port}"
-    >>> show(cfg.database.timeout)  # resolving interpolation
-    type: int, value: 3308
-
-
-Extracting lists of keys / values from a dictionary
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Some config options that are stored as a ``DictConfig`` may sometimes be easier to manipulate as lists,
-when we care only about the keys or the associated values.
-
-The resolvers ``oc.dict.keys`` and ``oc.dict.values`` simplify such operations by offering an alternative
-view of a dictionary's keys or values as a list.
-They take as input a string that is the path to another config node (using the same syntax
-as interpolations) and return a ``ListConfig`` with its keys / values.
-
-.. doctest::
-
-    >>> cfg = OmegaConf.create(
-    ...     {
-    ...         "workers": {
-    ...             "node3": "10.0.0.2",
-    ...             "node7": "10.0.0.9",
-    ...         },
-    ...         "nodes": "${oc.dict.keys: workers}",
-    ...         "ips": "${oc.dict.values: workers}",
-    ...     }
-    ... )
-    >>> # Keys are copied from the DictConfig:
-    >>> show(cfg.nodes)
-    type: ListConfig, value: ['node3', 'node7']
-    >>> # Values are dynamically fetched through interpolations:
-    >>> show(cfg.ips)
-    type: ListConfig, value: ['${workers.node3}', '${workers.node7}']
-    >>> assert cfg.ips == ["10.0.0.2", "10.0.0.9"]
-
-
-Custom interpolations
-^^^^^^^^^^^^^^^^^^^^^
-
-You can add additional interpolation types by registering custom resolvers with ``OmegaConf.register_new_resolver()``:
-
-.. code-block:: python
-
-    def register_new_resolver(
-        name: str,
-        resolver: Resolver,
-        *,
-        replace: bool = False,
-        use_cache: bool = False,
-    ) -> None
-
-Attempting to register the same resolver twice will raise a ``ValueError`` unless using ``replace=True``.
-
-The example below creates a resolver that adds 10 to the given value.
-
-.. doctest::
-
-    >>> OmegaConf.register_new_resolver("plus_10", lambda x: x + 10)
-    >>> c = OmegaConf.create({'key': '${plus_10:990}'})
-    >>> c.key
-    1000
-
-Custom resolvers support variadic argument lists in the form of a comma separated list of zero or more values.
-Whitespaces are stripped from both ends of each value ("foo,bar" is the same as "foo, bar ").
-You can use literal commas and spaces anywhere by escaping (:code:`\,` and :code:`\ `), or
-simply use quotes to bypass character limitations in strings.
-
-.. doctest::
-
-    >>> OmegaConf.register_new_resolver("concat", lambda x, y: x+y)
-    >>> c = OmegaConf.create({
-    ...     'key1': '${concat:Hello,World}',
-    ...     'key_trimmed': '${concat:Hello , World}',
-    ...     'escape_whitespace': '${concat:Hello,\ World}',
-    ...     'quoted': '${concat:"Hello,", " World"}',
-    ... })
-    >>> c.key1
-    'HelloWorld'
-    >>> c.key_trimmed
-    'HelloWorld'
-    >>> c.escape_whitespace
-    'Hello World'
-    >>> c.quoted
-    'Hello, World'
-
-
-Custom resolvers can return lists or dictionaries, that are automatically converted into DictConfig and ListConfig:
+Resolvers
+^^^^^^^^^
+You can add additional interpolation types by registering resolvers using ``OmegaConf.register_new_resolver()``.
+Such resolvers are called when the config node is accessed.
+See :doc:`custom_resolvers` for more details, or keep reading for a minimal example.
 
 .. doctest::
 
     >>> OmegaConf.register_new_resolver(
-    ...     "min_max", lambda *a: {"min": min(a), "max": max(a)}
+    ...     "add", lambda *numbers: sum(numbers)
     ... )
-    >>> c = OmegaConf.create({'stats': '${min_max: -1, 3, 2, 5, -10}'})
-    >>> assert isinstance(c.stats, DictConfig)
-    >>> c.stats.min, c.stats.max
-    (-10, 5)
+    >>> c = OmegaConf.create({'total': '${add:1,2,3}'})
+    >>> c.total
+    6
 
+Built-in resolvers
+^^^^^^^^^^^^^^^^^^
+OmegaConf comes with a set of built-in custom resolvers:
 
-You can take advantage of nested interpolations to perform custom operations over variables:
-
-.. doctest::
-
-    >>> OmegaConf.register_new_resolver("sum", lambda x, y: x + y)
-    >>> c = OmegaConf.create({"a": 1,
-    ...                       "b": 2,
-    ...                       "a_plus_b": "${sum:${a},${b}}"})
-    >>> c.a_plus_b
-    3
-
-More advanced resolver naming features include the ability to prefix a resolver name with a
-namespace, and to use interpolations in the name itself. The following example demonstrates both:
-
-.. doctest::
-
-    >>> OmegaConf.register_new_resolver("mylib.plus1", lambda x: x + 1)
-    >>> c = OmegaConf.create(
-    ...     {
-    ...         "func": "plus1",
-    ...         "x": "${mylib.${func}:3}",
-    ...     }
-    ... )
-    >>> c.x
-    4
-
-
-By default a custom resolver is called on every access, but it is possible to cache its output
-by registering it with ``use_cache=True``.
-This may be useful either for performance reasons or to ensure the same value is always returned.
-Note that the cache is based on the string literals representing the resolver's inputs, and not
-the inputs themselves:
-
-.. doctest::
-
-    >>> import random
-    >>> random.seed(1234)
-    >>> OmegaConf.register_new_resolver(
-    ...    "cached", random.randint, use_cache=True
-    ... )
-    >>> OmegaConf.register_new_resolver("uncached", random.randint)
-    >>> c = OmegaConf.create(
-    ...     {
-    ...         "uncached": "${uncached:0,10000}",
-    ...         "cached_1": "${cached:0,10000}",
-    ...         "cached_2": "${cached:0, 10000}",
-    ...         "cached_3": "${cached:0,${uncached}}",
-    ...     }
-    ... )
-    >>> # not the same since the cache is disabled by default
-    >>> assert c.uncached != c.uncached
-    >>> # same value on repeated access thanks to the cache
-    >>> assert c.cached_1 == c.cached_1 == 122
-    >>> # same input as `cached_1` => same value
-    >>> assert c.cached_2 == c.cached_1 == 122
-    >>> # same string literal "${uncached}" => same value
-    >>> assert c.cached_3 == c.cached_3 == 1192
-
-
-Custom interpolations can also receive the following special parameters:
-
-- ``_parent_`` : the parent node of an interpolation.
-- ``_root_``: The config root.
-
-This can be achieved by adding the special parameters to the resolver signature.
-Note that special parameters must be defined as named keywords (after the `*`):
-
-In this example, we use ``_parent_`` to implement a sum function that defaults to 0 if the node does not exist.
-(In contrast to the sum we defined earlier where accessing an invalid key, e.g. ``"a_plus_z": ${sum:${a}, ${z}}`` will result in an error).
-
-.. doctest::
-
-    >>> def sum2(a, b, *, _parent_):
-    ...     return _parent_.get(a, 0) + _parent_.get(b, 0)
-    >>> OmegaConf.register_new_resolver("sum2", sum2, use_cache=False)
-    >>> cfg = OmegaConf.create(
-    ...     {
-    ...         "node": {
-    ...             "a": 1,
-    ...             "b": 2,
-    ...             "a_plus_b": "${sum2:a,b}",
-    ...             "a_plus_z": "${sum2:a,z}",
-    ...         },
-    ...     }
-    ... )
-    >>> cfg.node.a_plus_b
-    3
-    >>> cfg.node.a_plus_z
-    1
+* :ref:`oc.decode`: Parsing an input string using interpolation grammar
+* :ref:`oc.env`: Accessing environment variables.
+* :ref:`oc.dict.{keys,values}`: Viewing the keys or the values of a dictionary as a list
 
 
 Merging configurations

--- a/news/681.feature
+++ b/news/681.feature
@@ -1,0 +1,1 @@
+Introduce oc.deprecated resolver, that enables deprecating config nodes

--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -63,7 +63,9 @@ def select_value(
         throw_on_missing=throw_on_missing,
         absolute_key=absolute_key,
     )
+
     if isinstance(ret, Node) and ret._is_missing():
+        assert not throw_on_missing  # would have raised an exception in select_node
         return None
 
     return _get_value(ret)
@@ -106,6 +108,4 @@ def select_node(
     ):
         return default
 
-    if value is not None and value._is_missing():
-        return None
     return value

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -633,7 +633,17 @@ class Container(Node):
         resolver = OmegaConf._get_resolver(inter_type)
         if resolver is not None:
             root_node = self._get_root()
-            return resolver(root_node, self, inter_args, inter_args_str)
+            node = None
+            if key is not None:
+                node = self._get_node(key, validate_access=True)
+            assert node is None or isinstance(node, Node)
+            return resolver(
+                root_node,
+                self,
+                node,
+                inter_args,
+                inter_args_str,
+            )
         else:
             raise UnsupportedInterpolationType(
                 f"Unsupported interpolation type {inter_type}"

--- a/omegaconf/resolvers/oc/dict.py
+++ b/omegaconf/resolvers/oc/dict.py
@@ -53,7 +53,7 @@ def _get_and_validate_dict_input(
     parent: BaseContainer,
     resolver_name: str,
 ) -> DictConfig:
-    from omegaconf import OmegaConf
+    from omegaconf._impl import select_value
 
     if not isinstance(key, str):
         raise TypeError(
@@ -61,7 +61,7 @@ def _get_and_validate_dict_input(
             f"of type: {type(key).__name__}"
         )
 
-    in_dict = OmegaConf.select(
+    in_dict = select_value(
         parent,
         key,
         throw_on_missing=True,

--- a/tests/interpolation/built_in_resolvers/test_oc_deprecated.py
+++ b/tests/interpolation/built_in_resolvers/test_oc_deprecated.py
@@ -1,0 +1,107 @@
+import re
+from typing import Any
+
+from pytest import mark, param, raises, warns
+
+from omegaconf import OmegaConf
+from omegaconf.errors import InterpolationResolutionError
+
+
+@mark.parametrize(
+    ("cfg", "key", "expected_value", "expected_warning"),
+    [
+        param(
+            {"a": 10, "b": "${oc.deprecated: a}"},
+            "b",
+            10,
+            "'b' is deprecated. Change your code and config to use 'a'",
+            id="value",
+        ),
+        param(
+            {"a": 10, "b": "${oc.deprecated: a, '$OLD_KEY is deprecated'}"},
+            "b",
+            10,
+            "b is deprecated",
+            id="value-custom-message",
+        ),
+        param(
+            {
+                "a": 10,
+                "b": "${oc.deprecated: a, ${warning}}",
+                "warning": "$OLD_KEY is bad, $NEW_KEY is good",
+            },
+            "b",
+            10,
+            "b is bad, a is good",
+            id="value-custom-message-config-variable",
+        ),
+        param(
+            {"a": {"b": 10}, "b": "${oc.deprecated: a}"},
+            "b",
+            OmegaConf.create({"b": 10}),
+            "'b' is deprecated. Change your code and config to use 'a'",
+            id="dict",
+        ),
+        param(
+            {"a": {"b": 10}, "b": "${oc.deprecated: a}"},
+            "b.b",
+            10,
+            "'b' is deprecated. Change your code and config to use 'a'",
+            id="dict_value",
+        ),
+        param(
+            {"a": [0, 1], "b": "${oc.deprecated: a}"},
+            "b",
+            OmegaConf.create([0, 1]),
+            "'b' is deprecated. Change your code and config to use 'a'",
+            id="list",
+        ),
+        param(
+            {"a": [0, 1], "b": "${oc.deprecated: a}"},
+            "b[1]",
+            1,
+            "'b' is deprecated. Change your code and config to use 'a'",
+            id="list_value",
+        ),
+    ],
+)
+def test_deprecated(
+    cfg: Any, key: str, expected_value: Any, expected_warning: str
+) -> None:
+    cfg = OmegaConf.create(cfg)
+    with warns(UserWarning, match=re.escape(expected_warning)):
+        value = OmegaConf.select(cfg, key)
+    assert value == expected_value
+    assert type(value) == type(expected_value)
+
+
+@mark.parametrize(
+    ("cfg", "error"),
+    [
+        param(
+            {"a": "${oc.deprecated: z}"},
+            "ConfigKeyError raised while resolving interpolation:"
+            " In oc.deprecated resolver at 'a': Key not found: 'z'",
+            id="target_not_found",
+        ),
+        param(
+            {"a": "${oc.deprecated: 111111}"},
+            "TypeError raised while resolving interpolation: oc.deprecated:"
+            " interpolation key type is not a string (int)",
+            id="invalid_key_type",
+        ),
+        param(
+            {"a": "${oc.deprecated: b, 1000}", "b": 10},
+            "TypeError raised while resolving interpolation: oc.deprecated:"
+            " interpolation message type is not a string (int)",
+            id="invalid_message_type",
+        ),
+    ],
+)
+def test_deprecated_target_not_found(cfg: Any, error: str) -> None:
+    cfg = OmegaConf.create(cfg)
+    with raises(
+        InterpolationResolutionError,
+        match=re.escape(error),
+    ):
+        cfg.a

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -5,6 +5,7 @@ from _pytest.python_api import RaisesContext
 from pytest import mark, param, raises
 
 from omegaconf import MissingMandatoryValue, OmegaConf
+from omegaconf._impl import select_value
 from omegaconf._utils import _ensure_container
 from omegaconf.errors import ConfigKeyError, InterpolationKeyError
 
@@ -265,8 +266,8 @@ class TestSelectFromNestedNode:
     ) -> None:
         cfg = OmegaConf.create(inp)
         # select returns the same result when a key is relative independent of absolute_key flag.
-        assert OmegaConf.select(cfg.a, key, absolute_key=False) == expected
-        assert OmegaConf.select(cfg.a, key, absolute_key=True) == expected
+        assert select_value(cfg.a, key, absolute_key=False) == expected
+        assert select_value(cfg.a, key, absolute_key=True) == expected
 
     @mark.parametrize(
         ("key", "expected"),
@@ -282,7 +283,7 @@ class TestSelectFromNestedNode:
         self, key: str, expected: Any
     ) -> None:
         cfg = OmegaConf.create(inp)
-        assert OmegaConf.select(cfg.a, key, absolute_key=False) == expected
+        assert select_value(cfg.a, key, absolute_key=False) == expected
 
     @mark.parametrize(
         ("key", "expected"),
@@ -300,4 +301,4 @@ class TestSelectFromNestedNode:
         self, key: str, expected: Any
     ) -> None:
         cfg = OmegaConf.create(inp)
-        assert OmegaConf.select(cfg.a, key, absolute_key=True) == expected
+        assert select_value(cfg.a, key, absolute_key=True) == expected


### PR DESCRIPTION
1. Refactor docs, moving resolvers to a dedicated page.
2. Adding support for oc.deprecated.

Most of changed lines here are from the docs refactor.
Try to go over it anyway and let me know if you have any feedback.

Closes #681.