### PR TITLE
Implement `ListConfig.__radd__`

### DIFF
--- a/news/849.feature
+++ b/news/849.feature
@@ -1,0 +1,1 @@
+Enable adding a listconfig to a list via the `ListConfig.__radd__` dunder method.

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -534,6 +534,13 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
         res.extend(other)
         return res
 
+    def __radd__(self, other: Union[List[Any], "ListConfig"]) -> "ListConfig":
+        # res is sharing this list's parent to allow interpolation to work as expected
+        res = ListConfig(parent=self._get_parent(), content=[])
+        res.extend(other)
+        res.extend(self)
+        return res
+
     def __iadd__(self, other: Iterable[Any]) -> "ListConfig":
         self.extend(other)
         return self


### PR DESCRIPTION
Closes #849.

### Before:
```python
>>> cfg = OmegaConf.create([1, 2])
>>> [3] + cfg
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: can only concatenate list (not "ListConfig") to list
```
### After:
```python
>>> cfg = OmegaConf.create([1, 2])
>>> [3] + cfg
[3, 1, 2]
```