### PR TITLE
Optimization to avoid re-fetching the node on each resolver call

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -480,7 +480,7 @@ class Container(Node):
 
         try:
             resolved = self.resolve_parse_tree(
-                parse_tree=parse_tree, key=key, parent=parent, memo=memo
+                parse_tree=parse_tree, node=value, key=key, parent=parent, memo=memo
             )
         except InterpolationResolutionError:
             if throw_on_resolution_failure:
@@ -546,7 +546,7 @@ class Container(Node):
     def _wrap_interpolation_result(
         self,
         parent: Optional["Container"],
-        value: "Node",
+        value: Node,
         key: Any,
         resolved: Any,
         throw_on_resolution_failure: bool,
@@ -624,6 +624,7 @@ class Container(Node):
     def _evaluate_custom_resolver(
         self,
         key: Any,
+        node: Node,
         inter_type: str,
         inter_args: Tuple[Any, ...],
         inter_args_str: Tuple[str, ...],
@@ -633,10 +634,6 @@ class Container(Node):
         resolver = OmegaConf._get_resolver(inter_type)
         if resolver is not None:
             root_node = self._get_root()
-            node = None
-            if key is not None:
-                node = self._get_node(key, validate_access=True)
-            assert node is None or isinstance(node, Node)
             return resolver(
                 root_node,
                 self,
@@ -674,6 +671,7 @@ class Container(Node):
     def resolve_parse_tree(
         self,
         parse_tree: ParserRuleContext,
+        node: Node,
         memo: Optional[Set[int]] = None,
         key: Optional[Any] = None,
         parent: Optional["Container"] = None,
@@ -696,6 +694,7 @@ class Container(Node):
         ) -> Any:
             return self._evaluate_custom_resolver(
                 key=key,
+                node=node,
                 inter_type=name,
                 inter_args=args,
                 inter_args_str=args_str,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -885,7 +885,7 @@ class OmegaConf:
         name: str,
     ) -> Optional[
         Callable[
-            [Container, Container, Optional[Node], Tuple[Any, ...], Tuple[str, ...]],
+            [Container, Container, Node, Tuple[Any, ...], Tuple[str, ...]],
             Any,
         ]
     ]:

--- a/omegaconf/resolvers/oc/__init__.py
+++ b/omegaconf/resolvers/oc/__init__.py
@@ -29,7 +29,7 @@ def env(key: str, default: Any = _DEFAULT_MARKER_) -> Optional[str]:
             raise KeyError(f"Environment variable '{key}' not found")
 
 
-def decode(expr: Optional[str], _parent_: Container) -> Any:
+def decode(expr: Optional[str], _parent_: Container, _node_: Node) -> Any:
     """
     Parse and evaluate `expr` according to the `singleElement` rule of the grammar.
 
@@ -45,7 +45,7 @@ def decode(expr: Optional[str], _parent_: Container) -> Any:
         )
 
     parse_tree = parse(expr, parser_rule="singleElement", lexer_mode="VALUE_MODE")
-    val = _parent_.resolve_parse_tree(parse_tree)
+    val = _parent_.resolve_parse_tree(parse_tree, node=_node_)
     return _get_value(val)
 
 
@@ -54,7 +54,7 @@ def deprecated(
     message: str = "'$OLD_KEY' is deprecated. Change your code and config to use '$NEW_KEY'",
     *,
     _parent_: Container,
-    _node_: Optional[Node],
+    _node_: Node,
 ) -> Any:
     from omegaconf._impl import select_node
 
@@ -68,7 +68,6 @@ def deprecated(
             f"oc.deprecated: interpolation message type is not a string ({type(message).__name__})"
         )
 
-    assert _node_ is not None
     full_key = _node_._get_full_key(key=None)
     target_node = select_node(_parent_, key, absolute_key=True)
     if target_node is None:

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -6,6 +6,7 @@ import antlr4
 from pytest import mark, param, raises, warns
 
 from omegaconf import (
+    AnyNode,
     Container,
     DictConfig,
     ListConfig,
@@ -518,6 +519,9 @@ class TestOmegaConfGrammar:
             return _utils._get_value(
                 cfg.resolve_parse_tree(
                     parse_tree,
+                    # Create a dummy `AnyNode` (it should not actually be used in these
+                    # grammer tests, but `resolve_parse_tree()` requires it).
+                    node=AnyNode(None, parent=cfg),
                     key=None,
                     parent=cfg,
                 )


### PR DESCRIPTION
Note that the node is now guaranteed to always be available.

This is my suggestion from https://github.com/omry/omegaconf/pull/679#discussion_r614137195