### PR TITLE
BaseContainer: error if `parent` has wrong type

### DIFF
--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -28,6 +28,7 @@ from ._utils import (
 from .base import Container, ContainerMetadata, DictKeyType, Node, SCMode
 from .errors import (
     ConfigCycleDetectedException,
+    ConfigTypeError,
     MissingMandatoryValue,
     ReadonlyConfigError,
     ValidationError,
@@ -42,6 +43,8 @@ class BaseContainer(Container, ABC):
     _resolvers: Dict[str, Any] = {}
 
     def __init__(self, parent: Optional["Container"], metadata: ContainerMetadata):
+        if not (parent is None or isinstance(parent, Container)):
+            raise ConfigTypeError("Node parent should be a Container")
         super().__init__(parent=parent, metadata=metadata)
         self.__dict__["_content"] = None
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -44,7 +44,7 @@ class BaseContainer(Container, ABC):
 
     def __init__(self, parent: Optional["Container"], metadata: ContainerMetadata):
         if not (parent is None or isinstance(parent, Container)):
-            raise ConfigTypeError("Node parent should be a Container")
+            raise ConfigTypeError("Parent type is not omegaconf.Container")
         super().__init__(parent=parent, metadata=metadata)
         self.__dict__["_content"] = None
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1401,6 +1401,22 @@ def test_parse_error_on_creation(create_func: Any, arg: Any) -> None:
         create_func(arg)
 
 
+@mark.parametrize(
+    ["create_func", "obj"],
+    [
+        param(DictConfig, {"zz": 10}, id="dict"),
+        param(DictConfig, {}, id="dict_empty"),
+        param(DictConfig, User, id="structured"),
+        param(ListConfig, ["zz"], id="list"),
+        param(ListConfig, [], id="list_empty"),
+        param(OmegaConf.create, {"zz": 10}, id="create"),
+    ],
+)
+def test_parent_type_error_on_creation(create_func: Any, obj: Any) -> None:
+    with raises(ConfigTypeError, match="Node parent should be a Container"):
+        create_func(obj, parent={"a"})  # bad parent
+
+
 def test_cycle_when_iterating_over_parents() -> None:
     c = OmegaConf.create({"x": {}})
     x_node = c._get_node("x")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1413,7 +1413,9 @@ def test_parse_error_on_creation(create_func: Any, arg: Any) -> None:
     ],
 )
 def test_parent_type_error_on_creation(create_func: Any, obj: Any) -> None:
-    with raises(ConfigTypeError, match="Node parent should be a Container"):
+    with raises(
+        ConfigTypeError, match=re.escape("Parent type is not omegaconf.Container")
+    ):
         create_func(obj, parent={"a"})  # bad parent
 
 


### PR DESCRIPTION
Previously the following examples either gave an `AssertionError` or returned a config object with bad metadata:
```python
OmegaConf.create( {}, {"a", "b"})  # bad metadata
OmegaConf.create({"zz": 10}, {"a", "b"})  # used to raise AssertionError
OmegaConf.create(Dog, {"a", "b"})  # used to raise AssertionError
```
Now all three examples raise `ConfigTypeError`.