### PR TITLE
Fix PyYAML dependency version sintax

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 antlr4-python3-runtime==4.8
-PyYAML>=5.1.*
+PyYAML>=5.1.0
 # Use dataclasses backport for Python 3.6.
 dataclasses;python_version=='3.6'


### PR DESCRIPTION
PEP440 requires >=5.1.0 instead of >=5.1.*