### PR TITLE
Adds literal node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,4 @@ repos:
     hooks:
       - id: mypy
         args: [--strict]
-        additional_dependencies: ['pytest']
+        additional_dependencies: ['pytest', 'types-dataclasses']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
       - id: black
         language_version: python3.8

--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -14,6 +14,7 @@ from .nodes import (
     EnumNode,
     FloatNode,
     IntegerNode,
+    LiteralNode,
     StringNode,
     ValueNode,
 )
@@ -53,6 +54,7 @@ __all__ = [
     "StringNode",
     "BooleanNode",
     "EnumNode",
+    "LiteralNode",
     "FloatNode",
     "MISSING",
     "SI",

--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -15,6 +15,7 @@ from .nodes import (
     EnumNode,
     FloatNode,
     IntegerNode,
+    LiteralNode,
     StringNode,
     ValueNode,
 )
@@ -55,6 +56,7 @@ __all__ = [
     "BytesNode",
     "BooleanNode",
     "EnumNode",
+    "LiteralNode",
     "FloatNode",
     "MISSING",
     "SI",

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # pragma: no cover
 
 
 # Regexprs to match key paths like: a.b, a[b], ..a[c].d, etc.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -855,7 +855,7 @@ def type_str(t: Any, include_module_name: bool = False) -> str:
         if hasattr(t, "__name__"):
             name = str(t.__name__)
         else:
-            if hasattr(t, "__origin__") and t.__origin__ is not None:
+            if getattr(t, "__origin__", None) is not None:
                 name = type_str(t.__origin__)
             else:
                 name = str(t)

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -600,7 +600,7 @@ def is_tuple_annotation(type_: Any) -> bool:
 
 def is_literal_annotation(type_: Any) -> bool:
     origin = getattr(type_, "__origin__", None)
-    if sys.version_info >= (3, 8, 0):
+    if sys.version_info >= (3, 8):
         return origin is Literal  # pragma: no cover
     else:
         return (

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -12,7 +12,6 @@ from typing import (
     Dict,
     Iterator,
     List,
-    Literal,
     Optional,
     Tuple,
     Type,
@@ -43,6 +42,11 @@ try:
 
 except ImportError:  # pragma: no cover
     attr = None  # type: ignore # pragma: no cover
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 # Regexprs to match key paths like: a.b, a[b], ..a[c].d, etc.
@@ -831,6 +835,13 @@ def type_str(t: Any, include_module_name: bool = False) -> str:
         return "Any"
     if t is ...:
         return "..."
+    if (
+        isinstance(t, int)
+        or isinstance(t, str)
+        or isinstance(t, bytes)
+        or isinstance(t, Enum)
+    ):
+        return str(t)
 
     if sys.version_info < (3, 7, 0):  # pragma: no cover
         # Python 3.6

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -606,7 +606,9 @@ def is_literal_annotation(type_: Any) -> bool:
         return (
             origin is Literal
             or type_ is Literal
-            or ("typing_extensions.Literal" in str(type_) and not isinstance(type, str))
+            or (
+                "typing_extensions.Literal" in str(type_) and not isinstance(type_, str)
+            )
         )  # pragma: no cover
 
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -862,7 +862,7 @@ def type_str(t: Any, include_module_name: bool = False) -> str:
         if hasattr(t, "__name__"):
             name = str(t.__name__)
         else:
-            if hasattr(t, "__origin__") and t.__origin__ is not None:
+            if getattr(t, "__origin__", None) is not None:
                 name = type_str(t.__origin__)
             else:
                 name = str(t)

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -47,6 +47,8 @@ if sys.version_info >= (3, 8):
     from typing import Literal  # pragma: no cover
 else:
     from typing_extensions import Literal  # pragma: no cover
+if sys.version_info < (3, 7):
+    from typing_extensions import _Literal  # type: ignore # pragma: no cover
 
 
 # Regexprs to match key paths like: a.b, a[b], ..a[c].d, etc.
@@ -600,16 +602,11 @@ def is_tuple_annotation(type_: Any) -> bool:
 
 def is_literal_annotation(type_: Any) -> bool:
     origin = getattr(type_, "__origin__", None)
-    if sys.version_info >= (3, 8):
-        return origin is Literal  # pragma: no cover
-    else:
-        return (
-            origin is Literal
-            or type_ is Literal
-            or (
-                "typing_extensions.Literal" in str(type_) and not isinstance(type_, str)
-            )
-        )  # pragma: no cover
+    # For python 3.6 and earllier typing_extensions.Literal does not have an origin attribute, and
+    # Literal is an instance of an internal _Literal class that we can check against.
+    if sys.version_info < (3, 7):
+        return type(type_) is _Literal  # pragma: no cover
+    return origin is Literal  # pragma: no cover
 
 
 def is_dict_subclass(type_: Any) -> bool:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     attr = None  # type: ignore # pragma: no cover
 
 if sys.version_info >= (3, 8):
-    from typing import Literal
+    from typing import Literal  # pragma: no cover
 else:
     from typing_extensions import Literal  # pragma: no cover
 
@@ -600,10 +600,14 @@ def is_tuple_annotation(type_: Any) -> bool:
 
 def is_literal_annotation(type_: Any) -> bool:
     origin = getattr(type_, "__origin__", None)
-    if sys.version_info < (3, 7, 0):
-        return origin is Literal or type_ is Literal  # pragma: no cover
-    else:
+    if sys.version_info >= (3, 8, 0):
         return origin is Literal  # pragma: no cover
+    else:
+        return (
+            origin is Literal
+            or type_ is Literal
+            or ("typing_extensions.Literal" in str(type_) and not isinstance(type, str))
+        )  # pragma: no cover
 
 
 def is_dict_subclass(type_: Any) -> bool:
@@ -848,14 +852,15 @@ def type_str(t: Any, include_module_name: bool = False) -> str:
         or isinstance(t, bytes)
         or isinstance(t, Enum)
     ):
-        return str(t)
+        # only occurs when using typing.Literal after 3.8
+        return str(t)  # pragma: no cover
 
     if sys.version_info < (3, 7, 0):  # pragma: no cover
         # Python 3.6
         if hasattr(t, "__name__"):
             name = str(t.__name__)
         else:
-            if t.__origin__ is not None:
+            if hasattr(t, "__origin__") and t.__origin__ is not None:
                 name = type_str(t.__origin__)
             else:
                 name = str(t)

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -12,6 +12,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Literal,
     Optional,
     Tuple,
     Type,
@@ -591,6 +592,14 @@ def is_tuple_annotation(type_: Any) -> bool:
         return origin is Tuple or type_ is Tuple  # pragma: no cover
     else:
         return origin is tuple  # pragma: no cover
+
+
+def is_literal_annotation(type_: Any) -> bool:
+    origin = getattr(type_, "__origin__", None)
+    if sys.version_info < (3, 7, 0):
+        return origin is Literal or type_ is Literal  # pragma: no cover
+    else:
+        return origin is Literal  # pragma: no cover
 
 
 def is_dict_subclass(type_: Any) -> bool:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -12,7 +12,6 @@ from typing import (
     Dict,
     Iterator,
     List,
-    Literal,
     Optional,
     Tuple,
     Type,
@@ -43,6 +42,11 @@ try:
 
 except ImportError:  # pragma: no cover
     attr = None  # type: ignore # pragma: no cover
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 # Regexprs to match key paths like: a.b, a[b], ..a[c].d, etc.
@@ -838,6 +842,13 @@ def type_str(t: Any, include_module_name: bool = False) -> str:
         return "Any"
     if t is ...:
         return "..."
+    if (
+        isinstance(t, int)
+        or isinstance(t, str)
+        or isinstance(t, bytes)
+        or isinstance(t, Enum)
+    ):
+        return str(t)
 
     if sys.version_info < (3, 7, 0):  # pragma: no cover
         # Python 3.6

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -429,14 +429,12 @@ class LiteralNode(ValueNode):
             ),
         )
 
-    def _validate_and_convert_impl(self, value: Any) -> Enum:
+    def _validate_and_convert_impl(self, value: Any) -> Any:
         return self.validate_and_convert_to_literal(
             enum_type=self.literal_type, value=value
         )
 
-    def validate_and_convert_to_literal(
-        self, enum_type: Type[Enum], value: Any
-    ) -> Enum:
+    def validate_and_convert_to_literal(self, enum_type: Type[Enum], value: Any) -> Any:
         if value not in self.fields:
             raise ValidationError(
                 f"Value $VALUE ($VALUE_TYPE) is not a valid input for {enum_type}"

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -3,7 +3,7 @@ import math
 import sys
 from abc import abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, Optional, Type, Union
 
 from omegaconf._utils import (
     ValueKind,
@@ -454,7 +454,10 @@ class LiteralNode(ValueNode):
                 f"LiteralNode can only operate on Literal annotation ({literal_type})"
             )
         self.literal_type = literal_type
-        self.fields: List[Any] = list(self.literal_type.__args__)
+        if hasattr(self.literal_type, "__args__"):
+            self.fields = list(self.literal_type.__args__)  # pragma: no cover
+        elif hasattr(self.literal_type, "__values__"):  # pragma: no cover
+            self.fields = list(self.literal_type.__values__)  # pragma: no cover
         super().__init__(
             parent=parent,
             value=value,

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -416,10 +416,18 @@ class LiteralNode(ValueNode):
                 f"LiteralNode can only operate on Literal annotation ({literal_type})"
             )
         self.literal_type = literal_type
-        if hasattr(self.literal_type, "__args__"):
-            self.fields = list(self.literal_type.__args__)  # pragma: no cover
+        if hasattr(self.literal_type, "__args__"):  # pragma: no cover
+            # python 3.7 and above
+            args = self.literal_type.__args__
+            self.fields = list(args) if args is not None else []
         elif hasattr(self.literal_type, "__values__"):  # pragma: no cover
-            self.fields = list(self.literal_type.__values__)  # pragma: no cover
+            # python 3.6 and below
+            values = self.literal_type.__values__
+            self.fields = list(values) if values is not None else []
+        else:  # pragma: no cover
+            raise ValidationError(
+                f"literal_type={literal_type} is a literal but has no __args__ or __values__"
+            )
         super().__init__(
             parent=parent,
             value=value,

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -454,10 +454,18 @@ class LiteralNode(ValueNode):
                 f"LiteralNode can only operate on Literal annotation ({literal_type})"
             )
         self.literal_type = literal_type
-        if hasattr(self.literal_type, "__args__"):
-            self.fields = list(self.literal_type.__args__)  # pragma: no cover
+        if hasattr(self.literal_type, "__args__"):  # pragma: no cover
+            # python 3.7 and above
+            args = self.literal_type.__args__
+            self.fields = list(args) if args is not None else []
         elif hasattr(self.literal_type, "__values__"):  # pragma: no cover
-            self.fields = list(self.literal_type.__values__)  # pragma: no cover
+            # python 3.6 and below
+            values = self.literal_type.__values__
+            self.fields = list(values) if values is not None else []
+        else:  # pragma: no cover
+            raise ValidationError(
+                f"literal_type={literal_type} is a literal but has no __args__ or __values__"
+            )
         super().__init__(
             parent=parent,
             value=value,

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -3,13 +3,14 @@ import math
 import sys
 from abc import abstractmethod
 from enum import Enum
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from omegaconf._utils import (
     ValueKind,
     _is_interpolation,
     get_type_of,
     get_value_kind,
+    is_literal_annotation,
     is_primitive_container,
     type_str,
 )
@@ -396,6 +397,61 @@ class EnumNode(ValueNode):  # lgtm [py/missing-equals] : Intentional.
 
     def __deepcopy__(self, memo: Dict[int, Any]) -> "EnumNode":
         res = EnumNode(enum_type=self.enum_type)
+        self._deepcopy_impl(res, memo)
+        return res
+
+
+class LiteralNode(ValueNode):
+    def __init__(
+        self,
+        literal_type: Any,  # cannot Type[Literal] because Literal requires an argument
+        value: Optional[Union[Enum, str, int, bool]] = None,
+        key: Any = None,
+        parent: Optional[Container] = None,
+        is_optional: bool = True,
+        flags: Optional[Dict[str, bool]] = None,
+    ):
+        if not is_literal_annotation(literal_type):
+            raise ValidationError(
+                f"LiteralNode can only operate on Literal annotation ({literal_type})"
+            )
+        self.literal_type = literal_type
+        self.fields: List[Any] = list(self.literal_type.__args__)
+        super().__init__(
+            parent=parent,
+            value=value,
+            metadata=Metadata(
+                key=key,
+                optional=is_optional,
+                ref_type=literal_type,
+                object_type=literal_type,
+                flags=flags,
+            ),
+        )
+
+    def _validate_and_convert_impl(self, value: Any) -> Enum:
+        return self.validate_and_convert_to_literal(
+            enum_type=self.literal_type, value=value
+        )
+
+    def validate_and_convert_to_literal(
+        self, enum_type: Type[Enum], value: Any
+    ) -> Enum:
+        if value not in self.fields:
+            raise ValidationError(
+                f"Value $VALUE ($VALUE_TYPE) is not a valid input for {enum_type}"
+            )
+        index = self.fields.index(value)
+        if isinstance(value, type(self.fields[index])):
+            raise ValidationError(
+                f"Value $VALUE ($VALUE_TYPE) is not a valid input for {enum_type} because "
+                f"type(value)={type(value)} but the matching literal value's type={type(self.fields[index])}"
+            )
+
+        return value
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "LiteralNode":
+        res = LiteralNode(literal_type=self.literal_type)
         self._deepcopy_impl(res, memo)
         return res
 

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -3,7 +3,7 @@ import math
 import sys
 from abc import abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, Optional, Type, Union
 
 from omegaconf._utils import (
     ValueKind,
@@ -416,7 +416,10 @@ class LiteralNode(ValueNode):
                 f"LiteralNode can only operate on Literal annotation ({literal_type})"
             )
         self.literal_type = literal_type
-        self.fields: List[Any] = list(self.literal_type.__args__)
+        if hasattr(self.literal_type, "__args__"):
+            self.fields = list(self.literal_type.__args__)  # pragma: no cover
+        elif hasattr(self.literal_type, "__values__"):  # pragma: no cover
+            self.fields = list(self.literal_type.__values__)  # pragma: no cover
         super().__init__(
             parent=parent,
             value=value,

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -467,14 +467,12 @@ class LiteralNode(ValueNode):
             ),
         )
 
-    def _validate_and_convert_impl(self, value: Any) -> Enum:
+    def _validate_and_convert_impl(self, value: Any) -> Any:
         return self.validate_and_convert_to_literal(
             enum_type=self.literal_type, value=value
         )
 
-    def validate_and_convert_to_literal(
-        self, enum_type: Type[Enum], value: Any
-    ) -> Enum:
+    def validate_and_convert_to_literal(self, enum_type: Type[Enum], value: Any) -> Any:
         if value not in self.fields:
             raise ValidationError(
                 f"Value $VALUE ($VALUE_TYPE) is not a valid input for {enum_type}"

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -442,7 +442,7 @@ class LiteralNode(ValueNode):
                 f"Value $VALUE ($VALUE_TYPE) is not a valid input for {enum_type}"
             )
         index = self.fields.index(value)
-        if isinstance(value, type(self.fields[index])):
+        if not isinstance(value, type(self.fields[index])):
             raise ValidationError(
                 f"Value $VALUE ($VALUE_TYPE) is not a valid input for {enum_type} because "
                 f"type(value)={type(value)} but the matching literal value's type={type(self.fields[index])}"

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -480,7 +480,7 @@ class LiteralNode(ValueNode):
                 f"Value $VALUE ($VALUE_TYPE) is not a valid input for {enum_type}"
             )
         index = self.fields.index(value)
-        if isinstance(value, type(self.fields[index])):
+        if not isinstance(value, type(self.fields[index])):
             raise ValidationError(
                 f"Value $VALUE ($VALUE_TYPE) is not a valid input for {enum_type} because "
                 f"type(value)={type(value)} but the matching literal value's type={type(self.fields[index])}"

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -43,6 +43,7 @@ from ._utils import (
     is_dict_annotation,
     is_int,
     is_list_annotation,
+    is_literal_annotation,
     is_primitive_container,
     is_primitive_dict,
     is_primitive_list,
@@ -66,6 +67,7 @@ from .nodes import (
     EnumNode,
     FloatNode,
     IntegerNode,
+    LiteralNode,
     StringNode,
     ValueNode,
 )
@@ -1046,6 +1048,14 @@ def _node_wrap(
         )
     elif type_ == Any or type_ is None:
         node = AnyNode(value=value, key=key, parent=parent)
+    elif is_literal_annotation(type_):
+        node = LiteralNode(
+            literal_type=type_,
+            value=value,
+            key=key,
+            parent=parent,
+            is_optional=is_optional,
+        )
     elif issubclass(type_, Enum):
         node = EnumNode(
             enum_type=type_,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -43,6 +43,7 @@ from ._utils import (
     is_dict_annotation,
     is_int,
     is_list_annotation,
+    is_literal_annotation,
     is_primitive_container,
     is_primitive_dict,
     is_primitive_list,
@@ -67,6 +68,7 @@ from .nodes import (
     EnumNode,
     FloatNode,
     IntegerNode,
+    LiteralNode,
     StringNode,
     ValueNode,
 )
@@ -1047,6 +1049,14 @@ def _node_wrap(
         )
     elif type_ == Any or type_ is None:
         node = AnyNode(value=value, key=key, parent=parent)
+    elif is_literal_annotation(type_):
+        node = LiteralNode(
+            literal_type=type_,
+            value=value,
+            key=key,
+            parent=parent,
+            is_optional=is_optional,
+        )
     elif issubclass(type_, Enum):
         node = EnumNode(
             enum_type=type_,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,4 +2,4 @@ antlr4-python3-runtime==4.8
 PyYAML>=5.1.0
 # Use dataclasses backport for Python 3.6.
 dataclasses;python_version=='3.6'
-typing_extensionsl;python_version<='3.7'
+typing_extensions;python_version<='3.7'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,3 +2,4 @@ antlr4-python3-runtime==4.8
 PyYAML>=5.1.0
 # Use dataclasses backport for Python 3.6.
 dataclasses;python_version=='3.6'
+typing_extensionsl;python_version<='3.7'

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import attr
 from pytest import importorskip
@@ -167,6 +167,23 @@ class EnumConfig:
 
     # interpolation, will inherit the type and value of `with_default'
     interpolation: Color = II("with_default")
+
+
+@attr.s(auto_attribs=True)
+class LiteralConfig:
+    # with default value
+    with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+
+    # default is None
+    null_default: Optional[Literal["foo", "bar", True, b"baz", 5, Color.GREEN]] = None
+
+    # explicit no default
+    mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+    # interpolation, will inherit the type and value of `with_default'
+    interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+        "with_default"
+    )
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -186,21 +186,47 @@ class EnumConfig:
     interpolation: Color = II("with_default")
 
 
-@attr.s(auto_attribs=True)
-class LiteralConfig:
-    # with default value
-    with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+if sys.version_info >= (3, 7):  # pragma: no cover
 
-    # default is None
-    null_default: Optional[Literal["foo", "bar", True, b"baz", 5, Color.GREEN]] = None
+    @attr.s(auto_attribs=True)
+    class LiteralConfig:
+        # with default value
+        with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
 
-    # explicit no default
-    mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+        # default is None
+        null_default: Optional[
+            Literal["foo", "bar", True, b"baz", 5, Color.GREEN]
+        ] = None
 
-    # interpolation, will inherit the type and value of `with_default'
-    interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
-        "with_default"
-    )
+        # explicit no default
+        mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+        # interpolation, will inherit the type and value of `with_default'
+        interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+            "with_default"
+        )
+
+
+else:  # pragma: no cover
+    # bare literals throw errors for python 3.7+. They're against spec for python 3.6 and earlier,
+    # but we should test that they fail to validate anyway.
+    @attr.s(auto_attribs=True)
+    class LiteralConfig:
+        # with default value
+        with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+
+        # default is None
+        null_default: Optional[
+            Literal["foo", "bar", True, b"baz", 5, Color.GREEN]
+        ] = None
+        # explicit no default
+        mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+        # interpolation, will inherit the type and value of `with_default'
+        interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+            "with_default"
+        )
+        no_args: Optional[Literal] = None  # type: ignore
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import attr
 from pytest import importorskip
@@ -8,7 +8,9 @@ from omegaconf import II, MISSING, SI
 from tests import Color
 
 if sys.version_info >= (3, 8):  # pragma: no cover
-    from typing import TypedDict
+    from typing import Literal, TypedDict
+else:
+    from typing_extensions import Literal
 
 # attr is a dependency of pytest which means it's always available when testing with pytest.
 importorskip("attr")

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -206,7 +206,6 @@ if sys.version_info >= (3, 7):  # pragma: no cover
             "with_default"
         )
 
-
 else:  # pragma: no cover
     # bare literals throw errors for python 3.7+. They're against spec for python 3.6 and earlier,
     # but we should test that they fail to validate anyway.

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import attr
 from pytest import importorskip
@@ -182,6 +182,23 @@ class EnumConfig:
 
     # interpolation, will inherit the type and value of `with_default'
     interpolation: Color = II("with_default")
+
+
+@attr.s(auto_attribs=True)
+class LiteralConfig:
+    # with default value
+    with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+
+    # default is None
+    null_default: Optional[Literal["foo", "bar", True, b"baz", 5, Color.GREEN]] = None
+
+    # explicit no default
+    mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+    # interpolation, will inherit the type and value of `with_default'
+    interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+        "with_default"
+    )
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -171,21 +171,47 @@ class EnumConfig:
     interpolation: Color = II("with_default")
 
 
-@attr.s(auto_attribs=True)
-class LiteralConfig:
-    # with default value
-    with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+if sys.version_info >= (3, 7):  # pragma: no cover
 
-    # default is None
-    null_default: Optional[Literal["foo", "bar", True, b"baz", 5, Color.GREEN]] = None
+    @attr.s(auto_attribs=True)
+    class LiteralConfig:
+        # with default value
+        with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
 
-    # explicit no default
-    mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+        # default is None
+        null_default: Optional[
+            Literal["foo", "bar", True, b"baz", 5, Color.GREEN]
+        ] = None
 
-    # interpolation, will inherit the type and value of `with_default'
-    interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
-        "with_default"
-    )
+        # explicit no default
+        mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+        # interpolation, will inherit the type and value of `with_default'
+        interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+            "with_default"
+        )
+
+
+else:  # pragma: no cover
+    # bare literals throw errors for python 3.7+. They're against spec for python 3.6 and earlier,
+    # but we should test that they fail to validate anyway.
+    @attr.s(auto_attribs=True)
+    class LiteralConfig:
+        # with default value
+        with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+
+        # default is None
+        null_default: Optional[
+            Literal["foo", "bar", True, b"baz", 5, Color.GREEN]
+        ] = None
+        # explicit no default
+        mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+        # interpolation, will inherit the type and value of `with_default'
+        interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+            "with_default"
+        )
+        no_args: Optional[Literal] = None  # type: ignore
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -1,7 +1,7 @@
 import dataclasses
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from pytest import importorskip
 
