### PR TITLE
simplify ListConfig.insert

### DIFF
--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -319,16 +319,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                 assert isinstance(self.__dict__["_content"], list)
                 # insert place holder
                 self.__dict__["_content"].insert(index, None)
-                is_optional, ref_type = _resolve_optional(self._metadata.element_type)
-                node = _maybe_wrap(
-                    ref_type=ref_type,
-                    key=index,
-                    value=item,
-                    is_optional=is_optional,
-                    parent=self,
-                )
-                self._validate_set(key=index, value=node)
-                self._set_at_index(index, node)
+                self._set_at_index(index, item)
                 self._update_keys()
             except Exception:
                 del self.__dict__["_content"][index]


### PR DESCRIPTION
Removes an unnecessary call to `_maybe_wrap` in `ListConfig.insert`.
The inserted item will be wrapped later by `BaseContainer._set_item_impl` if necessary.
