### PR TITLE
Fix crash with "interpolation-like" strings from interpolations

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -568,6 +568,9 @@ class Container(Node):
                 value=resolved,
                 key=key,
                 ref_type=value._metadata.ref_type,
+                # Since `resolved` was obtained by resolving an interpolation, it cannot
+                # be itself an interpolation even if may look like one (ex: "${foo}").
+                can_be_interpolation=False,
             )
         else:
             # Other objects get wrapped into an `AnyNode` with `allow_objects` set

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -15,7 +15,6 @@ from ._utils import (
     _is_missing_value,
     format_and_raise,
     get_value_kind,
-    is_primitive_type,
     split_key,
 )
 from .errors import (
@@ -504,7 +503,7 @@ class Container(Node):
         resolved: Any,
         throw_on_resolution_failure: bool,
     ) -> Optional["Node"]:
-        from .nodes import AnyNode, ValueNode
+        from .nodes import AnyNode, InterpolationResultNode, ValueNode
 
         # If the output is not a Node already (e.g., because it is the output of a
         # custom resolver), then we will need to wrap it within a Node.
@@ -533,63 +532,10 @@ class Container(Node):
                 resolved = conv_value
 
         if must_wrap:
-            return self._wrap_interpolation_result(
-                parent=parent,
-                value=value,
-                key=key,
-                resolved=resolved,
-                throw_on_resolution_failure=throw_on_resolution_failure,
-            )
+            return InterpolationResultNode(value=resolved, key=key, parent=parent)
         else:
             assert isinstance(resolved, Node)
             return resolved
-
-    def _wrap_interpolation_result(
-        self,
-        parent: Optional["Container"],
-        value: Node,
-        key: Any,
-        resolved: Any,
-        throw_on_resolution_failure: bool,
-    ) -> Optional["Node"]:
-        from .basecontainer import BaseContainer
-        from .nodes import AnyNode, StringInterpolationResultNode
-        from .omegaconf import _node_wrap
-
-        assert parent is None or isinstance(parent, BaseContainer)
-
-        if is_primitive_type(type(resolved)):
-            # Primitive types get wrapped using `_node_wrap()`, ensuring value is
-            # validated and potentially converted.
-            # There is one exception when the following two conditions are met:
-            #   - `resolved` is a string, and
-            #   - the target type is either unspecified / Any / str
-            # In that case, we wrap `resolved` inside a `StringInterpolationResultNode`
-            # so as to ensure that it cannot be considered itself as an interpolation,
-            # e.g., when `resolved` would be a string like "${foo}".
-            target_type = value._metadata.ref_type
-            if isinstance(resolved, str) and target_type in [None, Any, str]:
-                wrapped: Node = StringInterpolationResultNode(
-                    value=resolved, key=key, parent=parent
-                )
-            else:
-                wrapped = _node_wrap(
-                    type_=target_type,
-                    parent=parent,
-                    is_optional=value._metadata.optional,
-                    value=resolved,
-                    key=key,
-                    ref_type=target_type,
-                )
-        else:
-            # Other objects get wrapped into an `AnyNode` with `allow_objects` set
-            # to True.
-            wrapped = AnyNode(
-                value=resolved, key=key, parent=None, flags={"allow_objects": True}
-            )
-            wrapped._set_parent(parent)
-
-        return wrapped
 
     def _validate_not_dereferencing_to_parent(self, node: Node, target: Node) -> None:
         parent: Optional[Node] = node

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -392,14 +392,14 @@ class EnumNode(ValueNode):  # lgtm [py/missing-equals] : Intentional.
         return res
 
 
-class StringInterpolationResultNode(ValueNode):
+class InterpolationResultNode(ValueNode):
     """
-    Special node type, used to wrap string interpolation results.
+    Special node type, used to wrap interpolation results.
     """
 
     def __init__(
         self,
-        value: str,
+        value: Any,
         key: Any = None,
         parent: Optional[Container] = None,
         flags: Optional[Dict[str, bool]] = None,
@@ -408,7 +408,7 @@ class StringInterpolationResultNode(ValueNode):
             parent=parent,
             value=value,
             metadata=Metadata(
-                ref_type=str, object_type=str, key=key, optional=False, flags=flags
+                ref_type=Any, object_type=None, key=key, optional=True, flags=flags
             ),
         )
         # In general we should not try to write into interpolation results.
