### PR TITLE
add pathlib.Path support

### DIFF
--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -6,6 +6,7 @@
     from enum import Enum
     from dataclasses import dataclass, field
     import os
+    import pathlib
     from pytest import raises
     from typing import Dict, Any
     import sys
@@ -29,7 +30,7 @@ in the input class.
 
 
 Currently, type hints supported in OmegaConf’s structured configs include:
- - primitive types (int, float, bool, str) and enum types (user-defined
+ - primitive types (int, float, bool, str, Path) and enum types (user-defined
    subclasses of enum.Enum). See the :ref:`simple_types` section below.
  - structured config fields (i.e. MyConfig.x can have type hint MySubConfig).
    See the :ref:`nesting_structured_configs` section below.
@@ -50,6 +51,7 @@ Simple types include
  - bool: boolean values (True, False, On, Off etc)
  - str: any string
  - bytes: an immutable sequence of numbers in [0, 255]
+ - pathlib.Path: filesystem paths as represented by python's standard library `pathlib`
  - Enums: User defined enums
 
 The following class defines fields with all simple types:
@@ -68,6 +70,7 @@ The following class defines fields with all simple types:
     ...     height: Height = Height.SHORT
     ...     description: str = "text"
     ...     data: bytes = b"bin_data"
+    ...     path: pathlib.Path = pathlib.Path("hello.txt")
 
 You can create a config based on the SimpleTypes class itself or an instance of it.
 Those would be equivalent by default, but the Object variant allows you to set the values of specific
@@ -91,6 +94,8 @@ fields during construction.
     description: text
     data: !!binary |
       YmluX2RhdGE=
+    path: !!python/object/apply:pathlib.PosixPath
+    - hello.txt
     <BLANKLINE>
 
 The resulting object is a regular OmegaConf ``DictConfig``, except that it will utilize the type information in the input class/object
@@ -229,7 +234,7 @@ You can assign subclasses:
 Lists
 ^^^^^
 Structured Config fields annotated with ``typing.List`` or ``typing.Tuple`` can hold any type
-supported by OmegaConf (``int``, ``float``. ``bool``, ``str``, ``bytes``, ``Enum`` or Structured configs).
+supported by OmegaConf (``int``, ``float``. ``bool``, ``str``, ``bytes``, ``pathlib.Path``, ``Enum`` or Structured configs).
 
 .. doctest::
 
@@ -242,7 +247,7 @@ supported by OmegaConf (``int``, ``float``. ``bool``, ``str``, ``bytes``, ``Enum
     >>> @dataclass
     ... class ListsExample:
     ...     # Typed list can hold Any, int, float, bool, str,
-    ...     # bytes and Enums as well as arbitrary Structured configs.
+    ...     # bytes, pathlib.Path and Enums as well as arbitrary Structured configs.
     ...     ints: List[int] = field(default_factory=lambda: [10, 20, 30])
     ...     bools: Tuple[bool, bool] = field(default_factory=lambda: (True, False))
     ...     users: List[User] = field(default_factory=lambda: [User(name="omry")])
@@ -271,8 +276,8 @@ Dictionaries
 ^^^^^^^^^^^^
 Dictionaries are supported via annotation of structured config fields with ``typing.Dict``.
 Keys must be typed as one of ``str``, ``int``, ``Enum``, ``float``, ``bytes``, or ``bool``. Values can
-be any of the types supported by OmegaConf (``Any``, ``int``, ``float``, ``bool``, ``bytes``, ``str`` and ``Enum`` as well
-as arbitrary Structured configs)
+be any of the types supported by OmegaConf (``Any``, ``int``, ``float``, ``bool``, ``bytes``,
+``pathlib.Path``, ``str`` and ``Enum`` as well as arbitrary Structured configs)
 
 .. doctest::
 
@@ -280,8 +285,6 @@ as arbitrary Structured configs)
     >>> from typing import Dict
     >>> @dataclass
     ... class DictExample:
-    ...     # Typed dict keys are strings; values can be typed as Any, int, float, bool, str, bytes and Enums or
-    ...     # arbitrary Structured configs
     ...     ints: Dict[str, int] = field(default_factory=lambda: {"a": 10, "b": 20, "c": 30})
     ...     bools: Dict[str, bool] = field(default_factory=lambda: {"Uno": True, "Zoro": False})
     ...     users: Dict[str, User] = field(default_factory=lambda: {"omry": User(name="omry")})

--- a/news/97.feature
+++ b/news/97.feature
@@ -1,0 +1,1 @@
+Add support for `pathlib.Path`-typed values.

--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -15,6 +15,7 @@ from .nodes import (
     EnumNode,
     FloatNode,
     IntegerNode,
+    PathNode,
     StringNode,
     ValueNode,
 )
@@ -53,6 +54,7 @@ __all__ = [
     "IntegerNode",
     "StringNode",
     "BytesNode",
+    "PathNode",
     "BooleanNode",
     "EnumNode",
     "FloatNode",

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import pathlib
 import re
 import string
 import sys
@@ -680,16 +681,19 @@ def _valid_dict_key_annotation_type(type_: Any) -> bool:
     return type_ is None or type_ is Any or issubclass(type_, DictKeyType.__args__)  # type: ignore
 
 
+BASE_TYPES = (
+    int,
+    float,
+    bool,
+    bytes,
+    str,
+    type(None),
+)
+
+
 def is_primitive_type_annotation(type_: Any) -> bool:
     type_ = get_type_of(type_)
-    return issubclass(type_, Enum) or type_ in (
-        int,
-        float,
-        bool,
-        str,
-        bytes,
-        type(None),
-    )
+    return issubclass(type_, (Enum, pathlib.Path)) or type_ in BASE_TYPES
 
 
 def _get_value(value: Any) -> Any:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -152,6 +152,20 @@ def get_yaml_loader() -> Any:
         ]
         for key, resolvers in loader.yaml_implicit_resolvers.items()
     }
