### PR TITLE
Fix `default_factory` support in structured config subclasses

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -341,11 +341,8 @@ def get_dataclass_data(
         is_optional, type_ = _resolve_optional(resolved_hints[field.name])
         type_ = _resolve_forward(type_, obj.__module__)
 
-        if hasattr(obj, name):
-            value = getattr(obj, name)
-            if value == dataclasses.MISSING:
-                value = MISSING
-        else:
+        value = getattr(obj, name, MISSING)
+        if value in (MISSING, dataclasses.MISSING):
             if field.default_factory == dataclasses.MISSING:  # type: ignore
                 value = MISSING
             else:

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -560,19 +560,25 @@ class UntypedDict:
 
 class StructuredSubclass:
     @attr.s(auto_attribs=True)
-    class ParentConfig:
+    class ParentInts:
         int1: int
         int2: int
         int3: int = attr.NOTHING  # type: ignore
         int4: int = MISSING
+
+    @attr.s(auto_attribs=True)
+    class ChildInts(ParentInts):
+        int2: int = 5
+        int3: int = 10
+        int4: int = 15
+
+    @attr.s(auto_attribs=True)
+    class ParentContainers:
         list1: List[int] = MISSING
         list2: List[int] = [5, 6]
         dict: Dict[str, Any] = MISSING
 
     @attr.s(auto_attribs=True)
-    class ChildConfig(ParentConfig):
-        int2: int = 5
-        int3: int = 10
-        int4: int = 15
+    class ChildContainers(ParentContainers):
         list1: List[int] = [1, 2, 3]
         dict: Dict[str, Any] = {"a": 5, "b": 6}

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -556,3 +556,23 @@ class UntypedList:
 class UntypedDict:
     dict: Dict = {"foo": "var"}  # type: ignore
     opt_dict: Optional[Dict] = None  # type: ignore
+
+
+class StructuredSubclass:
+    @attr.s(auto_attribs=True)
+    class ParentConfig:
+        int1: int
+        int2: int
+        int3: int = attr.NOTHING  # type: ignore
+        int4: int = MISSING
+        list1: List[int] = MISSING
+        list2: List[int] = [5, 6]
+        dict: Dict[str, Any] = MISSING
+
+    @attr.s(auto_attribs=True)
+    class ChildConfig(ParentConfig):
+        int2: int = 5
+        int3: int = 10
+        int4: int = 15
+        list1: List[int] = [1, 2, 3]
+        dict: Dict[str, Any] = {"a": 5, "b": 6}

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -581,19 +581,25 @@ class UntypedDict:
 
 class StructuredSubclass:
     @dataclass
-    class ParentConfig:
+    class ParentInts:
         int1: int
         int2: int
         int3: int = dataclasses.MISSING  # type: ignore
         int4: int = MISSING
+
+    @dataclass
+    class ChildInts(ParentInts):
+        int2: int = 5
+        int3: int = 10
+        int4: int = 15
+
+    @dataclass
+    class ParentContainers:
         list1: List[int] = MISSING
         list2: List[int] = field(default_factory=lambda: [5, 6])
         dict: Dict[str, Any] = MISSING
 
     @dataclass
-    class ChildConfig(ParentConfig):
-        int2: int = 5
-        int3: int = 10
-        int4: int = 15
+    class ChildContainers(ParentContainers):
         list1: List[int] = field(default_factory=lambda: [1, 2, 3])
         dict: Dict[str, Any] = field(default_factory=lambda: {"a": 5, "b": 6})

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -577,3 +577,23 @@ class UntypedList:
 class UntypedDict:
     dict: Dict = field(default_factory=lambda: {"foo": "var"})  # type: ignore
     opt_dict: Optional[Dict] = None  # type: ignore
+
+
+class StructuredSubclass:
+    @dataclass
+    class ParentConfig:
+        int1: int
+        int2: int
+        int3: int = dataclasses.MISSING  # type: ignore
+        int4: int = MISSING
+        list1: List[int] = MISSING
+        list2: List[int] = field(default_factory=lambda: [5, 6])
+        dict: Dict[str, Any] = MISSING
+
+    @dataclass
+    class ChildConfig(ParentConfig):
+        int2: int = 5
+        int3: int = 10
+        int4: int = 15
+        list1: List[int] = field(default_factory=lambda: [1, 2, 3])
+        dict: Dict[str, Any] = field(default_factory=lambda: {"a": 5, "b": 6})

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1170,3 +1170,32 @@ class TestConfigs2:
         c3 = OmegaConf.merge(c1, c2)
         with raises(ValidationError):
             c3.missing.append("xx")
+
+
+@mark.parametrize(
+    "key, parent_expected, child_expected",
+    [
+        param("int1", MISSING, MISSING, id="int1_inherit_unspecified"),
+        param("int2", MISSING, 5, id="int2_overwrite_unspecified"),
+        param("int3", MISSING, 10, id="int3_overwrite_native_missing"),
+        param("int4", MISSING, 15, id="int4_overwrite_missing"),
+        param("list1", MISSING, [1, 2, 3], id="list1_overwrite_missing"),
+        param("list2", [5, 6], [5, 6], id="list2_inherit_default"),
+        param("dict", MISSING, {"a": 5, "b": 6}, id="dict_overwrite_missing"),
+    ],
+)
+def test_structured_config_inheritance(
+    module: Any, key: str, parent_expected: Any, child_expected: Any
+) -> None:
+
+    parent = OmegaConf.structured(module.StructuredSubclass.ParentConfig)
+    if parent_expected is MISSING:
+        assert OmegaConf.is_missing(parent, key)
+    else:
+        assert parent[key] == parent_expected
+
+    child = OmegaConf.structured(module.StructuredSubclass.ChildConfig)
+    if child_expected is MISSING:
+        assert OmegaConf.is_missing(child, key)
+    else:
+        assert child[key] == child_expected

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1172,30 +1172,32 @@ class TestConfigs2:
             c3.missing.append("xx")
 
 
-@mark.parametrize(
-    "key, parent_expected, child_expected",
-    [
-        param("int1", MISSING, MISSING, id="int1_inherit_unspecified"),
-        param("int2", MISSING, 5, id="int2_overwrite_unspecified"),
-        param("int3", MISSING, 10, id="int3_overwrite_native_missing"),
-        param("int4", MISSING, 15, id="int4_overwrite_missing"),
-        param("list1", MISSING, [1, 2, 3], id="list1_overwrite_missing"),
-        param("list2", [5, 6], [5, 6], id="list2_inherit_default"),
-        param("dict", MISSING, {"a": 5, "b": 6}, id="dict_overwrite_missing"),
-    ],
-)
-def test_structured_config_inheritance(
-    module: Any, key: str, parent_expected: Any, child_expected: Any
-) -> None:
+class TestStructredConfigInheritance:
+    def test_leaf_node_inheritance(self, module: Any) -> None:
+        parent = OmegaConf.structured(module.StructuredSubclass.ParentInts)
+        child = OmegaConf.structured(module.StructuredSubclass.ChildInts)
 
-    parent = OmegaConf.structured(module.StructuredSubclass.ParentConfig)
-    if parent_expected is MISSING:
-        assert OmegaConf.is_missing(parent, key)
-    else:
-        assert parent[key] == parent_expected
+        assert OmegaConf.is_missing(parent, "int1")
+        assert OmegaConf.is_missing(child, "int1")
 
-    child = OmegaConf.structured(module.StructuredSubclass.ChildConfig)
-    if child_expected is MISSING:
-        assert OmegaConf.is_missing(child, key)
-    else:
-        assert child[key] == child_expected
+        assert OmegaConf.is_missing(parent, "int2")
+        assert child.int2 == 5
+
+        assert OmegaConf.is_missing(parent, "int3")
+        assert child.int3 == 10
+
+        assert OmegaConf.is_missing(parent, "int4")
+        assert child.int4 == 15
+
+    def test_container_inheritance(self, module: Any) -> None:
+        parent = OmegaConf.structured(module.StructuredSubclass.ParentContainers)
+        child = OmegaConf.structured(module.StructuredSubclass.ChildContainers)
+
+        assert OmegaConf.is_missing(parent, "list1")
+        assert child.list1 == [1, 2, 3]
+
+        assert parent.list2 == [5, 6]
+        assert child.list2 == [5, 6]
+
+        assert OmegaConf.is_missing(parent, "dict")
+        assert child.dict == {"a": 5, "b": 6}


### PR DESCRIPTION
This PR closes #817.

#### Commits:

- https://github.com/omry/omegaconf/commit/78da5506e6772a6ed377d1763a4419ec9ef0f4ce:
  Write failing tests based on #817.
  As of this commit, the following two tests fail:
  ```
  pytest tests/structured_conf/test_structured_config.py -k 'dataclasses-dict_overwrite_missing'
  pytest tests/structured_conf/test_structured_config.py -k 'dataclasses-list1_overwrite_missing'
  ```
- https://github.com/omry/omegaconf/commit/9bbaadc11891e5991075952d0812ff3b508cce99:
  Support defining default_factory in child structured config. Tests pass.
