### PR TITLE
Fix CI for black==22.1.0

### DIFF
--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -121,7 +121,7 @@ PARAMS_SINGLE_ELEMENT_NO_INTERPOLATION: List[Tuple[str, str, Any]] = [
     ("str_ws_1", "hello world", "hello world"),
     ("str_ws_2", "a b\tc  \t\t  d", "a b\tc  \t\t  d"),
     ("str_esc_ws_1", r"\ hello\ world\ ", " hello world "),
-    ("str_esc_ws_2", fr"\ \{TAB}\{TAB}", f" {TAB}{TAB}"),
+    ("str_esc_ws_2", rf"\ \{TAB}\{TAB}", f" {TAB}{TAB}"),
     ("str_esc_comma", r"hello\, world", "hello, world"),
     ("str_esc_colon", r"a\:b", "a:b"),
     ("str_esc_equal", r"a\=b", "a=b"),
@@ -186,9 +186,9 @@ PARAMS_SINGLE_ELEMENT_NO_INTERPOLATION: List[Tuple[str, str, Any]] = [
     ),
     (
         "dict_unquoted_key",
-        fr"{{a0-null-1-3.14-NaN- {TAB}-true-False-{UNQUOTED_SPECIAL}\(\)\[\]\{{\}}\:\=\ \{TAB}\,:0}}",
+        rf"{{a0-null-1-3.14-NaN- {TAB}-true-False-{UNQUOTED_SPECIAL}\(\)\[\]\{{\}}\:\=\ \{TAB}\,:0}}",
         {
-            fr"a0-null-1-3.14-NaN- {TAB}-true-False-{UNQUOTED_SPECIAL}()[]{{}}:= {TAB},": 0
+            rf"a0-null-1-3.14-NaN- {TAB}-true-False-{UNQUOTED_SPECIAL}()[]{{}}:= {TAB},": 0
         },
     ),
     (


### PR DESCRIPTION
Version 22.1.0 of the [black](https://github.com/psf/black) formatter
now [normalizes string prefix order](https://github.com/psf/black/pull/2297).

This PR updates our codebase so that CI will not fail with this new version of black.
