### PR TITLE
Update docs with missing import for open_dict

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -544,6 +544,7 @@ You can temporarily remove the struct flag from a config object:
 
 .. doctest:: loaded
 
+    >>> from omegaconf import open_dict
     >>> conf = OmegaConf.create({"a": {"aa": 10, "bb": 20}})
     >>> OmegaConf.set_struct(conf, True)
     >>> with open_dict(conf):


### PR DESCRIPTION
Adding the import relative to `omegaconf.open_dict` that is missing in section **Struct flag**.