+
+    loader.add_constructor(
+        "tag:yaml.org,2002:python/object/apply:pathlib.Path",
+        lambda loader, node: pathlib.Path(*loader.construct_sequence(node)),
+    )
+    loader.add_constructor(
+        "tag:yaml.org,2002:python/object/apply:pathlib.PosixPath",
+        lambda loader, node: pathlib.PosixPath(*loader.construct_sequence(node)),
+    )
+    loader.add_constructor(
+        "tag:yaml.org,2002:python/object/apply:pathlib.WindowsPath",
+        lambda loader, node: pathlib.WindowsPath(*loader.construct_sequence(node)),
+    )
+
     return loader
 
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -67,6 +67,7 @@ from .nodes import (
     EnumNode,
     FloatNode,
     IntegerNode,
+    PathNode,
     StringNode,
     ValueNode,
 )
@@ -1077,6 +1078,8 @@ def _node_wrap(
         node = StringNode(value=value, key=key, parent=parent, is_optional=is_optional)
     elif ref_type == bytes:
         node = BytesNode(value=value, key=key, parent=parent, is_optional=is_optional)
+    elif ref_type == pathlib.Path:
+        node = PathNode(value=value, key=key, parent=parent, is_optional=is_optional)
     else:
         if parent is not None and parent._get_flag("allow_objects") is True:
             node = AnyNode(value=value, key=key, parent=parent)

--- a/tests/examples/dataclass_postponed_annotations.py
+++ b/tests/examples/dataclass_postponed_annotations.py
@@ -4,6 +4,7 @@ from __future__ import annotations  # type: ignore # noqa  # Python 3.6 linters 
 
 from dataclasses import dataclass, fields
 from enum import Enum
+from pathlib import Path
 
 from pytest import raises
 
@@ -23,6 +24,7 @@ class SimpleTypes:
     height: "Height" = Height.SHORT  # test forward ref
     description: str = "text"
     data: bytes = b"bin_data"
+    path: Path = Path("hello.txt")
 
 
 def simple_types_class() -> None:
@@ -36,6 +38,7 @@ def simple_types_class() -> None:
     assert conf.num == 10
     assert conf.pi == 3.1415
     assert conf.data == b"bin_data"
+    assert conf.path == Path("hello.txt")
     assert conf.is_awesome is True
     assert conf.height == Height.SHORT
     assert conf.description == "text"

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -1,5 +1,6 @@
 import copy
 import re
+from pathlib import Path
 from textwrap import dedent
 from typing import Any, Tuple
 
@@ -142,6 +143,7 @@ def test_indirect_interpolation2() -> None:
         param({"a": "${b}", "b": 3.14, "s": "foo_${b}"}, id="float"),
         param({"a": "${b}", "b": Color.RED, "s": "foo_${b}"}, id="enum"),
         param({"a": "${b}", "b": b"binary", "s": "foo_${b}"}, id="bytes"),
+        param({"a": "${b}", "b": Path("hello.txt"), "s": "foo_${b}"}, id="path"),
     ],
 )
 def test_type_inherit_type(cfg: Any) -> None:

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import attr
@@ -173,6 +174,21 @@ class BytesConfig:
 
     # interpolation, will inherit the type and value of `with_default'
     interpolation: bytes = II("with_default")