@@ -168,6 +168,23 @@ class EnumConfig:
 
     # interpolation, will inherit the type and value of `with_default'
     interpolation: Color = II("with_default")
+
+
+@dataclass
+class LiteralConfig:
+    # with default value
+    with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+
+    # default is None
+    null_default: Optional[Literal["foo", "bar", True, b"baz", 5, Color.GREEN]] = None
+
+    # explicit no default
+    mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+    # interpolation, will inherit the type and value of `with_default'
+    interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+        "with_default"
+    )
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -1,7 +1,7 @@
 import dataclasses
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from pytest import importorskip
 
@@ -183,6 +183,23 @@ class EnumConfig:
 
     # interpolation, will inherit the type and value of `with_default'
     interpolation: Color = II("with_default")
+
+
+@dataclass
+class LiteralConfig:
+    # with default value
+    with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+
+    # default is None
+    null_default: Optional[Literal["foo", "bar", True, b"baz", 5, Color.GREEN]] = None
+
+    # explicit no default
+    mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+    # interpolation, will inherit the type and value of `with_default'
+    interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+        "with_default"
+    )
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -207,7 +207,6 @@ if sys.version_info >= (3, 7):  # pragma: no cover
             "with_default"
         )
 
-
 else:  # pragma: no cover
     # bare literals throw errors for python 3.7+. They're against spec for python 3.6 and earlier,
     # but we should test that they fail to validate anyway.

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -172,21 +172,47 @@ class EnumConfig:
     interpolation: Color = II("with_default")
 
 
