### PR TITLE
Pytest to fail on warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ exclude = '''
 '''
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=append"
+addopts = "--import-mode=append -Werror"
 
 [tool.towncrier]
     package = "omegaconf"


### PR DESCRIPTION
I've added a '-Werror' flag to pytest's ini options.

I expect that the CI tests will fail (#710 is fixing some warnings that are currently issued).