### PR TITLE
674 select with default

### DIFF
--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -89,7 +89,7 @@ def select_node(
             key = f".{key}"
 
         cfg, key = cfg._resolve_key_and_root(key)
-        _root, _last_key, value = cfg._select_impl(
+        _root, _last_key, node = cfg._select_impl(
             key,
             throw_on_missing=throw_on_missing,
             throw_on_resolution_failure=throw_on_resolution_failure,
@@ -100,12 +100,8 @@ def select_node(
         else:
             return None
 
-    if (
-        default is not _DEFAULT_MARKER_
-        and _root is not None
-        and _last_key is not None
-        and _last_key not in _root
-    ):
+    default_provided = default is not _DEFAULT_MARKER_
+    if default_provided and (node is None or node._is_missing()):
         return default
 
-    return value
+    return node

--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -55,27 +55,28 @@ def select_value(
     throw_on_missing: bool = False,
     absolute_key: bool = False,
 ) -> Any:
-    ret = select_node(
+    node = select_node(
         cfg=cfg,
         key=key,
-        default=default,
         throw_on_resolution_failure=throw_on_resolution_failure,
         throw_on_missing=throw_on_missing,
         absolute_key=absolute_key,
     )
 
-    if isinstance(ret, Node) and ret._is_missing():
-        assert not throw_on_missing  # would have raised an exception in select_node
-        return None
+    node_not_found = node is None
+    if node_not_found or node._is_missing():
+        if default is not _DEFAULT_MARKER_:
+            return default
+        else:
+            return None
 
-    return _get_value(ret)
+    return _get_value(node)
 
 
 def select_node(
     cfg: Container,
     key: str,
     *,
-    default: Any = _DEFAULT_MARKER_,
     throw_on_resolution_failure: bool = True,
     throw_on_missing: bool = False,
     absolute_key: bool = False,
@@ -95,13 +96,6 @@ def select_node(
             throw_on_resolution_failure=throw_on_resolution_failure,
         )
     except ConfigTypeError:
-        if default is not _DEFAULT_MARKER_:
-            return default
-        else:
-            return None
-
-    default_provided = default is not _DEFAULT_MARKER_
-    if default_provided and (node is None or node._is_missing()):
-        return default
+        return None
 
     return node

--- a/tests/interpolation/built_in_resolvers/test_dict.py
+++ b/tests/interpolation/built_in_resolvers/test_dict.py
@@ -27,6 +27,12 @@ from tests import User, Users
             ["a", "b"],
             id="dictconfig_chained_interpolation",
         ),
+        param(
+            {"a": "${oc.dict.keys:''}", "b": 10},
+            "a",
+            ["a", "b"],
+            id="select_keys_of_root",
+        ),
     ],
 )
 def test_dict_keys(cfg: Any, key: Any, expected: Any) -> None:
@@ -63,19 +69,6 @@ def test_dict_keys(cfg: Any, key: Any, expected: Any) -> None:
                 ),
             ),
             id="config_key_error",
-        ),
-        param(
-            # This might be allowed in the future. Currently it fails.
-            {"foo": "${oc.dict.keys_or_values:''}"},
-            "foo",
-            raises(
-                InterpolationResolutionError,
-                match=re.escape(
-                    "ConfigKeyError raised while resolving interpolation: "
-                    "Key not found: ''"
-                ),
-            ),
-            id="config_key_error_empty",
         ),
         param(
             {"foo": "${oc.dict.keys_or_values:bar}", "bar": 0},

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -9,7 +9,10 @@ from omegaconf._utils import _ensure_container
 from omegaconf.errors import InterpolationKeyError
 
 
-@mark.parametrize("struct", [False, True])
+@mark.parametrize(
+    "struct",
+    [param(False, id="not_struct"), param(True, id="struct")],
+)
 class TestSelect:
     @mark.parametrize(
         "cfg, key, expected",
@@ -100,7 +103,7 @@ class TestSelect:
             param({"int": 0}, "int.y", id="non_container"),
         ],
     )
-    def test_select_default(
+    def test_select_default_returned(
         self,
         cfg: Any,
         struct: Optional[bool],
@@ -110,6 +113,47 @@ class TestSelect:
         cfg = _ensure_container(cfg)
         OmegaConf.set_struct(cfg, struct)
         assert OmegaConf.select(cfg, key, default=default) == default
+
+    @mark.parametrize("default", [10, None])
+    @mark.parametrize(
+        ("cfg", "key", "expected"),
+        [
+            param({"x": None}, "x", None, id="none"),
+            param({"x": None}, "", {"x": None}, id="root"),
+        ],
+    )
+    def test_select_default_not_used(
+        self,
+        cfg: Any,
+        struct: Optional[bool],
+        key: Any,
+        default: Any,
+        expected: Any,
+    ) -> None:
+        cfg = _ensure_container(cfg)
+        OmegaConf.set_struct(cfg, struct)
+        assert OmegaConf.select(cfg, key, default=default) == expected
+
+    @mark.parametrize("default", [10, None])
+    @mark.parametrize(
+        ("cfg", "key", "expected"),
+        [
+            param({"x": {"y": None}}, "y", None, id="none"),
+            param({"x": {"y": 99}}, "y", 99, id="none"),
+            param({"x": {"y": None}}, "..", {"x": {"y": None}}, id="root"),
+        ],
+    )
+    def test_nested_select_default_not_used(
+        self,
+        cfg: Any,
+        struct: Optional[bool],
+        key: Any,
+        default: Any,
+        expected: Any,
+    ) -> None:
+        cfg = _ensure_container(cfg)
+        OmegaConf.set_struct(cfg, struct)
+        assert OmegaConf.select(cfg.x, key, default=default) == expected
 
     @mark.parametrize("default", [10, None])
     @mark.parametrize(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -119,7 +119,8 @@ class TestSelect:
         ("cfg", "key", "expected"),
         [
             param({"x": None}, "x", None, id="none"),
-            param({"x": None}, "", {"x": None}, id="root"),
+            param({"x": DictConfig(None)}, "x", None, id="DictConfig(none)"),
+            param({"x": None}, "", DictConfig({"x": None}), id="root"),
         ],
     )
     def test_select_default_not_used(
@@ -132,7 +133,9 @@ class TestSelect:
     ) -> None:
         cfg = _ensure_container(cfg)
         OmegaConf.set_struct(cfg, struct)
-        assert OmegaConf.select(cfg, key, default=default) == expected
+        selected = OmegaConf.select(cfg, key, default=default)
+        assert selected == expected
+        assert type(selected) is type(expected)
 
     @mark.parametrize("default", [10, None])
     @mark.parametrize(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -142,7 +142,7 @@ class TestSelect:
         ("cfg", "key", "expected"),
         [
             param({"x": {"y": None}}, "y", None, id="none"),
-            param({"x": {"y": 99}}, "y", 99, id="none"),
+            param({"x": {"y": 99}}, "y", 99, id="value"),
             param({"x": {"y": None}}, "..", {"x": {"y": None}}, id="root"),
         ],
     )


### PR DESCRIPTION
Fixes #674

Note:
1. I removed a test from `oc.dict.{keys,values}`, was not sure exactly what it was protecting against but it looks like it was depending on some funky logic in select that is not needed by anything else.

2. News fragment is not needed because default value in OmegaConf.select is new in 2.1.