+
+
+@attr.s(auto_attribs=True)
+class PathConfig:
+    # with default value
+    with_default: Path = Path("hello.txt")
+
+    # default is None
+    null_default: Optional[Path] = None
+
+    # explicit no default
+    mandatory_missing: Path = MISSING
+
+    # interpolation, will inherit the type and value of `with_default'
+    interpolation: Path = II("with_default")
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -1,6 +1,7 @@
 import dataclasses
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pytest import importorskip
@@ -174,6 +175,21 @@ class BytesConfig:
 
     # interpolation, will inherit the type and value of `with_default'
     interpolation: bytes = II("with_default")
+
+
+@dataclass
+class PathConfig:
+    # with default value
+    with_default: Path = Path("hello.txt")
+
+    # default is None
+    null_default: Optional[Path] = None
+
+    # explicit no default
+    mandatory_missing: Path = MISSING
+
+    # interpolation, will inherit the type and value of `with_default'
+    interpolation: Path = II("with_default")
 
 
 @dataclass

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1,4 +1,6 @@
+import dataclasses
 import inspect
+import pathlib
 import sys
 from importlib import import_module
 from typing import Any, Callable, Dict, List, Optional
@@ -836,6 +838,22 @@ class TestConfigs:
         conf._promote(module.BoolConfig(with_default=False))
         assert OmegaConf.get_type(conf) == module.BoolConfig
         assert conf.with_default is False
+
+    def test_promote_to_dataclass(self, module: Any) -> None:
+        @dataclasses.dataclass
+        class Foo:
+            foo: pathlib.Path
+            bar: str
+            qub: int = 5
+
+        x = DictConfig({"foo": "hello.txt", "bar": "hello.txt"})
+        assert isinstance(x.foo, str)
+        assert isinstance(x.bar, str)
+
+        x._promote(Foo)
+        assert isinstance(x.foo, pathlib.Path)
+        assert isinstance(x.bar, str)
+        assert x.qub == 5
 
     def test_set_key_with_with_dataclass(self, module: Any) -> None:
         cfg = OmegaConf.create({"foo": [1, 2]})

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -3,6 +3,7 @@ import inspect
 import pathlib
 import sys
 from importlib import import_module
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from pytest import fixture, mark, param, raises
@@ -49,22 +50,36 @@ class EnumConfigAssignments:
         (2, Color.GREEN),
         (3, Color.BLUE),
     ]
-    illegal = ["foo", True, b"RED", False, 4, 1.0]
+    illegal = ["foo", True, b"RED", False, 4, 1.0, Path("hello.txt")]
 
 
 class IntegersConfigAssignments:
     legal = [("10", 10), ("-10", -10), 100, 0, 1]
-    illegal = ["foo", 1.0, float("inf"), b"123", float("nan"), Color.BLUE, True]
+    illegal = [
+        "foo",
+        1.0,
+        float("inf"),
+        b"123",
+        float("nan"),
+        Color.BLUE,
+        True,
+        Path("hello.txt"),
+    ]
 
 
 class StringConfigAssignments:
     legal = ["10", "-10", "foo", "", (Color.BLUE, "Color.BLUE")]
