### PR TITLE
clarify message re OC_CAUSE=1 env var

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -716,7 +716,7 @@ def _raise(ex: Exception, cause: Exception) -> None:
         ex.__cause__ = cause
     else:
         ex.__cause__ = None
-    raise ex.with_traceback(sys.exc_info()[2])  # set end OC_CAUSE=1 for full backtrace
+    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
 
 
 def format_and_raise(


### PR DESCRIPTION
* omegaconf/_utils.py: Fix typo, and clarify
that one needs to set the environment variable
to get the full backtrace