### PR TITLE
`OmegaConf.to_object` handling of `init=False` fields

### DIFF
--- a/news/789.bugfix
+++ b/news/789.bugfix
@@ -1,0 +1,1 @@
+`OmegaConf.to_object` now works properly with structured configs that have `init=False` fields

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -268,10 +268,14 @@ def extract_dict_subclass_data(obj: Any, parent: Any) -> Optional[Dict[str, Any]
         return None
 
 
-def get_attr_class_field_names(obj: Any) -> List[str]:
+def get_attr_class_init_field_names(obj: Any) -> List[str]:
     is_type = isinstance(obj, type)
     obj_type = obj if is_type else type(obj)
-    return list(attr.fields_dict(obj_type))
+    return [
+        fieldname
+        for fieldname, attribute in attr.fields_dict(obj_type).items()
+        if attribute.init
+    ]
 
 
 def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, Any]:
@@ -321,8 +325,8 @@ def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, A
     return d
 
 
-def get_dataclass_field_names(obj: Any) -> List[str]:
-    return [field.name for field in dataclasses.fields(obj)]
+def get_dataclass_init_field_names(obj: Any) -> List[str]:
+    return [field.name for field in dataclasses.fields(obj) if field.init]
 
 
 def get_dataclass_data(
@@ -421,11 +425,11 @@ def is_structured_config_frozen(obj: Any) -> bool:
     return False
 
 
-def get_structured_config_field_names(obj: Any) -> List[str]:
+def get_structured_config_init_field_names(obj: Any) -> List[str]:
     if is_dataclass(obj):
-        return get_dataclass_field_names(obj)
+        return get_dataclass_init_field_names(obj)
     elif is_attr_class(obj):
-        return get_attr_class_field_names(obj)
+        return get_attr_class_init_field_names(obj)
     else:
         raise ValueError(f"Unsupported type: {type(obj).__name__}")
 

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -607,3 +607,13 @@ class StructuredSubclass:
     class ChildContainers(ParentContainers):
         list1: List[int] = [1, 2, 3]
         dict: Dict[str, Any] = {"a": 5, "b": 6}
+
+
+@attr.s(auto_attribs=True)
+class HasInitFalseFields:
+    post_initialized: str = attr.field(init=False)
+    without_default: str = attr.field(init=False)
+    with_default: str = attr.field(init=False, default="default")
+
+    def __attrs_post_init__(self) -> None:
+        self.post_initialized = "set_by_post_init"

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -628,3 +628,13 @@ class StructuredSubclass:
     class ChildContainers(ParentContainers):
         list1: List[int] = field(default_factory=lambda: [1, 2, 3])
         dict: Dict[str, Any] = field(default_factory=lambda: {"a": 5, "b": 6})
+
+
+@dataclass
+class HasInitFalseFields:
+    post_initialized: str = field(init=False)
+    without_default: str = field(init=False)
+    with_default: str = field(init=False, default="default")
+
+    def __post_init__(self) -> None:
+        self.post_initialized = "set_by_post_init"

--- a/tests/test_to_container.py
+++ b/tests/test_to_container.py
@@ -430,6 +430,42 @@ class TestInstantiateStructuredConfigs:
         assert type(user) is module.User
         assert user.extra_field == 123
 
+    def test_init_false_with_default(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.HasInitFalseFields)
+        assert cfg.with_default == "default"
+        data = self.round_trip_to_object(cfg)
+        assert data.with_default == "default"
+
+    def test_init_false_with_default_overridden(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.HasInitFalseFields)
+        cfg.with_default = "default_overridden"
+        data = self.round_trip_to_object(cfg)
+        assert data.with_default == "default_overridden"
+
+    def test_init_false_without_default(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.HasInitFalseFields)
+        assert OmegaConf.is_missing(cfg, "without_default")
+        data = self.round_trip_to_object(cfg)
+        assert not hasattr(data, "without_default")
+
+    def test_init_false_without_default_overridden(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.HasInitFalseFields)
+        cfg.with_default = "default_overridden"
+        data = self.round_trip_to_object(cfg)
+        assert data.with_default == "default_overridden"
+
+    def test_init_false_post_initialized(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.HasInitFalseFields)
+        assert OmegaConf.is_missing(cfg, "post_initialized")
+        data = self.round_trip_to_object(cfg)
+        assert data.post_initialized == "set_by_post_init"
+
+    def test_init_false_post_initialized_overridden(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.HasInitFalseFields)
+        cfg.post_initialized = "overridden"
+        data = self.round_trip_to_object(cfg)
+        assert data.post_initialized == "overridden"
+
 
 class TestEnumToStr:
     """Test the `enum_to_str` argument to the `OmegaConf.to_container function`"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -151,6 +151,7 @@ class _TestDataclass:
     e: _TestEnum = _TestEnum.A
     list1: List[int] = field(default_factory=list)
     dict1: Dict[str, int] = field(default_factory=dict)
+    init_false: str = field(init=False, default="foo")
 
 
 @attr.s(auto_attribs=True)
@@ -163,6 +164,7 @@ class _TestAttrsClass:
     e: _TestEnum = _TestEnum.A
     list1: List[int] = []
     dict1: Dict[str, int] = {}
+    init_false: str = attr.field(init=False, default="foo")
 
 
 @dataclass
@@ -226,12 +228,12 @@ class TestGetStructuredConfigInfo:
         [_TestDataclass, _TestDataclass(), _TestAttrsClass, _TestAttrsClass()],
     )
     def test_get_structured_config_field_names(self, test_cls_or_obj: Any) -> None:
-        field_names = _utils.get_structured_config_field_names(test_cls_or_obj)
+        field_names = _utils.get_structured_config_init_field_names(test_cls_or_obj)
         assert field_names == ["x", "s", "b", "d", "f", "e", "list1", "dict1"]
 
     def test_get_structured_config_field_names_throws_ValueError(self) -> None:
         with raises(ValueError):
-            _utils.get_structured_config_field_names("invalid")
+            _utils.get_structured_config_init_field_names("invalid")
 
 
 @mark.parametrize(


### PR DESCRIPTION
This PR improves `OmegaConf.to_object` so that structured configs with `init=False` fields can be handled.

This comes up for example when calling `to_object` on a structured config generated by [`hydra_zen.builds`](https://mit-ll-responsible-ai.github.io/hydra-zen/generated/hydra_zen.builds.html) (as such structured configs use an `init=False` field for the `_target_` key).

Here is a demo of the use-cases enabled by this PR:
```python
# example.py
from dataclasses import dataclass, field
from omegaconf import DictConfig, OmegaConf

@dataclass
class Foo:
    x: str = field(init=False)
    y: str = field(init=False, default="default")
    z: str = field(init=False)
    def __post_init__(self) -> None:
        self.z = "set_by_post_init"


cfg1 = OmegaConf.structured(Foo)
assert OmegaConf.is_missing(cfg1, "x")
assert cfg1.y == "default"
assert OmegaConf.is_missing(cfg1, "z")

obj1 = OmegaConf.to_object(cfg1)
assert not hasattr(obj1, "x")
assert obj1.y == "default"
assert obj1.z == "set_by_post_init"


cfg2 = OmegaConf.structured(Foo)
cfg2.x = "new_x"
cfg2.y = "new_y"
cfg2.z = "new_z"

obj2 = OmegaConf.to_object(cfg2)
assert obj2.x == "new_x"
assert obj2.y == "new_y"
assert obj2.z == "new_z"
```
#### Pre-PR behavior:
```
$ python example.py
Traceback (most recent call last):
  File "/home/rig1/dev/omegaconf/example.py", line 22, in <module>
    obj1 = OmegaConf.to_object(cfg1)
...
omegaconf.errors.MissingMandatoryValue: Structured config of type `Foo` has missing mandatory value: x
    full_key: x
    object_type=Foo
```
#### Post-PR behavior:
```
$ python example.py  # no errors, assertions succeed
```
Closes #789.