### PR TITLE
Refactor test_structured_config.py: followup to #558

### DIFF
--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -935,15 +935,8 @@ def validate_frozen_impl(conf: DictConfig) -> None:
         ret.user.age = 20
 
 
-def test_attr_frozen() -> None:
-    from tests.structured_conf.data.attr_classes import FrozenClass
-
-    validate_frozen_impl(OmegaConf.structured(FrozenClass))
-    validate_frozen_impl(OmegaConf.structured(FrozenClass()))
-
-
-def test_dataclass_frozen() -> None:
-    from tests.structured_conf.data.dataclasses import FrozenClass
+def test_frozen(module: Any) -> None:
+    FrozenClass = module.FrozenClass
 
     validate_frozen_impl(OmegaConf.structured(FrozenClass))
     validate_frozen_impl(OmegaConf.structured(FrozenClass()))


### PR DESCRIPTION
PR #558 introduced the `module` fixture into test_structured_config.py.
This PR converts a straggler function that slipped through in #558 to use the `module` fixture as well.
