### PR TITLE
Improve error message for InterpolationValidationError

### DIFF
--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -185,13 +185,18 @@ class Node(ABC):
             return parent._get_flag(flag)
 
     def _format_and_raise(
-        self, key: Any, value: Any, cause: Exception, type_override: Any = None
+        self,
+        key: Any,
+        value: Any,
+        cause: Exception,
+        msg: Optional[str] = None,
+        type_override: Any = None,
     ) -> None:
         format_and_raise(
             node=self,
             key=key,
             value=value,
-            msg=str(cause),
+            msg=str(cause) if msg is None else msg,
             cause=cause,
             type_override=type_override,
         )
@@ -520,6 +525,7 @@ class Container(Node):
                         key=key,
                         value=res_value,
                         cause=e,
+                        msg=f"While dereferencing interpolation '{value}': {e}",
                         type_override=InterpolationValidationError,
                     )
                 return None

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -11,6 +11,7 @@ from omegaconf._utils import (
     get_type_of,
     get_value_kind,
     is_primitive_container,
+    type_str,
 )
 from omegaconf.base import Container, DictKeyType, Metadata, Node
 from omegaconf.errors import ReadonlyConfigError, UnsupportedValueType, ValidationError
@@ -52,7 +53,10 @@ class ValueNode(Node):
         if value is None:
             if self._is_optional():
                 return None
-            raise ValidationError("Non optional field cannot be assigned None")
+            ref_type_str = type_str(self._metadata.ref_type)
+            raise ValidationError(
+                f"Incompatible value '{value}' for field of type '{ref_type_str}'"
+            )
         # Subclasses can assume that `value` is not None in `_validate_and_convert_impl()`.
         return self._validate_and_convert_impl(value)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -115,6 +115,12 @@ class StructuredInterpolationKeyError:
 
 
 @dataclass
+class StructuredInterpolationValidationError:
+    x: Optional[int] = None
+    y: int = II(".x")
+
+
+@dataclass
 class StructuredWithMissing:
     num: int = MISSING
     opt_num: Optional[int] = MISSING

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -356,7 +356,9 @@ def test_interpolation_type_validated_ok(
             "num",
             raises(
                 InterpolationValidationError,
-                match=re.escape("Non optional field cannot be assigned None"),
+                match=re.escape(
+                    "While dereferencing interpolation '${opt_num}': Incompatible value 'None' for field of type 'int'"
+                ),
             ),
             id="non_optional_node_interpolation",
         ),

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -319,6 +319,7 @@ params = [
             create=lambda: OmegaConf.structured(StructuredInterpolationValidationError),
             op=lambda cfg: getattr(cfg, "y"),
             exception_type=InterpolationValidationError,
+            object_type=StructuredInterpolationValidationError,
             msg=(
                 "While dereferencing interpolation '${.x}': "
                 "Incompatible value 'None' for field of type 'int'"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -27,6 +27,7 @@ from omegaconf.errors import (
     InterpolationKeyError,
     InterpolationResolutionError,
     InterpolationToMissingValueError,
+    InterpolationValidationError,
     KeyValidationError,
     MissingMandatoryValue,
     OmegaConfBaseException,
@@ -42,6 +43,7 @@ from tests import (
     Plugin,
     Str2Int,
     StructuredInterpolationKeyError,
+    StructuredInterpolationValidationError,
     StructuredWithBadDict,
     StructuredWithBadList,
     StructuredWithMissing,
@@ -311,6 +313,20 @@ params = [
             child_node=lambda cfg: cfg._get_node("foo"),
         ),
         id="dict,accessing_missing_nested_interpolation",
+    ),
+    param(
+        Expected(
+            create=lambda: OmegaConf.structured(StructuredInterpolationValidationError),
+            op=lambda cfg: getattr(cfg, "y"),
+            exception_type=InterpolationValidationError,
+            msg=(
+                "While dereferencing interpolation '${.x}': "
+                "Incompatible value 'None' for field of type 'int'"
+            ),
+            key="y",
+            child_node=lambda cfg: cfg._get_node("y"),
+        ),
+        id="dict,non_optional_field_with_interpolation_to_none",
     ),
     # setattr
     param(
@@ -596,20 +612,20 @@ params = [
             create=lambda: None,
             op=lambda _: OmegaConf.structured(NotOptionalInt),
             exception_type=ValidationError,
-            msg="Non optional field cannot be assigned None",
+            msg="Incompatible value 'None' for field of type 'int'",
             key="foo",
             full_key="foo",
             parent_node=lambda _: {},
             object_type=NotOptionalInt,
         ),
-        id="dict:create_none_optional_with_none",
+        id="dict:create_non_optional_with_none",
     ),
     param(
         Expected(
             create=lambda: None,
             op=lambda _: OmegaConf.structured(NotOptionalInt),
             exception_type=ValidationError,
-            msg="Non optional field cannot be assigned None",
+            msg="Incompatible value 'None' for field of type 'int'",
             key="foo",
             full_key="foo",
             parent_node=lambda _: {},

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -19,6 +19,7 @@ from omegaconf import (
     StringNode,
     ValueNode,
 )
+from omegaconf._utils import type_str
 from omegaconf.errors import (
     InterpolationToMissingValueError,
     UnsupportedValueType,
@@ -600,7 +601,7 @@ def test_dereference_missing() -> None:
 )
 def test_validate_and_convert_none(make_func: Any) -> None:
     node = make_func("???", is_optional=False)
-    ref_type_str = node._metadata.ref_type.__name__
+    ref_type_str = type_str(node._metadata.ref_type)
     with raises(
         ValidationError,
         match=re.escape(

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -600,8 +600,12 @@ def test_dereference_missing() -> None:
 )
 def test_validate_and_convert_none(make_func: Any) -> None:
     node = make_func("???", is_optional=False)
+    ref_type_str = node._metadata.ref_type.__name__
     with raises(
-        ValidationError, match=re.escape("Non optional field cannot be assigned None")
+        ValidationError,
+        match=re.escape(
+            f"Incompatible value 'None' for field of type '{ref_type_str}'"
+        ),
     ):
         node.validate_and_convert(None)
 


### PR DESCRIPTION
This PR improves error messages raised when interpolating to `None` from a node whose `ref_type` is not optional.
- The interpolation key is now included in the error message.
- The error message now includes the `ref_type` of the target field.
- The error message no longer uses the word "assign", which was misleading because (semantically) assignment is not taking place when an interpolation is dereferenced.

If this PR is merged into `master`, I'll plan to cherry pick the updates and open a similar PR against the OmegaConf `2.1_branch`.


Closes #753.