-@dataclass
-class LiteralConfig:
-    # with default value
-    with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+if sys.version_info >= (3, 7):  # pragma: no cover
 
-    # default is None
-    null_default: Optional[Literal["foo", "bar", True, b"baz", 5, Color.GREEN]] = None
+    @dataclass
+    class LiteralConfig:
+        # with default value
+        with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
 
-    # explicit no default
-    mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+        # default is None
+        null_default: Optional[
+            Literal["foo", "bar", True, b"baz", 5, Color.GREEN]
+        ] = None
 
-    # interpolation, will inherit the type and value of `with_default'
-    interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
-        "with_default"
-    )
+        # explicit no default
+        mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+        # interpolation, will inherit the type and value of `with_default'
+        interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+            "with_default"
+        )
+
+
+else:  # pragma: no cover
+    # bare literals throw errors for python 3.7+. They're against spec for python 3.6 and earlier,
+    # but we should test that they fail to validate anyway.
+    @dataclass
+    class LiteralConfig:
+        # with default value
+        with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+
+        # default is None
+        null_default: Optional[
+            Literal["foo", "bar", True, b"baz", 5, Color.GREEN]
+        ] = None
+        # explicit no default
+        mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+        # interpolation, will inherit the type and value of `with_default'
+        interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+            "with_default"
+        )
+        no_args: Optional[Literal] = None  # type: ignore
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -187,21 +187,47 @@ class EnumConfig:
     interpolation: Color = II("with_default")
 
 
