### PR TITLE
improve Enum-type test coverage

### DIFF
--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -24,7 +24,14 @@ from omegaconf.errors import InterpolationResolutionError
 from omegaconf.errors import InterpolationResolutionError as IRE
 from omegaconf.errors import InterpolationValidationError, ReadonlyConfigError
 from omegaconf.nodes import InterpolationResultNode
-from tests import MissingDict, MissingList, StructuredWithMissing, SubscriptedList, User
+from tests import (
+    Color,
+    MissingDict,
+    MissingList,
+    StructuredWithMissing,
+    SubscriptedList,
+    User,
+)
 from tests.interpolation import dereference_node
 
 # file deepcode ignore CopyPasteError:
@@ -133,6 +140,7 @@ def test_indirect_interpolation2() -> None:
         param({"a": "${b}", "b": True, "s": "foo_${b}"}, id="bool"),
         param({"a": "${b}", "b": 10, "s": "foo_${b}"}, id="int"),
         param({"a": "${b}", "b": 3.14, "s": "foo_${b}"}, id="float"),
+        param({"a": "${b}", "b": Color.RED, "s": "foo_${b}"}, id="enum"),
     ],
 )
 def test_type_inherit_type(cfg: Any) -> None:

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -410,7 +410,7 @@ def test_append_invalid_element_type(
             ListConfig(content=[], element_type=Color),
             "RED",
             Color.RED,
-            id="list:convert_str_to_float",
+            id="list:convert_str_to_enum",
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -489,6 +489,7 @@ def test_is_list_annotation(type_: Any, expected: Any) -> Any:
         param(10, Any, id="int"),
         param(10.0, Any, id="float"),
         param(True, Any, id="bool"),
+        param(Color.RED, Any, id="bytes"),
         param("bar", Any, id="str"),
         param(None, Any, id="NoneType"),
         param({}, Any, id="dict"),


### PR DESCRIPTION
This PR rounds out the tests for Enum types.
It also removes a bit of dead code (`Enum2`) from `tests/test_nodes.py`.
