### PR TITLE
Fix regression:  merging list into optional tuple

### DIFF
--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -24,6 +24,7 @@ from ._utils import (
     is_primitive_dict,
     is_primitive_type,
     is_structured_config,
+    is_tuple_annotation,
 )
 from .base import Container, ContainerMetadata, DictKeyType, Node, SCMode
 from .errors import (
@@ -290,7 +291,7 @@ class BaseContainer(Container, ABC):
             if rt is not Any:
                 if is_dict_annotation(rt):
                     val = {}
-                elif is_list_annotation(rt):
+                elif is_list_annotation(rt) or is_tuple_annotation(rt):
                     val = []
                 else:
                     val = rt

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import attr
 from pytest import warns
@@ -237,6 +237,11 @@ class InterpolationDict:
 @dataclass
 class Str2Int(Dict[str, int]):
     pass
+
+
+@dataclass
+class OptTuple:
+    x: Optional[Tuple[int, ...]] = None
 
 
 def warns_dict_subclass_deprecated(dict_subclass: Any) -> Any:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -28,6 +28,7 @@ from tests import (
     InterpolationList,
     MissingDict,
     MissingList,
+    OptTuple,
     Package,
     Plugin,
     User,
@@ -249,6 +250,11 @@ from tests import (
             [{"user": User()}, {"user": {"foo": "bar"}}],
             raises(ConfigKeyError),
             id="merge_unknown_key_into_structured_node",
+        ),
+        param(
+            [OptTuple, {"x": [1, 2]}],
+            {"x": [1, 2]},
+            id="merge_list_into_optional_tuple_none",
         ),
         # DictConfig with element_type of Structured Config
         param(


### PR DESCRIPTION
Closes #751.

Previously (in OmegaConf 2.0) it was possible to merge a list into a ListConfig(None) that had `ref_type==Tuple[int, ...]` and `is_optional=True`.
In 2.1, this was no longer possible.

This PR patches the regression.