-@dataclass
-class LiteralConfig:
-    # with default value
-    with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+if sys.version_info >= (3, 7):  # pragma: no cover
 
-    # default is None
-    null_default: Optional[Literal["foo", "bar", True, b"baz", 5, Color.GREEN]] = None
+    @dataclass
+    class LiteralConfig:
+        # with default value
+        with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
 
-    # explicit no default
-    mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+        # default is None
+        null_default: Optional[
+            Literal["foo", "bar", True, b"baz", 5, Color.GREEN]
+        ] = None
 
-    # interpolation, will inherit the type and value of `with_default'
-    interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
-        "with_default"
-    )
+        # explicit no default
+        mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+        # interpolation, will inherit the type and value of `with_default'
+        interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+            "with_default"
+        )
+
+
+else:  # pragma: no cover
+    # bare literals throw errors for python 3.7+. They're against spec for python 3.6 and earlier,
+    # but we should test that they fail to validate anyway.
+    @dataclass
+    class LiteralConfig:
+        # with default value
+        with_default: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = "foo"
+
+        # default is None
+        null_default: Optional[
+            Literal["foo", "bar", True, b"baz", 5, Color.GREEN]
+        ] = None
+        # explicit no default
+        mandatory_missing: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = MISSING
+
+        # interpolation, will inherit the type and value of `with_default'
+        interpolation: Literal["foo", "bar", True, b"baz", 5, Color.GREEN] = II(
+            "with_default"
+        )
+        no_args: Optional[Literal] = None  # type: ignore
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -1,7 +1,7 @@
 import dataclasses
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pytest import importorskip
 
