### PR TITLE
2.1_branch CI: typo in black config regex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ exclude = '''
       \.eggs         # exclude a few common directories in the
     | \.git          # root of the project
     | \.mypy_cache
-    | \omegaconf/grammar/gen
+    | omegaconf/grammar/gen
     | \.nox
     | build
   )


### PR DESCRIPTION
A recently-released version of the black formater has exposted a typo in our pyproject.toml file.
This typo is not a problem on the master branch because it was fixed in #800.