-    illegal = [b"binary"]
+    illegal = [b"binary", Path("hello.txt")]
 
 
 class BytesConfigAssignments:
     legal = [b"binary"]
-    illegal = ["foo", 10, Color.BLUE, 10.1, True]
+    illegal = ["foo", 10, Color.BLUE, 10.1, True, Path("hello.txt")]
+
+
+class PathConfigAssignments:
+    legal = [Path("hello.txt"), ("hello.txt", Path("hello.txt"))]
+    illegal = [10, Color.BLUE, 10.1, True, b"binary"]
 
 
 class FloatConfigAssignments:
@@ -76,7 +91,7 @@ class FloatConfigAssignments:
         ("10.2", 10.2),
         ("10e-3", 10e-3),
     ]
-    illegal = ["foo", True, False, b"10.1", Color.BLUE]
+    illegal = ["foo", True, False, b"10.1", Color.BLUE, Path("hello.txt")]
 
 
 class BoolConfigAssignments:
@@ -96,11 +111,11 @@ class BoolConfigAssignments:
         ("0", False),
         (0, False),
     ]
-    illegal = [100.0, b"binary", Color.BLUE]
+    illegal = [100.0, b"binary", Color.BLUE, Path("hello.txt")]
 
 
 class AnyTypeConfigAssignments:
-    legal = [True, False, 10, 10.0, b"binary", "foobar", Color.BLUE]
+    legal = [True, False, 10, 10.0, b"binary", "foobar", Color.BLUE, Path("hello.txt")]
 
     illegal: Any = []
 
@@ -281,6 +296,7 @@ class TestConfigs:
             ("IntegersConfig", IntegersConfigAssignments, {}),
             ("FloatConfig", FloatConfigAssignments, {}),
             ("BytesConfig", BytesConfigAssignments, {}),
+            ("PathConfig", PathConfigAssignments, {}),
             ("StringConfig", StringConfigAssignments, {}),
             ("EnumConfig", EnumConfigAssignments, {}),
             # Use instance to build config
@@ -288,6 +304,7 @@ class TestConfigs:
             ("IntegersConfig", IntegersConfigAssignments, {"with_default": 42}),
             ("FloatConfig", FloatConfigAssignments, {"with_default": 42.0}),
             ("BytesConfig", BytesConfigAssignments, {"with_default": b"bin"}),
+            ("PathConfig", PathConfigAssignments, {"with_default": Path("file.txt")}),
             ("StringConfig", StringConfigAssignments, {"with_default": "fooooooo"}),
             ("EnumConfig", EnumConfigAssignments, {"with_default": Color.BLUE}),
             ("AnyTypeConfig", AnyTypeConfigAssignments, {}),

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
+from pathlib import Path
 from textwrap import dedent
 from typing import Any, Callable, List, MutableSequence, Optional, Union
 
@@ -407,6 +408,12 @@ def test_append_invalid_element_type(lc: ListConfig, element: Any, err: Any) -> 
             "RED",
             Color.RED,
             id="list:convert_str_to_enum",
+        ),
+        param(
+            ListConfig(content=[], element_type=Path),
+            "hello.txt",
+            Path("hello.txt"),
+            id="list:convert_str_to_path",
         ),
     ],
 )

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,4 +1,5 @@
 """Testing for OmegaConf"""
+import platform
 import re
 import sys
 from pathlib import Path
@@ -340,6 +341,37 @@ def test_yaml_merge() -> None:
         )
     )
     assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 3, "y": 2, "z": 1}}