@@ -9,7 +9,9 @@ from omegaconf import II, MISSING, SI
 from tests import Color
 
 if sys.version_info >= (3, 8):  # pragma: no cover
-    from typing import TypedDict
+    from typing import Literal, TypedDict
+else:
+    from typing_extensions import Literal
 
 # skip test if dataclasses are not available
 importorskip("dataclasses")

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -310,6 +310,10 @@ class TestConfigs:
                 with raises(ValidationError):
                     conf.mandatory_missing = illegal_value
 
+                if hasattr(conf, "no_args"):
+                    with raises(ValidationError):
+                        conf.no_args = illegal_value
+
             # Test assignment of legal values
             for legal_value in assignment_data.legal:
                 expected_data = legal_value

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -317,6 +317,10 @@ class TestConfigs:
                 with raises(ValidationError):
                     conf.mandatory_missing = illegal_value
 
+                if hasattr(conf, "no_args"):
+                    with raises(ValidationError):
+                        conf.no_args = illegal_value
+
             # Test assignment of legal values
             for legal_value in assignment_data.legal:
                 expected_data = legal_value

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -49,6 +49,11 @@ class EnumConfigAssignments:
     illegal = ["foo", True, False, 4, 1.0]
 
 
+class LiteralConfigAssignments:
+    legal = ["foo", "bar", True, b"baz", 5, Color.GREEN]
+    illegal = ["fuh", False, 4, 1.0, b"feh", Color.RED]
+
+
 class IntegersConfigAssignments:
     legal = [("10", 10), ("-10", -10), 100, 0, 1, 1]
     illegal = ["foo", 1.0, float("inf"), float("nan"), Color.BLUE]
@@ -259,12 +264,14 @@ class TestConfigs:
             ("FloatConfig", FloatConfigAssignments, {}),
             ("StringConfig", StringConfigAssignments, {}),
             ("EnumConfig", EnumConfigAssignments, {}),
+            ("LiteralConfig", LiteralConfigAssignments, {}),
             # Use instance to build config
             ("BoolConfig", BoolConfigAssignments, {"with_default": False}),
             ("IntegersConfig", IntegersConfigAssignments, {"with_default": 42}),
             ("FloatConfig", FloatConfigAssignments, {"with_default": 42.0}),
             ("StringConfig", StringConfigAssignments, {"with_default": "fooooooo"}),
             ("EnumConfig", EnumConfigAssignments, {"with_default": Color.BLUE}),
