### PR TITLE
New syntax for nested quoted values

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -678,7 +678,6 @@ class Container(Node):
         We make no assumption here on the type of the tree's root, so that the
         return value may be of any type.
         """
-        from .nodes import StringNode
 
         def node_interpolation_callback(
             inter_key: str, memo: Optional[Set[int]]
@@ -696,25 +695,9 @@ class Container(Node):
                 inter_args_str=args_str,
             )
 
-        def quoted_string_callback(quoted_str: str, memo: Optional[Set[int]]) -> str:
-            quoted_val = self._maybe_resolve_interpolation(
-                key=key,
-                parent=parent,
-                value=StringNode(
-                    value=quoted_str,
-                    key=key,
-                    parent=parent,
-                    is_optional=True,
-                ),
-                throw_on_resolution_failure=True,
-                memo=memo,
-            )
-            return str(quoted_val)
-
         visitor = GrammarVisitor(
             node_interpolation_callback=node_interpolation_callback,
             resolver_interpolation_callback=resolver_interpolation_callback,
-            quoted_string_callback=quoted_string_callback,
             memo=memo,
         )
         try:

--- a/omegaconf/grammar/OmegaConfGrammarLexer.g4
+++ b/omegaconf/grammar/OmegaConfGrammarLexer.g4
@@ -33,8 +33,8 @@ mode VALUE_MODE;
 INTER_OPEN: '${' WS? -> pushMode(INTERPOLATION_MODE);
 BRACE_OPEN: '{' WS? -> pushMode(VALUE_MODE);  // must keep track of braces to detect end of interpolation
 BRACE_CLOSE: WS? '}' -> popMode;
-QUOTE_OPEN: '\'' -> pushMode(QUOTED_SINGLE_MODE);
-QUOTE_DOUBLE: '"' -> type(QUOTE_OPEN), pushMode(QUOTED_DOUBLE_MODE);
+QUOTE_OPEN_SINGLE: '\'' -> pushMode(QUOTED_SINGLE_MODE);
+QUOTE_OPEN_DOUBLE: '"' -> pushMode(QUOTED_DOUBLE_MODE);
 
 COMMA: WS? ',' WS?;
 BRACKET_OPEN: '[' WS?;

--- a/omegaconf/grammar/OmegaConfGrammarLexer.g4
+++ b/omegaconf/grammar/OmegaConfGrammarLexer.g4
@@ -94,7 +94,7 @@ mode QUOTED_SINGLE_MODE;
 // This mode is very similar to `DEFAULT_MODE` except for the handling of quotes.
 
 QSINGLE_INTER_OPEN: INTER_OPEN -> type(INTER_OPEN), pushMode(INTERPOLATION_MODE);
-QUOTE_CLOSE: '\'' -> popMode;
+MATCHING_QUOTE_CLOSE: '\'' -> popMode;
 
 QSINGLE_ESC: ('\\\'' | ESC_BACKSLASH)+ -> type(ESC);
 QSINGLE_ESC_INTER: ESC_INTER -> type(ESC_INTER);
@@ -112,7 +112,7 @@ mode QUOTED_DOUBLE_MODE;
 // Same as `QUOTED_SINGLE_MODE` but for double quotes.
 
 QDOUBLE_INTER_OPEN: INTER_OPEN -> type(INTER_OPEN), pushMode(INTERPOLATION_MODE);
-QDOUBLE_CLOSE: '"' -> type(QUOTE_CLOSE), popMode;
+QDOUBLE_CLOSE: '"' -> type(MATCHING_QUOTE_CLOSE), popMode;
 
 QDOUBLE_ESC: ('\\"' | ESC_BACKSLASH)+ -> type(ESC);
 QDOUBLE_ESC_INTER: ESC_INTER -> type(ESC_INTER);

--- a/omegaconf/grammar/OmegaConfGrammarLexer.g4
+++ b/omegaconf/grammar/OmegaConfGrammarLexer.g4
@@ -33,7 +33,7 @@ mode VALUE_MODE;
 INTER_OPEN: '${' WS? -> pushMode(INTERPOLATION_MODE);
 BRACE_OPEN: '{' WS? -> pushMode(VALUE_MODE);  // must keep track of braces to detect end of interpolation
 BRACE_CLOSE: WS? '}' -> popMode;
-QUOTE_SINGLE: '\'' -> type(QUOTE_OPEN), pushMode(QUOTED_SINGLE_MODE);
+QUOTE_OPEN: '\'' -> pushMode(QUOTED_SINGLE_MODE);
 QUOTE_DOUBLE: '"' -> type(QUOTE_OPEN), pushMode(QUOTED_DOUBLE_MODE);
 
 COMMA: WS? ',' WS?;
@@ -94,7 +94,7 @@ mode QUOTED_SINGLE_MODE;
 // This mode is very similar to `DEFAULT_MODE` except for the handling of quotes.
 
 QSINGLE_INTER_OPEN: INTER_OPEN -> type(INTER_OPEN), pushMode(INTERPOLATION_MODE);
-QSINGLE_CLOSE: '\'' -> type(QUOTE_CLOSE), popMode;
+QUOTE_CLOSE: '\'' -> popMode;
 
 QSINGLE_ESC: ('\\\'' | ESC_BACKSLASH)+ -> type(ESC);
 QSINGLE_ESC_INTER: ESC_INTER -> type(ESC_INTER);
@@ -119,17 +119,3 @@ QDOUBLE_ESC_INTER: ESC_INTER -> type(ESC_INTER);
 
 QDOUBLE_SPECIAL_CHAR: SPECIAL_CHAR -> type(SPECIAL_CHAR);
 QDOUBLE_STR: ~["\\$]+ -> type(ANY_STR);
-
-
-////////////////
-// DUMMY_MODE //
-////////////////
-
-mode DUMMY_MODE;
-
-// This mode is not actually used for parsing: it is only there to define some
-// token types that may be re-used in other modes through the `type()` command
-// (as a result, we do not care what they match and just use a whitespace).
-
-QUOTE_OPEN: ' ';
-QUOTE_CLOSE: ' ';

--- a/omegaconf/grammar/OmegaConfGrammarLexer.g4
+++ b/omegaconf/grammar/OmegaConfGrammarLexer.g4
@@ -21,8 +21,8 @@ TOP_ESC: ESC_BACKSLASH+ -> type(ESC);
 
 // The backslash and dollar characters must not be grouped with others, so that
 // we can properly detect the tokens above.
-TOP_CHAR: [\\$];
-TOP_STR: ~[\\$]+;  // anything else
+SPECIAL_CHAR: [\\$];
+ANY_STR: ~[\\$]+;  // anything else
 
 ////////////////
 // VALUE_MODE //

--- a/omegaconf/grammar/OmegaConfGrammarLexer.g4
+++ b/omegaconf/grammar/OmegaConfGrammarLexer.g4
@@ -33,7 +33,7 @@ mode VALUE_MODE;
 INTER_OPEN: '${' WS? -> pushMode(INTERPOLATION_MODE);
 BRACE_OPEN: '{' WS? -> pushMode(VALUE_MODE);  // must keep track of braces to detect end of interpolation
 BRACE_CLOSE: WS? '}' -> popMode;
-QUOTE_OPEN: '\'' -> pushMode(QUOTED_SINGLE_MODE);
+QUOTE_SINGLE: '\'' -> type(QUOTE_OPEN), pushMode(QUOTED_SINGLE_MODE);
 QUOTE_DOUBLE: '"' -> type(QUOTE_OPEN), pushMode(QUOTED_DOUBLE_MODE);
 
 COMMA: WS? ',' WS?;
@@ -94,7 +94,7 @@ mode QUOTED_SINGLE_MODE;
 // This mode is very similar to `DEFAULT_MODE` except for the handling of quotes.
 
 QSINGLE_INTER_OPEN: INTER_OPEN -> type(INTER_OPEN), pushMode(INTERPOLATION_MODE);
-QUOTE_CLOSE: '\'' -> popMode;
+QSINGLE_CLOSE: '\'' -> type(QUOTE_CLOSE), popMode;
 
 QSINGLE_ESC: ('\\\'' | ESC_BACKSLASH)+ -> type(ESC);
 QSINGLE_ESC_INTER: ESC_INTER -> type(ESC_INTER);
@@ -119,3 +119,17 @@ QDOUBLE_ESC_INTER: ESC_INTER -> type(ESC_INTER);
 
 QDOUBLE_SPECIAL_CHAR: SPECIAL_CHAR -> type(SPECIAL_CHAR);
 QDOUBLE_STR: ~["\\$]+ -> type(ANY_STR);
+
+
+////////////////
+// DUMMY_MODE //
+////////////////
+
+mode DUMMY_MODE;
+
+// This mode is not actually used for parsing: it is only there to define some
+// token types that may be re-used in other modes through the `type()` command
+// (as a result, we do not care what they match and just use a whitespace).
+
+QUOTE_OPEN: ' ';
+QUOTE_CLOSE: ' ';

--- a/omegaconf/grammar/OmegaConfGrammarLexer.g4
+++ b/omegaconf/grammar/OmegaConfGrammarLexer.g4
@@ -33,6 +33,8 @@ mode VALUE_MODE;
 INTER_OPEN: '${' WS? -> pushMode(INTERPOLATION_MODE);
 BRACE_OPEN: '{' WS? -> pushMode(VALUE_MODE);  // must keep track of braces to detect end of interpolation
 BRACE_CLOSE: WS? '}' -> popMode;
+QUOTE_OPEN: '\'' -> pushMode(QUOTED_SINGLE_MODE);
+QUOTE_DOUBLE: '"' -> type(QUOTE_OPEN), pushMode(QUOTED_DOUBLE_MODE);
 
 COMMA: WS? ',' WS?;
 BRACKET_OPEN: '[' WS?;
@@ -60,21 +62,6 @@ ESC: (ESC_BACKSLASH | '\\(' | '\\)' | '\\[' | '\\]' | '\\{' | '\\}' |
       '\\:' | '\\=' | '\\,' | '\\ ' | '\\\t')+;
 WS: [ \t]+;
 
-// Quoted values for both types of quotes.
-// A quoted value is made of the enclosing quotes, and either:
-//   - nothing else
-//   - an even number of backslashes (meaning they are escaped)
-//   - a sequence of any character, followed by any non-backslash character, and optionally
-//     an even number of backslashes (i.e., also escaped)
-// Examples (right hand side: expected content of the resulting string, after processing):
-//    ""                    -> <empty>
-//    '\\'                  -> \
-//    "\\\\"                -> \\
-//    'abc\\'               -> abc\
-//    "abc\"def\\\'ghi\\\\" -> abc"def\\\'ghi\\
-QUOTED_VALUE:
-      '"' (('\\\\')* | (.)*? ~[\\] ('\\\\')*) '"'     // double quotes
-    | '\'' (('\\\\')* | (.)*? ~[\\] ('\\\\')*) '\'';  // single quotes
 
 ////////////////////////
 // INTERPOLATION_MODE //
@@ -96,3 +83,39 @@ INTER_ID: ID -> type(ID);
 // are only part of a key name, i.e., "${foo${bar}}" is not allowed. As a result, it
 // is ok to "consume" all '$' characters within the `INTER_KEY` token.
 INTER_KEY: ~[\\{}()[\]:. \t'"]+;
+
+
+////////////////////////
+// QUOTED_SINGLE_MODE //
+////////////////////////
+
+mode QUOTED_SINGLE_MODE;
+
+// This mode is very similar to `DEFAULT_MODE` except for the handling of quotes.
+
+QSINGLE_INTER_OPEN: INTER_OPEN -> type(INTER_OPEN), pushMode(INTERPOLATION_MODE);
+QUOTE_CLOSE: '\'' -> popMode;
+
+QSINGLE_ESC: ('\\\'' | ESC_BACKSLASH)+ -> type(ESC);
+QSINGLE_ESC_INTER: ESC_INTER -> type(ESC_INTER);
+
+QSINGLE_SPECIAL_CHAR: SPECIAL_CHAR -> type(SPECIAL_CHAR);
+QSINGLE_STR: ~['\\$]+ -> type(ANY_STR);
+
+
+////////////////////////
+// QUOTED_DOUBLE_MODE //
+////////////////////////
+
+mode QUOTED_DOUBLE_MODE;
+
+// Same as `QUOTED_SINGLE_MODE` but for double quotes.
+
+QDOUBLE_INTER_OPEN: INTER_OPEN -> type(INTER_OPEN), pushMode(INTERPOLATION_MODE);
+QDOUBLE_CLOSE: '"' -> type(QUOTE_CLOSE), popMode;
+
+QDOUBLE_ESC: ('\\"' | ESC_BACKSLASH)+ -> type(ESC);
+QDOUBLE_ESC_INTER: ESC_INTER -> type(ESC_INTER);
+
+QDOUBLE_SPECIAL_CHAR: SPECIAL_CHAR -> type(SPECIAL_CHAR);
+QDOUBLE_STR: ~["\\$]+ -> type(ANY_STR);

--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -75,15 +75,14 @@ primitive:
         | interpolation
       )+;
 
-// Same as `primitive` except that `COLON` and interpolations are not allowed.
+// Same as `primitive` except that `COLON`, interpolations and quoted values are not allowed.
 dictKey:
-      quotedValue
-    | (   ID                                     // foo_10
-        | NULL                                   // null, NULL
-        | INT                                    // 0, 10, -20, 1_000_000
-        | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3
-        | BOOL                                   // true, TrUe, false, False
-        | UNQUOTED_CHAR                          // /, -, \, +, ., $, %, *, @
-        | ESC                                    // \\, \(, \), \[, \], \{, \}, \:, \=, \ , \\t, \,
-        | WS                                     // whitespaces
-      )+;
+    (   ID                                     // foo_10
+      | NULL                                   // null, NULL
+      | INT                                    // 0, 10, -20, 1_000_000
+      | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3
+      | BOOL                                   // true, TrUe, false, False
+      | UNQUOTED_CHAR                          // /, -, \, +, ., $, %, *, @
+      | ESC                                    // \\, \(, \), \[, \], \{, \}, \:, \=, \ , \\t, \,
+      | WS                                     // whitespaces
+    )+;

--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -21,10 +21,9 @@ configValue: text EOF;
 singleElement: element EOF;
 
 
-// Text expressions.
+// Composite text expression (may contain interpolations).
 
-simpleText: (ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)+;          // without interpolations
-text: (simpleText | (simpleText? (interpolation simpleText?)+));  // with interpolations
+text: (interpolation | ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)+;
 
 
 // Elements.

--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -52,10 +52,17 @@ interpolationResolver: INTER_OPEN resolverName COLON sequence? BRACE_CLOSE;
 configKey: interpolation | ID | INTER_KEY;
 resolverName: (interpolation | ID) (DOT (interpolation | ID))* ;  // oc.env, myfunc, ns.${x}, ns1.ns2.f
 
+// Quoted values.
+
+// Ex: "hello world", 'hello ${world}'
+quotedValue: QUOTE_OPEN
+                  (interpolation | ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)*
+             QUOTE_CLOSE;
+
 // Primitive types.
 
 primitive:
-      QUOTED_VALUE                               // 'hello world', "hello world"
+      quotedValue
     | (   ID                                     // foo_10
         | NULL                                   // null, NULL
         | INT                                    // 0, 10, -20, 1_000_000
@@ -70,7 +77,7 @@ primitive:
 
 // Same as `primitive` except that `COLON` and interpolations are not allowed.
 dictKey:
-      QUOTED_VALUE                               // 'hello world', "hello world"
+      quotedValue
     | (   ID                                     // foo_10
         | NULL                                   // null, NULL
         | INT                                    // 0, 10, -20, 1_000_000

--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -57,7 +57,7 @@ resolverName: (interpolation | ID) (DOT (interpolation | ID))* ;  // oc.env, myf
 // Ex: "hello world", 'hello ${world}'
 quotedValue: (QUOTE_OPEN_SINGLE | QUOTE_OPEN_DOUBLE)
                   (interpolation | ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)*
-             QUOTE_CLOSE;
+             MATCHING_QUOTE_CLOSE;
 
 // Primitive types.
 

--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -55,7 +55,7 @@ resolverName: (interpolation | ID) (DOT (interpolation | ID))* ;  // oc.env, myf
 // Quoted values.
 
 // Ex: "hello world", 'hello ${world}'
-quotedValue: QUOTE_OPEN
+quotedValue: (QUOTE_OPEN_SINGLE | QUOTE_OPEN_DOUBLE)
                   (interpolation | ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)*
              QUOTE_CLOSE;
 

--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -30,6 +30,7 @@ text: (interpolation | ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)+;
 
 element:
       primitive
+    | quotedValue
     | listContainer
     | dictContainer
 ;
@@ -64,20 +65,19 @@ resolverName: (interpolation | ID) (DOT (interpolation | ID))* ;  // oc.env, myf
 quotedValue: (QUOTE_OPEN_SINGLE | QUOTE_OPEN_DOUBLE) text? MATCHING_QUOTE_CLOSE;
 
 primitive:
-      quotedValue
-    | (   ID                                     // foo_10
-        | NULL                                   // null, NULL
-        | INT                                    // 0, 10, -20, 1_000_000
-        | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3
-        | BOOL                                   // true, TrUe, false, False
-        | UNQUOTED_CHAR                          // /, -, \, +, ., $, %, *, @
-        | COLON                                  // :
-        | ESC                                    // \\, \(, \), \[, \], \{, \}, \:, \=, \ , \\t, \,
-        | WS                                     // whitespaces
-        | interpolation
-      )+;
+    (   ID                                     // foo_10
+      | NULL                                   // null, NULL
+      | INT                                    // 0, 10, -20, 1_000_000
+      | FLOAT                                  // 3.14, -20.0, 1e-1, -10e3
+      | BOOL                                   // true, TrUe, false, False
+      | UNQUOTED_CHAR                          // /, -, \, +, ., $, %, *, @
+      | COLON                                  // :
+      | ESC                                    // \\, \(, \), \[, \], \{, \}, \:, \=, \ , \\t, \,
+      | WS                                     // whitespaces
+      | interpolation
+    )+;
 
-// Same as `primitive` except that `COLON`, interpolations and quoted values are not allowed.
+// Same as `primitive` except that `COLON` and interpolations are not allowed.
 dictKey:
     (   ID                                     // foo_10
       | NULL                                   // null, NULL

--- a/omegaconf/grammar/OmegaConfGrammarParser.g4
+++ b/omegaconf/grammar/OmegaConfGrammarParser.g4
@@ -21,7 +21,7 @@ configValue: (toplevelStr | (toplevelStr? (interpolation toplevelStr?)+)) EOF;
 singleElement: element EOF;
 
 // Top-level string (that does not need to be parsed).
-toplevelStr: (ESC | ESC_INTER | TOP_CHAR | TOP_STR)+;
+toplevelStr: (ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)+;
 
 // Elements.
 

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -288,21 +288,17 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         assert ctx.getChildCount() == 2
         return self.visit(ctx.getChild(0))
 
-    def visitSimpleText(self, ctx: OmegaConfGrammarParser.SimpleTextContext) -> str:
-        # (ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)+
-        return self._unescape(ctx.getChildren())
-
     def visitText(self, ctx: OmegaConfGrammarParser.TextContext) -> Any:
-        # (simpleText | (simpleText? (interpolation simpleText?)+))
-        vals = [self.visit(c) for c in list(ctx.getChildren())]
-        assert vals
-        if len(vals) == 1 and isinstance(
-            ctx.getChild(0), OmegaConfGrammarParser.InterpolationContext
-        ):
-            # Single interpolation: return the result "as is".
-            return vals[0]
-        # Concatenation of multiple components.
-        return "".join(map(str, vals))
+        # (interpolation | ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)+
+
+        # Single interpolation? If yes, return its resolved value "as is".
+        if ctx.getChildCount() == 1:
+            c = ctx.getChild(0)
+            if isinstance(c, OmegaConfGrammarParser.InterpolationContext):
+                return self.visitInterpolation(c)
+
+        # Otherwise, concatenate string representations together.
+        return self._unescape(ctx.getChildren())
 
     def _createPrimitive(
         self,

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -114,7 +114,7 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         )
 
     def visitElement(self, ctx: OmegaConfGrammarParser.ElementContext) -> Any:
-        # primitive | listContainer | dictContainer
+        # primitive | quotedValue | listContainer | dictContainer
         assert ctx.getChildCount() == 1
         return self.visit(ctx.getChild(0))
 
@@ -307,14 +307,11 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
             OmegaConfGrammarParser.DictKeyContext,
         ],
     ) -> Any:
-        # quotedValue |
         # (ID | NULL | INT | FLOAT | BOOL | UNQUOTED_CHAR | COLON | ESC | WS | interpolation)+
         if ctx.getChildCount() == 1:
             child = ctx.getChild(0)
             if isinstance(child, OmegaConfGrammarParser.InterpolationContext):
                 return self.visitInterpolation(child)
-            elif isinstance(child, OmegaConfGrammarParser.QuotedValueContext):
-                return self.visitQuotedValue(child)
             assert isinstance(child, TerminalNode)
             symbol = child.symbol
             # Parse primitive types.

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -220,7 +220,7 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         return self._createPrimitive(ctx)
 
     def visitQuotedValue(self, ctx: OmegaConfGrammarParser.QuotedValueContext) -> str:
-        # QUOTE_OPEN
+        # (QUOTE_OPEN_SINGLE | QUOTE_OPEN_DOUBLE)
         #     (interpolation | ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)*
         # QUOTE_CLOSE;
         assert ctx.getChildCount() >= 2

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -301,7 +301,7 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         return self.visit(ctx.getChild(0))
 
     def visitToplevelStr(self, ctx: OmegaConfGrammarParser.ToplevelStrContext) -> str:
-        # (ESC | ESC_INTER | TOP_CHAR | TOP_STR)+
+        # (ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)+
         return self._unescape(ctx.getChildren())
 
     def _createPrimitive(

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -222,7 +222,7 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
     def visitQuotedValue(self, ctx: OmegaConfGrammarParser.QuotedValueContext) -> str:
         # (QUOTE_OPEN_SINGLE | QUOTE_OPEN_DOUBLE)
         #     (interpolation | ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)*
-        # QUOTE_CLOSE;
+        # MATCHING_QUOTE_CLOSE;
         assert ctx.getChildCount() >= 2
         return self._unescape(list(ctx.getChildren())[1:-1])
 

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -100,18 +100,6 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         assert ctx.getChildCount() == 2
         return self.visit(ctx.getChild(0))
 
-    def visitText(self, ctx: OmegaConfGrammarParser.TextContext) -> Any:
-        # (simpleText | (simpleText? (interpolation simpleText?)+))
-        vals = [self.visit(c) for c in list(ctx.getChildren())]
-        assert vals
-        if len(vals) == 1 and isinstance(
-            ctx.getChild(0), OmegaConfGrammarParser.InterpolationContext
-        ):
-            # Single interpolation: return the result "as is".
-            return vals[0]
-        # Concatenation of multiple components.
-        return "".join(map(str, vals))
-
     def visitDictKey(self, ctx: OmegaConfGrammarParser.DictKeyContext) -> Any:
         return self._createPrimitive(ctx)
 
@@ -303,6 +291,18 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
     def visitSimpleText(self, ctx: OmegaConfGrammarParser.SimpleTextContext) -> str:
         # (ESC | ESC_INTER | SPECIAL_CHAR | ANY_STR)+
         return self._unescape(ctx.getChildren())
+
+    def visitText(self, ctx: OmegaConfGrammarParser.TextContext) -> Any:
+        # (simpleText | (simpleText? (interpolation simpleText?)+))
+        vals = [self.visit(c) for c in list(ctx.getChildren())]
+        assert vals
+        if len(vals) == 1 and isinstance(
+            ctx.getChild(0), OmegaConfGrammarParser.InterpolationContext
+        ):
+            # Single interpolation: return the result "as is".
+            return vals[0]
+        # Concatenation of multiple components.
+        return "".join(map(str, vals))
 
     def _createPrimitive(
         self,

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -264,6 +264,12 @@ PARAMS_SINGLE_ELEMENT_WITH_INTERPOLATION = [
     ("str_quoted_nested_esc_quotes", "'${test:'b'}'", "b"),
     ("str_quoted_esc_inter", r"""'\${test:"b"}'""", '${test:"b"}'),
     ("str_quoted_esc_inter_and_quotes", r"'\${test:\'b\'}'", "${test:'b'}"),
+    ("str_quoted_esc_inter_nested_single_1", r"""'${test:'\${str}'}'""", "${str}"),
+    ("str_quoted_esc_inter_nested_single_2", r"""'${test:'\\${str}'}'""", r"\hi"),
+    ("str_quoted_esc_inter_nested_single_3", r"""'${test:'\\\${str}'}'""", r"\${str}"),
+    ("str_quoted_esc_inter_nested_double_1", r'''"${test:"\${str}"}"''', "${str}"),
+    ("str_quoted_esc_inter_nested_double_2", r'''"${test:"\\${str}"}"''', r"\hi"),
+    ("str_quoted_esc_inter_nested_double_3", r'''"${test:"\\\${str}"}"''', r"\${str}"),
     ("str_quoted_error_inside_quotes", "'${missing_brace'", GrammarParseError),
     # Whitespaces.
     ("ws_inter_node_outer", "${ \tdict.a  \t}", 0),

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -180,7 +180,7 @@ PARAMS_SINGLE_ELEMENT_NO_INTERPOLATION: List[Tuple[str, str, Any]] = [
     (
         "dict_quoted",
         "{0: 1, 'a': 'b', 1.1: 1e2, null: 0.1, true: false, -inf: true}",
-        {0: 1, "a": "b", 1.1: 100.0, None: 0.1, True: False, -math.inf: True},
+        GrammarParseError,
     ),
     (
         "structured_mixed",
@@ -201,7 +201,7 @@ PARAMS_SINGLE_ELEMENT_NO_INTERPOLATION: List[Tuple[str, str, Any]] = [
     ("dict_int_key", "{0: 0}", {0: 0}),
     ("dict_float_key", "{1.1: 0}", {1.1: 0}),
     ("dict_null_key", "{null: 0}", {None: 0}),
-    ("dict_nan_like_key", "{'nan': 0}", {"nan": 0}),
+    ("dict_nan_like_key", "{'nan': 0}", GrammarParseError),
     ("dict_list_as_key", "{[0]: 1}", GrammarParseError),
     (
         "dict_bool_key",
@@ -303,7 +303,7 @@ PARAMS_SINGLE_ELEMENT_WITH_INTERPOLATION = [
     ("space_in_args", "${test:a, b c}", ["a", "b c"]),
     ("list_as_input", "${test:[a, b], 0, [1.1]}", [["a", "b"], 0, [1.1]]),
     ("dict_as_input", "${test:{a: 1.1, b: b}}", {"a": 1.1, "b": "b"}),
-    ("dict_as_input_quotes", "${test:{'a': 1.1, b: b}}", {"a": 1.1, "b": "b"}),
+    ("dict_as_input_quotes", "${test:{'a': 1.1, b: b}}", GrammarParseError),
     ("dict_typo_colons", "${test:{a: 1.1, b:: b}}", {"a": 1.1, "b": ": b"}),
     ("missing_resolver", "${MiSsInG_ReSoLvEr:0}", UnsupportedInterpolationType),
     ("at_in_resolver", "${y@z:}", GrammarParseError),


### PR DESCRIPTION
Quoted values are now identified through lexer modes, which removes the
need for escaping quotes in nested interpolations.

Fixes #615