+
+
+@mark.parametrize(
+    "path_type",
+    [
+        param("Path", id="path"),
+        param(
+            "PosixPath",
+            marks=mark.skipif(
+                platform.system() == "Windows", reason="requires posix path support"
+            ),
+            id="posixpath",
+        ),
+        param(
+            "WindowsPath",
+            marks=mark.skipif(
+                platform.system() != "Windows", reason="requires windows"
+            ),
+            id="windowspath",
+        ),
+    ],
+)
+def test_create_path(path_type: str) -> None:
+    yaml_document = dedent(
+        """\
+        foo: !!python/object/apply:pathlib.{}
+          - hello.txt
+        """
+    )
+    yaml_document = yaml_document.format(path_type)
+    assert OmegaConf.create(yaml_document) == yaml.unsafe_load(yaml_document)
 
 
 @mark.parametrize(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,6 +1,7 @@
 """Testing for OmegaConf"""
 import re
 import sys
+from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, List, Optional
 
@@ -47,6 +48,7 @@ from tests import ConcretePlugin, IllegalType, NonCopyableIllegalType, Plugin
         (OmegaConf.create([]), []),
         (OmegaConf.create({"foo": OmegaConf.create([])}), {"foo": []}),
         (OmegaConf.create([OmegaConf.create({})]), [{}]),
+        (OmegaConf.create({"foo": Path("bar")}), {"foo": Path("bar")}),
     ],
 )
 def test_create_value(input_: Any, expected: Any) -> None:

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,5 +1,6 @@
 import copy
 import re
+from pathlib import Path
 from typing import Any, Optional
 
 from pytest import mark, raises, warns