+            ("LiteralConfig", LiteralConfigAssignments, {"with_default": "foo"}),
             ("AnyTypeConfig", AnyTypeConfigAssignments, {}),
         ],
     )

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -49,6 +49,11 @@ class EnumConfigAssignments:
     illegal = ["foo", True, b"RED", False, 4, 1.0]
 
 
+class LiteralConfigAssignments:
+    legal = ["foo", "bar", True, b"baz", 5, Color.GREEN]
+    illegal = ["fuh", False, 4, 1.0, b"feh", Color.RED]
+
+
 class IntegersConfigAssignments:
     legal = [("10", 10), ("-10", -10), 100, 0, 1]
     illegal = ["foo", 1.0, float("inf"), b"123", float("nan"), Color.BLUE, True]
@@ -265,6 +270,7 @@ class TestConfigs:
             ("BytesConfig", BytesConfigAssignments, {}),
             ("StringConfig", StringConfigAssignments, {}),
             ("EnumConfig", EnumConfigAssignments, {}),
+            ("LiteralConfig", LiteralConfigAssignments, {}),
             # Use instance to build config
             ("BoolConfig", BoolConfigAssignments, {"with_default": False}),
             ("IntegersConfig", IntegersConfigAssignments, {"with_default": 42}),
@@ -272,6 +278,7 @@ class TestConfigs:
             ("BytesConfig", BytesConfigAssignments, {"with_default": b"bin"}),
             ("StringConfig", StringConfigAssignments, {"with_default": "fooooooo"}),
             ("EnumConfig", EnumConfigAssignments, {"with_default": Color.BLUE}),
+            ("LiteralConfig", LiteralConfigAssignments, {"with_default": "foo"}),
             ("AnyTypeConfig", AnyTypeConfigAssignments, {}),
         ],
     )

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,5 +1,6 @@
 import copy
 import re
+import sys
 from typing import Any, Optional
 
 from pytest import mark, raises, warns
@@ -12,6 +13,7 @@ from omegaconf import (
     FloatNode,
     IntegerNode,
     ListConfig,
+    LiteralNode,
     OmegaConf,
     StringNode,
     ValidationError,
@@ -19,6 +21,11 @@ from omegaconf import (
 )
 from omegaconf._utils import _is_optional
 from tests import Color, Group
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 SKIP = object()
 
@@ -70,6 +77,16 @@ def verify(
             ),
             [Color.RED],
         ),
+        # LiteralNode
+        (
+            lambda value, is_optional, key=None: LiteralNode(
+                literal_type=Literal["foo", 5, b"bar", True, Color.GREEN],
+                value=value,
+                is_optional=is_optional,
+                key=key,
+            ),
+            ["foo", 5, b"bar", True, Color.GREEN],
+        ),
         # DictConfig
         (
             lambda value, is_optional, key=None: DictConfig(
@@ -99,6 +116,7 @@ def verify(
         "IntegerNode",
         "StringNode",
         "EnumNode",
+        "LiteralNode",
         "DictConfig",
         "ListConfig",
         "dataclass",

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,5 +1,6 @@
 import copy
 import re
+import sys
 from typing import Any, Optional
 
 from pytest import mark, raises, warns
@@ -11,6 +12,7 @@ from omegaconf import (
     FloatNode,
     IntegerNode,
     ListConfig,
+    LiteralNode,
     OmegaConf,
     StringNode,
     ValidationError,
@@ -18,6 +20,11 @@ from omegaconf import (
 )
 from omegaconf._utils import _is_optional
 from tests import Color, Group
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 SKIP = object()
 
@@ -68,6 +75,16 @@ def verify(
             ),
             [Color.RED],
         ),
+        # LiteralNode
+        (
+            lambda value, is_optional, key=None: LiteralNode(
+                literal_type=Literal["foo", 5, b"bar", True, Color.GREEN],
+                value=value,
+                is_optional=is_optional,
+                key=key,
+            ),
+            ["foo", 5, b"bar", True, Color.GREEN],
+        ),
         # DictConfig
         (
             lambda value, is_optional, key=None: DictConfig(
@@ -96,6 +113,7 @@ def verify(
         "IntegerNode",
         "StringNode",
         "EnumNode",
+        "LiteralNode",
         "DictConfig",
         "ListConfig",
         "dataclass",

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,6 +1,7 @@
 import copy
 import functools
 import re
+import sys
 from enum import Enum
 from functools import partial
 from typing import Any, Dict, Tuple, Type
@@ -16,6 +17,7 @@ from omegaconf import (
     FloatNode,
     IntegerNode,
     ListConfig,
+    LiteralNode,
     Node,
     OmegaConf,
     StringNode,
@@ -29,6 +31,11 @@ from omegaconf.errors import (
 )
 from omegaconf.nodes import InterpolationResultNode
 from tests import Color, Enum1, IllegalType, User
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 # testing valid conversions
@@ -156,6 +163,25 @@ def test_valid_inputs(type_: type, input_: Any, output_: Any) -> None:
         (partial(EnumNode, Color), {"foo": "bar"}),
         (partial(EnumNode, Color), ListConfig([1, 2])),
         (partial(EnumNode, Color), DictConfig({"foo": "bar"})),
+        (partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]), "baz"),
+        (partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]), 4),
+        (partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]), Color.RED),
+        (partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]), False),
+        (partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]), b"bez"),
+        (partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]), 1.0),
+        (partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]), [1, 2]),
+        (
+            partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]),
+            {"foo": "bar"},
+        ),
+        (
+            partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]),
+            ListConfig([1, 2]),
+        ),
+        (
+            partial(LiteralNode, Literal["foo", b"bar", 5, Color.GREEN, True]),
+            DictConfig({"foo": "bar"}),
+        ),
     ],
 )
 def test_invalid_inputs(type_: type, input_: Any) -> None:
