### PR TITLE
Make missing {Dict,List}Config compare equal to "???"

### DIFF
--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -594,6 +594,8 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             return DictConfig._dict_conf_eq(self, other)
         if isinstance(other, DictConfig):
             return DictConfig._dict_conf_eq(self, other)
+        if self._is_missing():
+            return _is_missing_literal(other)
         return NotImplemented
 
     def __ne__(self, other: Any) -> bool:

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -16,6 +16,7 @@ from typing import (
 
 from ._utils import (
     ValueKind,
+    _is_missing_literal,
     _is_none,
     _is_optional,
     format_and_raise,
@@ -481,6 +482,8 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
             return ListConfig._list_eq(self, other)
         if other is None or isinstance(other, ListConfig):
             return ListConfig._list_eq(self, other)
+        if self._is_missing():
+            return _is_missing_literal(other)
         return NotImplemented
 
     def __ne__(self, other: Any) -> bool:

--- a/tests/test_config_eq.py
+++ b/tests/test_config_eq.py
@@ -109,6 +109,8 @@ def test_eq(i1: Any, i2: Any) -> None:
 def test_missing_container_string_eq(cfg: Any, other: Any) -> None:
     assert cfg == other
     assert other == cfg
+    assert not (cfg != other)
+    assert not (other != cfg)
 
 
 @mark.parametrize(

--- a/tests/test_config_eq.py
+++ b/tests/test_config_eq.py
@@ -100,6 +100,18 @@ def test_eq(i1: Any, i2: Any) -> None:
 
 
 @mark.parametrize(
+    "cfg,other",
+    [
+        param(DictConfig("???"), "???", id="missing_dictconfig"),
+        param(ListConfig("???"), "???", id="missing_listconfig"),
+    ],
+)
+def test_missing_container_string_eq(cfg: Any, other: Any) -> None:
+    assert cfg == other
+    assert other == cfg
+
+
+@mark.parametrize(
     "input1, input2",
     [
         # Dicts


### PR DESCRIPTION
Closes #741.

I've added an additional branch to each of `DictConfig.__eq__` and `ListConfig.__eq__`:
```
if self._is_missing:
    return _is_missing_literal(other)
```

This allows for `assert DictConfig("???") == "???"` and `assert ListConfig("???") == "???"`.