@@ -13,6 +14,7 @@ from omegaconf import (
     IntegerNode,
     ListConfig,
     OmegaConf,
+    PathNode,
     StringNode,
     ValidationError,
     ValueNode,
@@ -63,6 +65,7 @@ def verify(
         (FloatNode, [3.1415]),
         (IntegerNode, [42]),
         (StringNode, ["hello"]),
+        (PathNode, [Path("hello.txt")]),
         # EnumNode
         (
             lambda value, is_optional, key=None: EnumNode(
@@ -98,6 +101,7 @@ def verify(
         "FloatNode",
         "IntegerNode",
         "StringNode",
+        "PathNode",
         "EnumNode",
         "DictConfig",
         "ListConfig",

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -185,6 +185,7 @@ def test_invalid_inputs(type_: type, input_: Any) -> None:
         (False, AnyNode),
         ("str", AnyNode),
         (b"\xf0\xf1\xf2", AnyNode),
+        (Path("hello.txt"), AnyNode),
     ],
 )
 def test_assigned_value_node_type(input_: type, expected_type: Any) -> None:
@@ -279,6 +280,7 @@ def test_merge_validation_error(c1: Dict[str, Any], c2: Dict[str, Any]) -> None:
         (AnyNode, "aaa", None),
         (StringNode, "blah", None),
         (BytesNode, b"foobar", None),
+        (PathNode, Path("hello.txt"), None),
     ],
 )
 def test_accepts_mandatory_missing(
@@ -306,24 +308,23 @@ def test_accepts_mandatory_missing(
 
 @mark.parametrize(
     "type_",
-    [BooleanNode, BytesNode, EnumNode, FloatNode, IntegerNode, StringNode, AnyNode],
+    [
+        BooleanNode,
+        BytesNode,
+        PathNode,
+        EnumNode,
+        FloatNode,
+        IntegerNode,
+        StringNode,
+        AnyNode,
+    ],
 )
 @mark.parametrize(
     "values, success_map",
     [
         param(
-            # True aliases
-            (True, "Y", "true", "yes", "on"),
-            {
-                "BooleanNode": True,
-                "StringNode": str,
-                "AnyNode": copy.copy,
-            },
-            id="true-aliases",
-        ),
-        param(
             # Integers
-            ("1", 1, 10, -10),
+            (1, 10, -10),
             {
                 "BooleanNode": True,
                 "IntegerNode": int,
@@ -334,24 +335,70 @@ def test_accepts_mandatory_missing(
             id="integers",
         ),
         param(
-            # Floaty things
-            ("1.0", 1.0, float("inf"), float("-inf"), "10e-3", 10e-3),
-            {"FloatNode": float, "StringNode": str, "AnyNode": copy.copy},
-            id="floaty-things",
+            # Integer strings
+            ("1",),
+            {
+                "BooleanNode": True,
+                "IntegerNode": int,
+                "FloatNode": float,
+                "StringNode": str,
+                "AnyNode": copy.copy,
+                "PathNode": Path,
+            },
+            id="integer-strings",
         ),
         param(
-            # False aliases
-            (False, "N", "false", "no", "off"),
+            # Floats
+            (1.0, float("inf"), float("-inf"), 10e-3),
+            {"FloatNode": float, "StringNode": str, "AnyNode": copy.copy},
+            id="floats",
+        ),
+        param(
+            # Floaty strings
+            ("1.0", "10e-3"),
+            {
+                "FloatNode": float,
+                "StringNode": str,
+                "AnyNode": copy.copy,
+                "PathNode": Path,
+            },
+            id="floaty-strings",
+        ),
+        param(
+            # Booleans
+            (True, False),
+            {
+                "BooleanNode": copy.copy,
+                "StringNode": str,
+                "AnyNode": copy.copy,
+            },
+            id="booleans",
+        ),
+        param(
+            # Trueish strings
+            ("Y", "true", "yes", "on"),
+            {
+                "BooleanNode": True,
+                "StringNode": str,
+                "AnyNode": copy.copy,
+                "PathNode": Path,
+            },
+            id="trueish-strings",
+        ),
+        param(
+            # Falsey strings
+            ("N", "false", "no", "off"),
             {
                 "BooleanNode": False,
                 "StringNode": str,
                 "AnyNode": copy.copy,
+                "PathNode": Path,
             },
-            id="false-alises",
+            id="falsey-strings",
         ),
         param(
-            # Falsy integers
-            ("0", 0),
+            # Falsy integer
+            (0,),
             {
                 "BooleanNode": False,
                 "IntegerNode": 0,
@@ -359,7 +406,20 @@ def test_accepts_mandatory_missing(
                 "StringNode": str,
                 "AnyNode": copy.copy,
             },
-            id="falsey-integers",
+            id="falsey-integer",
+        ),
+        param(
+            # Falsy integer string
+            ("0",),
+            {
+                "BooleanNode": False,
+                "IntegerNode": 0,
+                "FloatNode": 0.0,
+                "StringNode": str,
+                "AnyNode": copy.copy,
+                "PathNode": Path,
+            },
+            id="falsey-integer-string",
         ),
         param(
             # Binary data
@@ -369,6 +429,15 @@ def test_accepts_mandatory_missing(
                 "AnyNode": copy.copy,
             },
             id="binary-data",
+        ),
+        param(
+            # pathlib.Path data
+            (Path("hello.txt"),),
+            {
+                "PathNode": copy.copy,
+                "AnyNode": copy.copy,
+            },
+            id="path-data",
         ),
     ],
 )
@@ -398,6 +467,7 @@ def test_legal_assignment(
         (BooleanNode(), "foo"),
         (FloatNode(), "foo"),
         (BytesNode(), "foo"),
+        (PathNode(), 123),
         (EnumNode(enum_type=Enum1), "foo"),
     ],
 )
@@ -408,7 +478,16 @@ def test_illegal_assignment(node: ValueNode, value: Any) -> None:
 
 @mark.parametrize(
     "node_type",
-    [BooleanNode, BytesNode, EnumNode, FloatNode, IntegerNode, StringNode, AnyNode],
+    [
+        BooleanNode,
+        BytesNode,
+        PathNode,
+        EnumNode,
+        FloatNode,
+        IntegerNode,
+        StringNode,
+        AnyNode,
+    ],
 )
 @mark.parametrize(
     "enum_type, values, success_map",
@@ -448,6 +527,7 @@ def test_legal_assignment_enum(
         StringNode(value="foo"),
         StringNode(value="foo", is_optional=False),
         BytesNode(value=b"\xf0\xf1\xf2"),
+        PathNode(value=Path("hello.txt")),
         BooleanNode(value=True),
         IntegerNode(value=10),
         FloatNode(value=10.0),
@@ -483,6 +563,9 @@ def test_deepcopy(obj: Any) -> None:
         (BytesNode(), None, True),
         (BytesNode(), b"binary", False),
         (BytesNode(b"binary"), b"binary", True),
+        (PathNode(), None, True),
+        (PathNode(), Path("hello.txt"), False),
+        (PathNode(Path("hello.txt")), Path("hello.txt"), True),
         (BooleanNode(), True, False),
         (BooleanNode(), False, False),
         (BooleanNode(), None, True),
@@ -593,6 +676,7 @@ def test_dereference_missing() -> None:
         FloatNode,
         BooleanNode,
         BytesNode,
+        PathNode,
         lambda val, is_optional: EnumNode(
             enum_type=Color, value=val, is_optional=is_optional
         ),
@@ -639,6 +723,7 @@ def test_dereference_interpolation_to_missing() -> None:
         IntegerNode,
         InterpolationResultNode,
         StringNode,
+        PathNode,
     ],
 )
 def test_set_flags_in_init(type_: Any, flags: Dict[str, bool]) -> None:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -3,6 +3,7 @@ import functools
 import re
 from enum import Enum
 from functools import partial
+from pathlib import Path
 from typing import Any, Dict, Tuple, Type
 
 from pytest import mark, param, raises
@@ -18,6 +19,7 @@ from omegaconf import (
     ListConfig,
     Node,
     OmegaConf,
+    PathNode,
     StringNode,
     ValueNode,
 )
@@ -84,6 +86,9 @@ from tests import Color, Enum1, IllegalType, User
         (lambda v: EnumNode(enum_type=Color, value=v), "Color.RED", Color.RED),
         (lambda v: EnumNode(enum_type=Color, value=v), "RED", Color.RED),
         (lambda v: EnumNode(enum_type=Color, value=v), 1, Color.RED),
+        # Path node
+        (PathNode, "hello.txt", Path("hello.txt")),
+        (PathNode, Path("hello.txt"), Path("hello.txt")),
     ],
 )
 def test_valid_inputs(type_: type, input_: Any, output_: Any) -> None:
@@ -156,6 +161,8 @@ def test_valid_inputs(type_: type, input_: Any, output_: Any) -> None:
         (partial(EnumNode, Color), {"foo": "bar"}),
         (partial(EnumNode, Color), ListConfig([1, 2])),
         (partial(EnumNode, Color), DictConfig({"foo": "bar"})),
+        (PathNode, 1.0),
+        (PathNode, ["hello.txt"]),
     ],
 )
 def test_invalid_inputs(type_: type, input_: Any) -> None:

--- a/tests/test_pydev_resolver_plugin.py
+++ b/tests/test_pydev_resolver_plugin.py
@@ -15,6 +15,7 @@ from omegaconf import (
     ListConfig,
     Node,
     OmegaConf,
+    PathNode,
     StringNode,
     ValueNode,
 )
@@ -41,6 +42,7 @@ def resolver() -> Any:
         param(FloatNode(3.14), {}, id="float:3.14"),
         param(BooleanNode(True), {}, id="bool:True"),
         param(BytesNode(b"binary"), {}, id="bytes:binary"),
+        param(PathNode("hello.txt"), {}, id="path:hello.txt"),
         param(EnumNode(enum_type=Color, value=Color.RED), {}, id="Color:Color.RED"),
         # nodes are never returning a dictionary
         param(AnyNode("${foo}", parent=DictConfig({"foo": 10})), {}, id="any:inter_10"),
@@ -233,6 +235,7 @@ def test_get_dictionary_listconfig(
         (StringNode, True),
         (BooleanNode, True),
         (BytesNode, True),
+        (PathNode, True),
         (EnumNode, True),
         # not covering some other things.
         (builtins.int, False),


### PR DESCRIPTION
Add support for Path in Omegaconf.

Path type will never be automatically inferred when loading from YAML, so we will continue creating StringNode by default.
But if you use `structured` or `_promote` with a dataclass using Path some of `StringNode` can be converted to `PathNode` eg:

https://github.com/gwenzek/omegaconf/blob/1df8a05f9f740b7085fb65fe7a4d8b1e034f2ea6/tests/structured_conf/test_structured_config.py#L819-L833

This change is backward compatible, because code that currently use dataclass with Path fields currently see errors when running `structured`.

This should resolve #97 

cc: @odelalleau @Mortimerp9 