### PR TITLE
678 select

### DIFF
--- a/news/678.bugfix
+++ b/news/678.bugfix
@@ -1,0 +1,1 @@
+OmegaConf.select now returns None when attempting to select a child of a value or None node

--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from omegaconf import MISSING, Container, DictConfig, ListConfig, Node, ValueNode
-from omegaconf.errors import ConfigKeyError, InterpolationToMissingValueError
+from omegaconf.errors import ConfigTypeError, InterpolationToMissingValueError
 
 from ._utils import _DEFAULT_MARKER_, _get_value
 
@@ -94,11 +94,11 @@ def select_node(
             throw_on_missing=throw_on_missing,
             throw_on_resolution_failure=throw_on_resolution_failure,
         )
-    except ConfigKeyError:
+    except ConfigTypeError:
         if default is not _DEFAULT_MARKER_:
             return default
         else:
-            raise
+            return None
 
     if (
         default is not _DEFAULT_MARKER_

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -611,10 +611,6 @@ class Container(Node):
             raise InterpolationToMissingValueError(
                 f"MissingMandatoryValue while resolving interpolation: {exc}"
             ).with_traceback(sys.exc_info()[2])
-        except ConfigKeyError as exc:
-            raise InterpolationKeyError(
-                f"ConfigKeyError while resolving interpolation: {exc}"
-            ).with_traceback(sys.exc_info()[2])
 
         if parent is None or value is None:
             raise InterpolationKeyError(f"Interpolation key '{inter_key}' not found")

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -19,6 +19,7 @@ from ._utils import (
 )
 from .errors import (
     ConfigKeyError,
+    ConfigTypeError,
     InterpolationKeyError,
     InterpolationResolutionError,
     InterpolationToMissingValueError,
@@ -399,7 +400,7 @@ class Container(Node):
             if ret is not None and not isinstance(ret, Container):
                 parent_key = ".".join(split[0 : i + 1])
                 child_key = split[i + 1]
-                raise ConfigKeyError(
+                raise ConfigTypeError(
                     f"Error trying to access {key}: node `{parent_key}` "
                     f"is not a container and thus cannot contain `{child_key}`"
                 )

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -53,6 +53,7 @@ from ._utils import (
 from .base import Container, Node, SCMode
 from .basecontainer import BaseContainer
 from .errors import (
+    ConfigTypeError,
     MissingMandatoryValue,
     OmegaConfBaseException,
     UnsupportedInterpolationType,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -53,7 +53,6 @@ from ._utils import (
 from .base import Container, Node, SCMode
 from .basecontainer import BaseContainer
 from .errors import (
-    ConfigTypeError,
     MissingMandatoryValue,
     OmegaConfBaseException,
     UnsupportedInterpolationType,
@@ -1048,7 +1047,10 @@ def _select_one(
     from .listconfig import ListConfig
 
     ret_key: Union[str, int] = key
-    assert isinstance(c, (DictConfig, ListConfig)), f"Unexpected type: {c}"
+    assert isinstance(c, Container), f"Unexpected type: {c}"
+    if c._is_none():
+        return None, ret_key
+
     if isinstance(c, DictConfig):
         assert isinstance(ret_key, str)
         val = c._get_node(ret_key, validate_access=False)

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -18,6 +18,7 @@ from omegaconf import (
 )
 from omegaconf._utils import _ensure_container
 from omegaconf.errors import InterpolationKeyError
+from omegaconf.errors import InterpolationResolutionError
 from omegaconf.errors import InterpolationResolutionError as IRE
 from omegaconf.errors import InterpolationValidationError
 from tests import MissingDict, MissingList, StructuredWithMissing, SubscriptedList, User
@@ -85,7 +86,7 @@ def test_merge_with_interpolation() -> None:
 
 def test_non_container_interpolation() -> None:
     cfg = OmegaConf.create({"foo": 0, "bar": "${foo.baz}"})
-    with raises(InterpolationKeyError):
+    with raises(InterpolationResolutionError):
         cfg.bar
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -280,9 +280,9 @@ params = [
         Expected(
             create=lambda: OmegaConf.create({"foo": "${int.missing}", "int": 0}),
             op=lambda cfg: getattr(cfg, "foo"),
-            exception_type=InterpolationKeyError,
+            exception_type=InterpolationResolutionError,
             msg=(
-                "ConfigKeyError while resolving interpolation: Error trying to access int.missing: "
+                "ConfigTypeError raised while resolving interpolation: Error trying to access int.missing: "
                 "node `int` is not a container and thus cannot contain `missing`"
             ),
             key="foo",

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -7,7 +7,7 @@ from pytest import mark, param, raises
 from omegaconf import MissingMandatoryValue, OmegaConf
 from omegaconf._impl import select_value
 from omegaconf._utils import _ensure_container
-from omegaconf.errors import ConfigKeyError, InterpolationKeyError
+from omegaconf.errors import ConfigTypeError, InterpolationKeyError
 
 
 @mark.parametrize("struct", [False, True])
@@ -135,7 +135,7 @@ class TestSelect:
                 {"int": 0},
                 "int.y",
                 raises(
-                    ConfigKeyError,
+                    ConfigTypeError,
                     match=re.escape(
                         "Error trying to access int.y: node `int` is not a container "
                         "and thus cannot contain `y`"


### PR DESCRIPTION
Followup to discussion 678. easier to review individual commits.
1. eliminating redundant tests.
2. Change exception raised when trying to drill into a non-container with select from ConfigKeyError to ConfigTypeError.
3. Change OmegaConf.select to return None if user attempts to drill into a non existing node (into a ValueNode or into None).

Closes #678