### PR TITLE
adjust 736 news to use standard mechanism

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,3 @@
-## 2.2.0
-### Features
-
-- ListConfig now implements slice assignment ([#736](https://github.com/omry/omegaconf/issues/736))
-
 ## 2.1.1 (2021-08-17)
 ### Features
 

--- a/news/736.feature
+++ b/news/736.feature
@@ -1,0 +1,1 @@
+ListConfig now implements slice assignment.


### PR DESCRIPTION
Ease future updates from towncrier by using standard
news format for feature 736