### PR TITLE
remove redundant arg from _node_wrap

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1016,11 +1016,11 @@ def open_dict(config: Container) -> Generator[Container, None, None]:
 
 
 def _node_wrap(
-    ref_type: Any,
     parent: Optional[BaseContainer],
     is_optional: bool,
     value: Any,
     key: Any,
+    ref_type: Any = Any,
 ) -> Node:
     node: Node
     if is_dict_annotation(ref_type) or (is_primitive_dict(value) and ref_type is Any):

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1016,29 +1016,28 @@ def open_dict(config: Container) -> Generator[Container, None, None]:
 
 
 def _node_wrap(
-    type_: Any,
+    ref_type: Any,
     parent: Optional[BaseContainer],
     is_optional: bool,
     value: Any,
     key: Any,
-    ref_type: Any = Any,
 ) -> Node:
     node: Node
-    if is_dict_annotation(type_) or (is_primitive_dict(value) and type_ is Any):
-        key_type, element_type = get_dict_key_value_types(type_)
+    if is_dict_annotation(ref_type) or (is_primitive_dict(value) and ref_type is Any):
+        key_type, element_type = get_dict_key_value_types(ref_type)
         node = DictConfig(
             content=value,
             key=key,
             parent=parent,
-            ref_type=type_,
+            ref_type=ref_type,
             is_optional=is_optional,
             key_type=key_type,
             element_type=element_type,
         )
-    elif (is_list_annotation(type_) or is_tuple_annotation(type_)) or (
-        is_primitive_list(value) and type_ is Any
+    elif (is_list_annotation(ref_type) or is_tuple_annotation(ref_type)) or (
+        is_primitive_list(value) and ref_type is Any
     ):
-        element_type = get_list_element_type(type_)
+        element_type = get_list_element_type(ref_type)
         node = ListConfig(
             content=value,
             key=key,
@@ -1047,10 +1046,10 @@ def _node_wrap(
             element_type=element_type,
             ref_type=ref_type,
         )
-    elif is_structured_config(type_) or is_structured_config(value):
+    elif is_structured_config(ref_type) or is_structured_config(value):
         key_type, element_type = get_dict_key_value_types(value)
         node = DictConfig(
-            ref_type=type_,
+            ref_type=ref_type,
             is_optional=is_optional,
             content=value,
             key=key,
@@ -1058,31 +1057,31 @@ def _node_wrap(
             key_type=key_type,
             element_type=element_type,
         )
-    elif type_ == Any or type_ is None:
+    elif ref_type == Any or ref_type is None:
         node = AnyNode(value=value, key=key, parent=parent)
-    elif issubclass(type_, Enum):
+    elif issubclass(ref_type, Enum):
         node = EnumNode(
-            enum_type=type_,
+            enum_type=ref_type,
             value=value,
             key=key,
             parent=parent,
             is_optional=is_optional,
         )
-    elif type_ == int:
+    elif ref_type == int:
         node = IntegerNode(value=value, key=key, parent=parent, is_optional=is_optional)
-    elif type_ == float:
+    elif ref_type == float:
         node = FloatNode(value=value, key=key, parent=parent, is_optional=is_optional)
-    elif type_ == bool:
+    elif ref_type == bool:
         node = BooleanNode(value=value, key=key, parent=parent, is_optional=is_optional)
-    elif type_ == str:
+    elif ref_type == str:
         node = StringNode(value=value, key=key, parent=parent, is_optional=is_optional)
-    elif type_ == bytes:
+    elif ref_type == bytes:
         node = BytesNode(value=value, key=key, parent=parent, is_optional=is_optional)
     else:
         if parent is not None and parent._get_flag("allow_objects") is True:
             node = AnyNode(value=value, key=key, parent=parent)
         else:
-            raise ValidationError(f"Unexpected object type: {type_str(type_)}")
+            raise ValidationError(f"Unexpected object type: {type_str(ref_type)}")
     return node
 
 
@@ -1101,12 +1100,11 @@ def _maybe_wrap(
         return value
     else:
         return _node_wrap(
-            type_=ref_type,
+            ref_type=ref_type,
             parent=parent,
             is_optional=is_optional,
             value=value,
             key=key,
-            ref_type=ref_type,
         )
 
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -440,25 +440,24 @@ class DummyEnum(Enum):
 
 @mark.parametrize("is_optional", [True, False])
 @mark.parametrize(
-    "ref_type, type_, value, expected_type",
+    "ref_type, value, expected_type",
     [
-        (Any, Any, 10, AnyNode),
-        (DummyEnum, DummyEnum, DummyEnum.FOO, EnumNode),
-        (int, int, 42, IntegerNode),
-        (bytes, bytes, b"\xf0\xf1\xf2", BytesNode),
-        (float, float, 3.1415, FloatNode),
-        (bool, bool, True, BooleanNode),
-        (str, str, "foo", StringNode),
+        (Any, 10, AnyNode),
+        (DummyEnum, DummyEnum.FOO, EnumNode),
+        (int, 42, IntegerNode),
+        (bytes, b"\xf0\xf1\xf2", BytesNode),
+        (float, 3.1415, FloatNode),
+        (bool, True, BooleanNode),
+        (str, "foo", StringNode),
     ],
 )
 def test_node_wrap(
-    ref_type: type, type_: type, is_optional: bool, value: Any, expected_type: Any
+    ref_type: type, is_optional: bool, value: Any, expected_type: Any
 ) -> None:
     from omegaconf.omegaconf import _node_wrap
 
     ret = _node_wrap(
-        ref_type=Any,
-        type_=type_,
+        ref_type=ref_type,
         value=value,
         is_optional=is_optional,
         parent=None,
@@ -470,8 +469,7 @@ def test_node_wrap(
 
     if is_optional:
         ret = _node_wrap(
-            ref_type=Any,
-            type_=type_,
+            ref_type=ref_type,
             value=None,
             is_optional=is_optional,
             parent=None,
@@ -490,7 +488,11 @@ def test_node_wrap_illegal_type() -> None:
 
     with raises(ValidationError):
         _node_wrap(
-            type_=UserClass, value=UserClass(), is_optional=False, parent=None, key=None
+            ref_type=UserClass,
+            value=UserClass(),
+            is_optional=False,
+            parent=None,
+            key=None,
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -147,7 +147,7 @@ def test_node_wrap(target_type: Any, value: Any, expected: Any) -> None:
 
     if isinstance(expected, Node):
         res = _node_wrap(
-            type_=target_type, key="foo", value=value, is_optional=False, parent=None
+            ref_type=target_type, key="foo", value=value, is_optional=False, parent=None
         )
         assert type(res) == type(expected)
         assert res == expected
@@ -726,7 +726,7 @@ def test_get_ref_type_error() -> None:
 )
 def test_get_value_basic(value: Any) -> None:
     val_node = _node_wrap(
-        value=value, type_=Any, parent=None, is_optional=True, key=None
+        value=value, ref_type=Any, parent=None, is_optional=True, key=None
     )
     assert _get_value(val_node) == value
 


### PR DESCRIPTION
The arguments `type_` and `ref_type` to the `_node_wrap` function are redundant.
This PR removes the `type_` argument.
I chose to keep `ref_type` instead of `type_` for consistency with other parts of the codebase.