### PR TITLE
Fix CI failure

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ PYTHON_VERSIONS = os.environ.get(
 
 
 def deps(session, editable_install):
-    session.install("--upgrade", "setuptools", "pip")
+    session.install("--upgrade", "setuptools!=59.1.0", "pip")
     extra_flags = ["-e"] if editable_install else []
     session.install("-r", "requirements/dev.txt", *extra_flags, ".", silent=True)
 


### PR DESCRIPTION
See the CI failure in the commit below.
```text
DeprecationWarning: Creating a LegacyVersion has been deprecated and will be removed in the next major release
```
I can reproduce the failure locally with nox.