@@ -420,14 +420,11 @@ class StringInterpolationResultNode(ValueNode):
             raise ReadonlyConfigError("Cannot set value of read-only config node")
         self._val = self.validate_and_convert(value)
 
-    def _validate_and_convert_impl(self, value: Any) -> str:
-        if not isinstance(value, str):
-            raise ValidationError(
-                "Interpolation result `$VALUE` of type '$VALUE_TYPE' is not a string"
-            )
+    def _validate_and_convert_impl(self, value: Any) -> Any:
+        # Interpolation results may be anything.
         return value
 
-    def __deepcopy__(self, memo: Dict[int, Any]) -> "StringInterpolationResultNode":
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "InterpolationResultNode":
         # Currently there should be no need to deep-copy such nodes.
         raise NotImplementedError
 

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -404,13 +404,6 @@ class StringInterpolationResultNode(ValueNode):
         parent: Optional[Container] = None,
         flags: Optional[Dict[str, bool]] = None,
     ):
-        # In general we should not try to write into interpolation results.
-        if flags is None:
-            flags = {"readonly": True}
-        elif "readonly" not in flags:
-            flags = flags.copy()
-            flags["readonly"] = True
-
         super().__init__(
             parent=parent,
             value=value,
@@ -418,6 +411,9 @@ class StringInterpolationResultNode(ValueNode):
                 ref_type=str, object_type=str, key=key, optional=False, flags=flags
             ),
         )
+        # In general we should not try to write into interpolation results.
+        if flags is None or "readonly" not in flags:
+            self._set_flag("readonly", True)
 
     def _set_value(self, value: Any, flags: Optional[Dict[str, bool]] = None) -> None:
         if self._get_flag("readonly"):

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -39,13 +39,14 @@ class ValueNode(Node):
             self._val = value
 
     def _should_validate(self, value: Any) -> bool:
