### PR TITLE
typing: DictConfig.keys to return AbstractSet

### DIFF
--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -206,7 +206,7 @@ class BaseContainer(Container, ABC):
             ):
                 return conf._to_object()
 
-            retdict: Dict[str, Any] = {}
+            retdict: Dict[DictKeyType, Any] = {}
             for key in conf.keys():
                 node = conf._get_node(key)
                 assert isinstance(node, Node)

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -504,10 +504,12 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         except Exception as e:
             self._format_and_raise(key=key, value=None, cause=e)
 
-    def keys(self) -> Any:
+    def keys(self) -> AbstractSet[DictKeyType]:
         if self._is_missing() or self._is_interpolation() or self._is_none():
-            return list()
-        return self.__dict__["_content"].keys()
+            return set()
+        ret = self.__dict__["_content"].keys()
+        assert isinstance(ret, AbstractSet)
+        return ret
 
     def __contains__(self, key: object) -> bool:
         """
@@ -718,6 +720,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         field_items: Dict[str, Any] = {}
         nonfield_items: Dict[str, Any] = {}
         for k in self.keys():
+            assert isinstance(k, str)
             node = self._get_node(k)
             assert isinstance(node, Node)
             node = node._dereference_node()


### PR DESCRIPTION
This PR does two things:
- change return type of `DictConfig.keys` from `Any` to `AbstractSet[DictKeyType]`, and
- ensure that `DictConfig.keys` always returns an `AbstractSet`. Previously, an empty `list()` was returned in the case where the the config was an interpolation/missing/none.