### PR TITLE
to_object no enum_to_str

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -555,11 +555,7 @@ class OmegaConf:
         )
 
     @staticmethod
-    def to_object(
-        cfg: Any,
-        *,
-        enum_to_str: bool = False,
-    ) -> Union[Dict[DictKeyType, Any], List[Any], None, str, Any]:
+    def to_object(cfg: Any) -> Union[Dict[DictKeyType, Any], List[Any], None, str, Any]:
         """
         Resursively converts an OmegaConf config to a primitive container (dict or list).
         Any DictConfig objects backed by dataclasses or attrs classes are instantiated
@@ -574,7 +570,7 @@ class OmegaConf:
         return OmegaConf.to_container(
             cfg=cfg,
             resolve=True,
-            enum_to_str=enum_to_str,
+            enum_to_str=False,
             structured_config_mode=SCMode.INSTANTIATE,
         )
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -564,7 +564,6 @@ class OmegaConf:
         This is an alias for OmegaConf.to_container(..., resolve=True, structured_config_mode=SCMode.INSTANTIATE)
 
         :param cfg: the config to convert
-        :param enum_to_str: True to convert Enum values to strings
         :return: A dict or a list or dataclass representing this config.
         """
         return OmegaConf.to_container(

--- a/tests/test_to_container.py
+++ b/tests/test_to_container.py
@@ -246,9 +246,9 @@ class TestInstantiateStructuredConfigs:
     def module(self, request: Any) -> Any:
         return import_module(request.param)
 
-    def round_trip_to_object(self, input_data: Any, **kwargs: Any) -> Any:
+    def round_trip_to_object(self, input_data: Any) -> Any:
         serialized = OmegaConf.create(input_data)
-        round_tripped = OmegaConf.to_object(serialized, **kwargs)
+        round_tripped = OmegaConf.to_object(serialized)
         return round_tripped
 
     def test_basic(self, module: Any) -> None:


### PR DESCRIPTION
What do we think about removing the `enum_to_str` keyword argument from `OmegaConf.to_object`?
Here is my argument for removal:
- make the public API simpler,
- users can still call `OmegaConf.to_container(..., enum_to_str=True)` if they need it, and
- make sure that the `DictConfig._to_object` method is consistent with the `OmegaConf.to_object` method. Currently, `DictConfig._to_object` calls `BaseContainer._to_content` with `enum_to_str=False`, which will result in an inconsistency if the client calls `OmegaConf.to_object(cfg, enum_to_str=True)`, i.e. we could get some `enum_to_str=True` and some `enum_to_str=False` in the same deserialized object.