@@ -384,6 +410,13 @@ def test_legal_assignment(
                 type_(value)
 
 
+def test_literal_node_bad_literal_type() -> None:
+    with raises(ValidationError):
+        LiteralNode(literal_type=5, value=5)
+    with raises(ValidationError):
+        LiteralNode(literal_type=int, value=5)
+
+
 @mark.parametrize(
     "node,value",
     [
@@ -449,6 +482,7 @@ class DummyEnum(Enum):
         (float, float, 3.1415, FloatNode),
         (bool, bool, True, BooleanNode),
         (str, str, "foo", StringNode),
+        (Literal["foo"], Literal["foo"], "foo", LiteralNode),
     ],
 )
 def test_node_wrap(
@@ -552,6 +586,18 @@ def test_deepcopy(obj: Any) -> None:
             True,
         ),
         (EnumNode(enum_type=Enum1, value=Enum1.BAR), Enum1.BAR, True),
+        (LiteralNode(literal_type=Literal["foo"], value="foo"), "foo", True),
+        (
+            LiteralNode(literal_type=Literal["foo"], value="foo"),
+            LiteralNode(literal_type=Literal["foo"], value="foo"),
+            True,
+        ),
+        (
+            LiteralNode(literal_type=Literal["foo"], value="foo"),
+            StringNode(value="foo"),
+            True,
+        ),
+        (LiteralNode(literal_type=Literal["foo"], value="foo"), 5, False),
         (InterpolationResultNode("foo"), "foo", True),
         (InterpolationResultNode("${foo}"), "${foo}", True),
         (InterpolationResultNode("${foo"), "${foo", True),
@@ -648,6 +694,9 @@ def test_dereference_missing() -> None:
         BytesNode,
         lambda val, is_optional: EnumNode(
             enum_type=Color, value=val, is_optional=is_optional
+        ),
+        lambda val, is_optional: LiteralNode(
+            literal_type=Literal["foo"], value=val, is_optional=is_optional
         ),
     ],
 )

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from typing import Any
 
 from pytest import mark, param, raises, warns
@@ -23,7 +24,13 @@ from omegaconf.errors import (
     InterpolationToMissingValueError,
     UnsupportedInterpolationType,
 )
