### PR TITLE
add `str` test in test_dataclass_example.py:test_conversions

### DIFF
--- a/tests/examples/test_dataclass_example.py
+++ b/tests/examples/test_dataclass_example.py
@@ -73,6 +73,12 @@ def test_conversions() -> None:
         # ValidationError: "one" cannot be converted to an integer
         conf.num = "one"  # type: ignore
 
+    conf.description = "abc"  # ok, type matches
+    assert conf.description == "abc"
+    # ok, the int 20 is converted to the string "20"
+    conf.description = 20  # type: ignore
+    assert conf.description == "20"
+
     # booleans can take many forms
     for expected, values in {
         True: ["on", "yes", "true", True, "1"],


### PR DESCRIPTION
This PR adds a "string" case to the structured config convert-on-assignment test.