-        # Validate a value if it is not missing nor an interpolation.
-        return not isinstance(value, str) or get_value_kind(
+        # If `value` is missing or an interpolation, we do not need to validate it.
+        is_missing_or_inter = isinstance(value, str) and get_value_kind(
             value, strict_interpolation_validation=True
-        ) not in (
+        ) in (
             ValueKind.INTERPOLATION,
             ValueKind.MANDATORY_MISSING,
         )
+        return not is_missing_or_inter
 
     def validate_and_convert(self, value: Any) -> Any:
         """

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -24,7 +24,7 @@ class ValueNode(Node):
 
         super().__init__(parent=parent, metadata=metadata)
         with read_write(self):
-            self._set_value(value)
+            self._set_value(value)  # lgtm [py/init-calls-subclass]
 
     def _value(self) -> Any:
         return self._val

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -952,9 +952,6 @@ def _node_wrap(
     value: Any,
     key: Any,
     ref_type: Any = Any,
-    # Flag indicating whether the input value may be considered to be an interpolation.
-    # It is only used when wrapping a string within an `AnyNode` or `StringNode`.
-    can_be_interpolation: bool = True,
 ) -> Node:
     node: Node
     is_dict = is_primitive_dict(value) or is_dict_annotation(type_)
@@ -996,12 +993,7 @@ def _node_wrap(
             element_type=element_type,
         )
     elif type_ == Any or type_ is None:
-        node = AnyNode(
-            value=value,
-            key=key,
-            parent=parent,
-            can_be_interpolation=can_be_interpolation,
-        )
+        node = AnyNode(value=value, key=key, parent=parent)
     elif issubclass(type_, Enum):
         node = EnumNode(
             enum_type=type_,
@@ -1017,21 +1009,10 @@ def _node_wrap(
     elif type_ == bool:
         node = BooleanNode(value=value, key=key, parent=parent, is_optional=is_optional)
     elif type_ == str:
-        node = StringNode(
-            value=value,
-            key=key,
-            parent=parent,
-            is_optional=is_optional,
-            can_be_interpolation=can_be_interpolation,
-        )
+        node = StringNode(value=value, key=key, parent=parent, is_optional=is_optional)
     else:
         if parent is not None and parent._get_flag("allow_objects") is True:
-            node = AnyNode(
-                value=value,
-                key=key,
-                parent=parent,
-                can_be_interpolation=can_be_interpolation,
-            )
+            node = AnyNode(value=value, key=key, parent=parent)
         else:
             raise ValidationError(f"Unexpected object type: {type_str(type_)}")
     return node

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -952,6 +952,9 @@ def _node_wrap(
     value: Any,
     key: Any,
     ref_type: Any = Any,
+    # Flag indicating whether the input value may be considered to be an interpolation.
+    # It is only used when wrapping a string within an `AnyNode` or `StringNode`.
+    can_be_interpolation: bool = True,
 ) -> Node:
     node: Node
     is_dict = is_primitive_dict(value) or is_dict_annotation(type_)
@@ -993,7 +996,12 @@ def _node_wrap(
             element_type=element_type,
         )
     elif type_ == Any or type_ is None:
-        node = AnyNode(value=value, key=key, parent=parent)
+        node = AnyNode(
+            value=value,
+            key=key,
+            parent=parent,
+            can_be_interpolation=can_be_interpolation,
+        )
     elif issubclass(type_, Enum):
         node = EnumNode(
             enum_type=type_,
@@ -1009,10 +1017,21 @@ def _node_wrap(
     elif type_ == bool:
         node = BooleanNode(value=value, key=key, parent=parent, is_optional=is_optional)
     elif type_ == str:
-        node = StringNode(value=value, key=key, parent=parent, is_optional=is_optional)
+        node = StringNode(
+            value=value,
+            key=key,
+            parent=parent,
+            is_optional=is_optional,
+            can_be_interpolation=can_be_interpolation,
+        )
     else:
         if parent is not None and parent._get_flag("allow_objects") is True:
-            node = AnyNode(value=value, key=key, parent=parent)
+            node = AnyNode(
+                value=value,
+                key=key,
+                parent=parent,
+                can_be_interpolation=can_be_interpolation,
+            )
         else:
             raise ValidationError(f"Unexpected object type: {type_str(type_)}")
     return node

--- a/tests/interpolation/test_custom_resolvers.py
+++ b/tests/interpolation/test_custom_resolvers.py
@@ -5,7 +5,7 @@ from typing import Any
 from pytest import mark, param, raises, warns
 
 from omegaconf import OmegaConf, Resolver
-from omegaconf.nodes import AnyNode
+from omegaconf.nodes import InterpolationResultNode
 from tests.interpolation import dereference_node
 
 
@@ -355,8 +355,8 @@ def test_resolver_output_dict(restore_resolvers: Any, readonly: bool) -> None:
     assert isinstance(c.x, dict)
     assert c.x == some_dict
     x_node = dereference_node(c, "x")
-    assert isinstance(x_node, AnyNode)
-    assert x_node._get_flag("allow_objects")
+    assert isinstance(x_node, InterpolationResultNode)
+    assert x_node._get_flag("readonly")
 
 
 @mark.parametrize("readonly", [True, False])
@@ -378,8 +378,8 @@ def test_resolver_output_plain_dict_list(
     assert c.x == data
 
     x_node = dereference_node(c, "x")
-    assert isinstance(x_node, AnyNode)
-    assert x_node._get_flag("allow_objects")
+    assert isinstance(x_node, InterpolationResultNode)
+    assert x_node._get_flag("readonly")
 
 
 def test_register_cached_resolver_with_keyword_unsupported() -> None:

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -21,7 +21,7 @@ from omegaconf._utils import _ensure_container
 from omegaconf.errors import InterpolationKeyError
 from omegaconf.errors import InterpolationResolutionError
 from omegaconf.errors import InterpolationResolutionError as IRE
-from omegaconf.errors import InterpolationValidationError
+from omegaconf.errors import InterpolationValidationError, ReadonlyConfigError
 from tests import MissingDict, MissingList, StructuredWithMissing, SubscriptedList, User
 from tests.interpolation import dereference_node
 
@@ -500,4 +500,11 @@ def test_interpolation_like_result_is_not_an_interpolation(
         cfg = OmegaConf.structured(Config)
 
     assert cfg.x == expected
-    assert not dereference_node(cfg, "x")._is_interpolation()
+
+    # Check that the resulting node is not considered to be an interpolation.
+    resolved_node = dereference_node(cfg, "x")
+    assert not resolved_node._is_interpolation()
+
+    # Check that the resulting node is read-only.
+    with raises(ReadonlyConfigError):
+        resolved_node._set_value("foo")

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -23,6 +23,7 @@ from omegaconf.errors import InterpolationKeyError
 from omegaconf.errors import InterpolationResolutionError
 from omegaconf.errors import InterpolationResolutionError as IRE
 from omegaconf.errors import InterpolationValidationError, ReadonlyConfigError
+from omegaconf.nodes import InterpolationResultNode
 from tests import MissingDict, MissingList, StructuredWithMissing, SubscriptedList, User
 from tests.interpolation import dereference_node
 
@@ -260,7 +261,7 @@ def test_none_value_in_quoted_string(restore_resolvers: Any) -> None:
             User(name="Bond", age=SI("${cast:int,'7'}")),
             "age",
             7,
-            IntegerNode,
+            InterpolationResultNode,
             id="expected_type",
         ),
         param(
@@ -269,7 +270,7 @@ def test_none_value_in_quoted_string(restore_resolvers: Any) -> None:
             User(name="Bond", age=SI("${cast:int,${drop_last:${drop_last:7xx}}}")),
             "age",
             7,
-            IntegerNode,
+            InterpolationResultNode,
             id="intermediate_type_mismatch_ok",
         ),
         param(
@@ -278,7 +279,7 @@ def test_none_value_in_quoted_string(restore_resolvers: Any) -> None:
             User(name="Bond", age=SI("${cast:str,'7'}")),
             "age",
             7,
-            IntegerNode,
+            InterpolationResultNode,
             id="convert_str_to_int",
         ),
         param(

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -285,14 +285,14 @@ def test_none_value_in_quoted_string(restore_resolvers: Any) -> None:
         param(
             MissingList(list=SI("${oc.create:[a, b, c]}")),
             "list",
-            ["a", "b", "c"],
+            ListConfig(["a", "b", "c"]),
             ListConfig,
             id="list_str",
         ),
         param(
             MissingDict(dict=SI("${oc.create:{key1: val1, key2: val2}}")),
             "dict",
-            {"key1": "val1", "key2": "val2"},
+            DictConfig({"key1": "val1", "key2": "val2"}),
             DictConfig,
             id="dict_str",
         ),
@@ -314,6 +314,7 @@ def test_interpolation_type_validated_ok(
 
     val = cfg[key]
     assert val == expected_value
+    assert type(val) is type(expected_value)
 
     node = cfg._get_node(key)
     assert isinstance(node, Node)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -520,11 +520,9 @@ def test_eq(node: ValueNode, value: Any, expected: Any) -> None:
     assert (value == node) == expected
     assert (value != node) != expected
 
-    try:
+    # Check hash except for unhashable types (dict/list).
+    if not isinstance(value, (dict, list)):
         assert (node.__hash__() == value.__hash__()) == expected
-    except TypeError as exc:
-        # Skip this check if unhashable.
-        assert "unhashable type" in str(exc)
 
 
 @mark.parametrize("value", [1, 3.14, True, None, Enum1.FOO])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -644,16 +644,12 @@ def test_set_flags_in_init(type_: Any, flags: Dict[str, bool]) -> None:
 )
 def test_string_interpolation_result_flags(flags: Any) -> None:
     readonly = None if flags is None else flags.get("readonly")
-    flags_backup = copy.deepcopy(flags)
+    expected = [] if flags is None else list(flags.items())
     node = StringInterpolationResultNode("foo", flags=flags)
 
-    # Check that input flags are not mutated.
-    assert flags == flags_backup
-
     # Check that flags are set to their desired value.
-    if flags is not None:
-        for k, v in flags.items():
-            assert node._get_node_flag(k) is v
+    for k, v in expected:
+        assert node._get_node_flag(k) is v
 
     # Check that the readonly flag is set unless provided as input.
     if readonly is None:


### PR DESCRIPTION
Fixes #666

This is a first stab at it in order to ground discussions. I did a bit more than the "bandaid" fix I had suggested in #666, to get a cleaner behavior (at the expense of passing around a new "can_be_interpolation" flag).

In this first version I only included this flag in `AnyNode` and `StringNode` so as to somewhat limit potential side effects, though it's a bit ugly because it leaks into `ValueNode._set_value_impl()`. I wouldn't mind making it an attribute of `ValueNode`, which could serve as a first step towards caching the interpolation status in the future, but I preferred to wait until we'd discuss it.