+from omegaconf.nodes import LiteralNode
 from tests import Color, ConcretePlugin, IllegalType, StructuredWithMissing
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @mark.parametrize(
@@ -249,6 +256,13 @@ def test_coverage_for_deprecated_OmegaConf_is_optional() -> None:
             )
         ),
         (
+            lambda none: LiteralNode(
+                literal_type=Literal["foo"],
+                value="foo" if not none else None,
+                is_optional=True,
+            )
+        ),
+        (
             lambda none: ListConfig(
                 content=[1, 2, 3] if not none else None, is_optional=True
             )
@@ -336,6 +350,13 @@ def test_is_none_invalid_node() -> None:
             )
         ),
         (
+            lambda inter: LiteralNode(
+                literal_type=Literal["foo"],
+                value="foo" if inter is None else inter,
+                is_optional=True,
+            )
+        ),
+        (
             lambda inter: ListConfig(
                 content=[1, 2, 3] if inter is None else inter, is_optional=True
             )
@@ -360,6 +381,7 @@ def test_is_none_invalid_node() -> None:
         "BooleanNode",
         "BytesNode",
         "EnumNode",
+        "LiteralNode",
         "ListConfig",
         "DictConfig",
         "ConcretePlugin",

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from typing import Any
 
 from pytest import mark, param, raises, warns
@@ -22,7 +23,13 @@ from omegaconf.errors import (
     InterpolationToMissingValueError,
     UnsupportedInterpolationType,
 )
+from omegaconf.nodes import LiteralNode
 from tests import Color, ConcretePlugin, IllegalType, StructuredWithMissing
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @mark.parametrize(
@@ -247,6 +254,13 @@ def test_coverage_for_deprecated_OmegaConf_is_optional() -> None:
             )
         ),
         (
+            lambda none: LiteralNode(
+                literal_type=Literal["foo"],
+                value="foo" if not none else None,
+                is_optional=True,
+            )
+        ),
+        (
             lambda none: ListConfig(
                 content=[1, 2, 3] if not none else None, is_optional=True
             )
@@ -329,6 +343,13 @@ def test_is_none_invalid_node() -> None:
             )
         ),
         (
+            lambda inter: LiteralNode(
+                literal_type=Literal["foo"],
+                value="foo" if inter is None else inter,
+                is_optional=True,
+            )
+        ),
+        (
             lambda inter: ListConfig(
                 content=[1, 2, 3] if inter is None else inter, is_optional=True
             )
@@ -352,6 +373,7 @@ def test_is_none_invalid_node() -> None:
         "FloatNode",
         "BooleanNode",
         "EnumNode",
+        "LiteralNode",
         "ListConfig",
         "DictConfig",
         "ConcretePlugin",

--- a/tests/test_pydev_resolver_plugin.py
+++ b/tests/test_pydev_resolver_plugin.py
@@ -1,4 +1,5 @@
 import builtins
+import sys
 from typing import Any
 
 from pytest import fixture, mark, param
@@ -19,11 +20,17 @@ from omegaconf import (
     ValueNode,
 )
 from omegaconf._utils import type_str
+from omegaconf.nodes import LiteralNode
 from pydevd_plugins.extensions.pydevd_plugin_omegaconf import (
     OmegaConfDeveloperResolver,
     OmegaConfUserResolver,
 )
 from tests import Color
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @fixture
@@ -42,6 +49,7 @@ def resolver() -> Any:
         param(BooleanNode(True), {}, id="bool:True"),
         param(BytesNode(b"binary"), {}, id="bytes:binary"),
         param(EnumNode(enum_type=Color, value=Color.RED), {}, id="Color:Color.RED"),
+        param(LiteralNode(literal_type=Literal["foo"], value="foo"), {}, id="str:foo"),
         # nodes are never returning a dictionary
         param(AnyNode("${foo}", parent=DictConfig({"foo": 10})), {}, id="any:inter_10"),
         # DictConfig
@@ -234,6 +242,7 @@ def test_get_dictionary_listconfig(
         (BooleanNode, True),
         (BytesNode, True),
         (EnumNode, True),
+        (LiteralNode, True),
         # not covering some other things.
         (builtins.int, False),
         (dict, False),

--- a/tests/test_pydev_resolver_plugin.py
+++ b/tests/test_pydev_resolver_plugin.py
@@ -1,4 +1,5 @@
 import builtins
+import sys
 from typing import Any
 
 from pytest import fixture, mark, param
@@ -18,11 +19,17 @@ from omegaconf import (
     ValueNode,
 )
 from omegaconf._utils import type_str
+from omegaconf.nodes import LiteralNode
 from pydevd_plugins.extensions.pydevd_plugin_omegaconf import (
     OmegaConfDeveloperResolver,
     OmegaConfUserResolver,
 )
 from tests import Color
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @fixture
@@ -40,6 +47,7 @@ def resolver() -> Any:
         param(FloatNode(3.14), {}, id="float:3.14"),
         param(BooleanNode(True), {}, id="bool:True"),
         param(EnumNode(enum_type=Color, value=Color.RED), {}, id="Color:Color.RED"),
+        param(LiteralNode(literal_type=Literal["foo"], value="foo"), {}, id="str:foo"),
         # nodes are never returning a dictionary
         param(AnyNode("${foo}", parent=DictConfig({"foo": 10})), {}, id="any:inter_10"),
         # DictConfig
@@ -231,6 +239,7 @@ def test_get_dictionary_listconfig(
         (StringNode, True),
         (BooleanNode, True),
         (EnumNode, True),
+        (LiteralNode, True),
         # not covering some other things.
         (builtins.int, False),
         (dict, False),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -26,10 +27,16 @@ from omegaconf.nodes import (
     EnumNode,
     FloatNode,
     IntegerNode,
+    LiteralNode,
     StringNode,
 )
 from omegaconf.omegaconf import _node_wrap
 from tests import Color, ConcretePlugin, Dataframe, IllegalType, Plugin, User
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @mark.parametrize(
@@ -81,6 +88,18 @@ from tests import Color, ConcretePlugin, Dataframe, IllegalType, Plugin, User
         param(Color, "RED", EnumNode(enum_type=Color, value=Color.RED), id="Color"),
         param(
             Color, "Color.RED", EnumNode(enum_type=Color, value=Color.RED), id="Color"
+        ),
+        param(
+            Literal["foo"],
+            "foo",
+            LiteralNode(literal_type=Literal["foo"], value="foo"),
+            id='Literal["foo"]',
+        ),
+        param(
+            Literal["foo"],
+            5,
+            ValidationError,
+            id='Literal["foo"]',
         ),
         # bad type
         param(IllegalType, "nope", ValidationError, id="bad_type"),
@@ -507,6 +526,11 @@ def test_is_list_annotation(type_: Any, expected: Any) -> Any:
             Optional[Color],
             id="EnumNode[Color]",
         ),
+        param(
+            LiteralNode(literal_type=Literal["foo"], value="foo"),
+            Optional[Literal["foo"]],
+            id="Literal[foo]",
+        ),
         # Non-optional value nodes:
         param(IntegerNode(10, is_optional=False), int, id="IntegerNode"),
         param(FloatNode(10.0, is_optional=False), float, id="FloatNode"),
@@ -516,6 +540,11 @@ def test_is_list_annotation(type_: Any, expected: Any) -> Any:
             EnumNode(enum_type=Color, value=Color.RED, is_optional=False),
             Color,
             id="EnumNode[Color]",
+        ),
+        param(
+            LiteralNode(literal_type=Literal["foo"], value="foo", is_optional=False),
+            Literal["foo"],
+            id="Literal[foo]",
         ),
         # DictConfig
         param(DictConfig(content={}), Any, id="DictConfig"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -28,10 +29,16 @@ from omegaconf.nodes import (
     EnumNode,
     FloatNode,
     IntegerNode,
+    LiteralNode,
     StringNode,
 )
 from omegaconf.omegaconf import _node_wrap
 from tests import Color, ConcretePlugin, Dataframe, IllegalType, Plugin, User
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 @mark.parametrize(
@@ -102,7 +109,16 @@ from tests import Color, ConcretePlugin, Dataframe, IllegalType, Plugin, User
         ),
         param(Color, b"123", ValidationError, id="Color"),
         param(
-            Color, "Color.RED", EnumNode(enum_type=Color, value=Color.RED), id="Color"
+            Literal["foo"],
+            "foo",
+            LiteralNode(literal_type=Literal["foo"], value="foo"),
+            id='Literal["foo"]',
+        ),
+        param(
+            Literal["foo"],
+            5,
+            ValidationError,
+            id='Literal["foo"]',
         ),
         # bad type
         param(IllegalType, "nope", ValidationError, id="bad_type"),
@@ -564,6 +580,11 @@ def test_is_tuple_annotation(type_: Any, expected: Any) -> Any:
             Optional[Color],
             id="EnumNode[Color]",
         ),
+        param(
+            LiteralNode(literal_type=Literal["foo"], value="foo"),
+            Optional[Literal["foo"]],
+            id="Literal[foo]",
+        ),
         # Non-optional value nodes:
         param(IntegerNode(10, is_optional=False), int, id="IntegerNode"),
         param(FloatNode(10.0, is_optional=False), float, id="FloatNode"),
@@ -574,6 +595,11 @@ def test_is_tuple_annotation(type_: Any, expected: Any) -> Any:
             EnumNode(enum_type=Color, value=Color.RED, is_optional=False),
             Color,
             id="EnumNode[Color]",
+        ),
+        param(
+            LiteralNode(literal_type=Literal["foo"], value="foo", is_optional=False),
+            Literal["foo"],
+            id="Literal[foo]",
         ),
         # DictConfig
         param(DictConfig(content={}), Any, id="DictConfig"),


### PR DESCRIPTION
Adds literal node, solving #422 

I tried to implement this as a wrapper around `EnumNode`, but this turned out to be impossible. `Literal` can accept `int, str, bool` and `Enum` values, but enum keys must be strings. So for example

```python
from dataclasses import dataclass

@dataclass
class Config:
  mode: Literal["5", 5]
```

there is no way to map both of these values to separate enum keys without also causing a collision somewhere else. 

This PR validates a `LiteralNode` value by insisting on both `=` equality and type equality. Both are needed, otherwise python's promiscuous primitive equalities cause problems e.g. `1.0` is valid under `Literal[True]`.

I tried to add tests wherever `EnumNode` had tests, but I'm unfamiliar with the codebase. Please let me know if additional tests are needed.