### PR TITLE
Allow assignment of MISSING in List[Structured]

### DIFF
--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -98,19 +98,23 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                         "$FULL_KEY is not optional and cannot be assigned None"
                     )
 
-        is_optional, target_type = _resolve_optional(self._metadata.element_type)
-        value_type = OmegaConf.get_type(value)
+        vk = get_value_kind(value)
+        if vk == ValueKind.MANDATORY_MISSING:
+            return
+        else:
+            is_optional, target_type = _resolve_optional(self._metadata.element_type)
+            value_type = OmegaConf.get_type(value)
 
-        if (value_type is None and not is_optional) or (
-            is_structured_config(target_type)
-            and value_type is not None
-            and not issubclass(value_type, target_type)
-        ):
-            msg = (
-                f"Invalid type assigned: {type_str(value_type)} is not a "
-                f"subclass of {type_str(target_type)}. value: {value}"
-            )
-            raise ValidationError(msg)
+            if (value_type is None and not is_optional) or (
+                is_structured_config(target_type)
+                and value_type is not None
+                and not issubclass(value_type, target_type)
+            ):
+                msg = (
+                    f"Invalid type assigned: {type_str(value_type)} is not a "
+                    f"subclass of {type_str(target_type)}. value: {value}"
+                )
+                raise ValidationError(msg)
 
     def __deepcopy__(self, memo: Dict[int, Any]) -> "ListConfig":
         res = ListConfig(None)

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -407,8 +407,18 @@ class DictOfObjects:
 
 
 @attr.s(auto_attribs=True)
+class DictOfObjectsMissing:
+    users: Dict[str, User] = {"moe": MISSING}
+
+
+@attr.s(auto_attribs=True)
 class ListOfObjects:
     users: List[User] = [User(name="Joe", age=18)]
+
+
+@attr.s(auto_attribs=True)
+class ListOfObjectsMissing:
+    users: List[User] = [MISSING]
 
 
 class DictSubclass:

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -428,8 +428,18 @@ class DictOfObjects:
 
 
 @dataclass
+class DictOfObjectsMissing:
+    users: Dict[str, User] = field(default_factory=lambda: {"moe": MISSING})
+
+
+@dataclass
 class ListOfObjects:
     users: List[User] = field(default_factory=lambda: [User(name="Joe", age=18)])
+
+
+@dataclass
+class ListOfObjectsMissing:
+    users: List[User] = field(default_factory=lambda: [MISSING])
 
 
 class DictSubclass:

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -746,6 +746,20 @@ class TestConfigs:
         with raises(ValidationError):
             dct.fail = "fail"
 
+    def test_dict_of_objects_missing(self, module: Any) -> None:
+        conf = OmegaConf.structured(module.DictOfObjectsMissing)
+        dct = conf.users
+
+        assert OmegaConf.is_missing(dct, "moe")
+
+        dct.miss = MISSING
+        assert OmegaConf.is_missing(dct, "miss")
+
+    def test_assign_dict_of_objects(self, module: Any) -> None:
+        conf = OmegaConf.structured(module.DictOfObjects)
+        conf.users = {"poe": module.User(name="Poe", age=8), "miss": MISSING}
+        assert conf.users == {"poe": {"name": "Poe", "age": 8}, "miss": "???"}
+
     def test_list_of_objects(self, module: Any) -> None:
         conf = OmegaConf.structured(module.ListOfObjects)
         assert conf.users[0].age == 18
@@ -757,6 +771,19 @@ class TestConfigs:
 
         with raises(ValidationError):
             conf.users.append("fail")
+
+    def test_list_of_objects_missing(self, module: Any) -> None:
+        conf = OmegaConf.structured(module.ListOfObjectsMissing)
+
+        assert OmegaConf.is_missing(conf.users, 0)
+
+        conf.users.append(MISSING)
+        assert OmegaConf.is_missing(conf.users, 1)
+
+    def test_assign_list_of_objects(self, module: Any) -> None:
+        conf = OmegaConf.structured(module.ListOfObjects)
+        conf.users = [module.User(name="Poe", age=8), MISSING]
+        assert conf.users == [{"name": "Poe", "age": 8}, "???"]
 
     def test_promote_api(self, module: Any) -> None:
         conf = OmegaConf.create(module.AnyTypeConfig)


### PR DESCRIPTION
This PR is to close #827.

#### Commits:
- https://github.com/omry/omegaconf/commit/9970a3d9cdf5f541fd478070e1cafb94c7b7f49e: Write failing tests based on #827.
  As of this commit, the following four tests fail:
    ```text
    - tests/structured_conf/test_structured_config.py::TestConfigs::test_list_of_objects_missing[dataclasses]
    - tests/structured_conf/test_structured_config.py::TestConfigs::test_list_of_objects_missing[attr_classes]
    - tests/structured_conf/test_structured_config.py::TestConfigs::test_assign_list_of_objects[dataclasses]
    - tests/structured_conf/test_structured_config.py::TestConfigs::test_assign_list_of_objects[attr_classes]
    ```
- ~https://github.com/omry/omegaconf/commit/75369399a43a9c107470194c3b0ca57a666c5348~ https://github.com/omry/omegaconf/pull/828/commits/7e5ed4d2b9c45b776de7cad4976601a92434decb: Modify `ListConfig._validate_set` to allow `MISSING`.
