### PR TITLE
`get_dataclass_data`: branch on dataclass vs dataclass instance

### DIFF
--- a/news/831.bugfix
+++ b/news/831.bugfix
@@ -1,0 +1,1 @@
+Fix bugs related to creation of structured configs from dataclasses having fields with a default_factory

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -608,6 +608,16 @@ class StructuredSubclass:
         list1: List[int] = [1, 2, 3]
         dict: Dict[str, Any] = {"a": 5, "b": 6}
 
+    @attr.s(auto_attribs=True)
+    class ParentNoDefaultFactory:
+        no_default_to_list: Any
+        int_to_list: Any = 1
+
+    @attr.s(auto_attribs=True)
+    class ChildWithDefaultFactory(ParentNoDefaultFactory):
+        no_default_to_list: Any = ["hi"]
+        int_to_list: Any = ["hi"]
+
 
 @attr.s(auto_attribs=True)
 class HasInitFalseFields:

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -629,6 +629,16 @@ class StructuredSubclass:
         list1: List[int] = field(default_factory=lambda: [1, 2, 3])
         dict: Dict[str, Any] = field(default_factory=lambda: {"a": 5, "b": 6})
 
+    @dataclass
+    class ParentNoDefaultFactory:
+        no_default_to_list: Any
+        int_to_list: Any = 1
+
+    @dataclass
+    class ChildWithDefaultFactory(ParentNoDefaultFactory):
+        no_default_to_list: Any = field(default_factory=lambda: ["hi"])
+        int_to_list: Any = field(default_factory=lambda: ["hi"])
+
 
 @dataclass
 class HasInitFalseFields:


### PR DESCRIPTION
This PR modifies the `_utils.get_dataclasses_data` function to fix two closely-related bugs, #830 and #831.

## Change introduced
- `get_dataclass_data(obj)` now branches based on whether its input is a dataclass vs a dataclass instance. This closes [#830](#830).
- `get_dataclass_data` no-longer branches based on whether the attribute lookup `getattr(obj, fieldname)` is equal to the missing string `"???"`. This closes [#831](#831).