### PR TITLE
Update the return type annotation for OmegaConf.to_container

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -549,7 +549,7 @@ class OmegaConf:
         throw_on_missing: bool = False,
         enum_to_str: bool = False,
         structured_config_mode: SCMode = SCMode.DICT,
-    ) -> Union[Dict[DictKeyType, Any], List[Any], None, str]:
+    ) -> Union[Dict[DictKeyType, Any], List[Any], None, str, Any]:
         """
         Resursively converts an OmegaConf config to a primitive container (dict or list).
         :param cfg: the config to convert


### PR DESCRIPTION
This update adds `Any` to the union return type for
`OmegaConf.to_container`.

**Motivation**
`OmegaConf.to_container` may return a dataclass instance in the case
where the `structured_config_mode` parameter passed to `to_container`
has value `SCMode.INSTANTIATE`. This is the case in which the
`Any` return type annotation applies.
