### PR TITLE
refactoring: rename some functions

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -3,21 +3,12 @@ import os
 import re
 import string
 import sys
+import typing
 import warnings
 from contextlib import contextmanager
 from enum import Enum
 from textwrap import dedent
-from typing import (
-    Any,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    get_type_hints,
-)
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 import yaml
 
@@ -340,7 +331,7 @@ def get_dataclass_data(
     obj_type = get_type_of(obj)
     dummy_parent = OmegaConf.create({}, flags=flags)
     dummy_parent._metadata.object_type = obj_type
-    resolved_hints = get_type_hints(obj_type)
+    resolved_hints = typing.get_type_hints(obj_type)
     for field in dataclasses.fields(obj):
         name = field.name
         is_optional, type_ = _resolve_optional(resolved_hints[field.name])
@@ -715,7 +706,7 @@ def _get_value(value: Any) -> Any:
     return value
 
 
-def get_ref_type(obj: Any, key: Any = None) -> Optional[Type[Any]]:
+def get_type_hint(obj: Any, key: Any = None) -> Optional[Type[Any]]:
     from omegaconf import Container, Node
 
     if isinstance(obj, Container):
@@ -794,7 +785,7 @@ def format_and_raise(
         object_type = OmegaConf.get_type(node)
         object_type_str = type_str(object_type)
 
-        ref_type = get_ref_type(node)
+        ref_type = get_type_hint(node)
         ref_type_str = type_str(ref_type)
 
     msg = string.Template(msg).safe_substitute(

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -672,7 +672,7 @@ def get_dict_key_value_types(ref_type: Any) -> Tuple[Any, Any]:
     return key_type, element_type
 
 
-def valid_value_annotation_type(type_: Any) -> bool:
+def is_valid_value_annotation(type_: Any) -> bool:
     _, type_ = _resolve_optional(type_)
     return (
         type_ is Any

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -3,7 +3,6 @@ import os
 import re
 import string
 import sys
-import typing
 import warnings
 from contextlib import contextmanager
 from enum import Enum
@@ -323,6 +322,8 @@ def get_dataclass_init_field_names(obj: Any) -> List[str]:
 def get_dataclass_data(
     obj: Any, allow_objects: Optional[bool] = None
 ) -> Dict[str, Any]:
+    from typing import get_type_hints
+
     from omegaconf.omegaconf import MISSING, OmegaConf, _node_wrap
 
     flags = {"allow_objects": allow_objects} if allow_objects is not None else {}
@@ -331,7 +332,7 @@ def get_dataclass_data(
     obj_type = get_type_of(obj)
     dummy_parent = OmegaConf.create({}, flags=flags)
     dummy_parent._metadata.object_type = obj_type
-    resolved_hints = typing.get_type_hints(obj_type)
+    resolved_hints = get_type_hints(obj_type)
     for field in dataclasses.fields(obj):
         name = field.name
         is_optional, type_ = _resolve_optional(resolved_hints[field.name])

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -676,7 +676,7 @@ def is_valid_value_annotation(type_: Any) -> bool:
     _, type_ = _resolve_optional(type_)
     return (
         type_ is Any
-        or is_primitive_type(type_)
+        or is_primitive_type_annotation(type_)
         or is_structured_config(type_)
         or is_container_annotation(type_)
     )
@@ -688,7 +688,7 @@ def _valid_dict_key_annotation_type(type_: Any) -> bool:
     return type_ is None or type_ is Any or issubclass(type_, DictKeyType.__args__)  # type: ignore
 
 
-def is_primitive_type(type_: Any) -> bool:
+def is_primitive_type_annotation(type_: Any) -> bool:
     type_ = get_type_of(type_)
     return issubclass(type_, Enum) or type_ in (
         int,

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -176,7 +176,7 @@ def _get_class(path: str) -> type:
     return klass
 
 
-def _is_union(type_: Any) -> bool:
+def is_union_annotation(type_: Any) -> bool:
     return getattr(type_, "__origin__", None) is Union
 
 
@@ -300,7 +300,7 @@ def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, A
             value = attrib.default
             if value == attr.NOTHING:
                 value = MISSING
-        if _is_union(type_):
+        if is_union_annotation(type_):
             e = ConfigValueError(
                 f"Union types are not supported:\n{name}: {type_str(type_)}"
             )
@@ -358,7 +358,7 @@ def get_dataclass_data(
             else:
                 value = MISSING
 
-        if _is_union(type_):
+        if is_union_annotation(type_):
             e = ConfigValueError(
                 f"Union types are not supported:\n{name}: {type_str(type_)}"
             )

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -15,9 +15,9 @@ from ._utils import (
     _is_missing_value,
     format_and_raise,
     get_value_kind,
+    is_valid_value_annotation,
     split_key,
     type_str,
-    valid_value_annotation_type,
 )
 from .errors import (
     ConfigKeyError,
@@ -86,7 +86,7 @@ class ContainerMetadata(Metadata):
             self.ref_type = Any
         assert self.key_type is Any or isinstance(self.key_type, type)
         if self.element_type is not None:
-            if not valid_value_annotation_type(self.element_type):
+            if not is_valid_value_annotation(self.element_type):
                 raise ValidationError(
                     f"Unsupported value type: '{type_str(self.element_type, include_module_name=True)}'"
                 )

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -16,7 +16,6 @@ from ._utils import (
     _is_missing_value,
     _is_none,
     _is_special,
-    _is_union,
     _resolve_optional,
     get_ref_type,
     get_structured_config_data,
@@ -29,6 +28,7 @@ from ._utils import (
     is_primitive_type,
     is_structured_config,
     is_tuple_annotation,
+    is_union_annotation,
 )
 from .base import Container, ContainerMetadata, DictKeyType, Node, SCMode
 from .errors import (
@@ -106,7 +106,7 @@ class BaseContainer(Container, ABC):
                 assert False
         if sys.version_info < (3, 7):  # pragma: no cover
             element_type = self._metadata.element_type
-            if _is_union(element_type):
+            if is_union_annotation(element_type):
                 raise OmegaConfBaseException(
                     "Serializing structured configs with `Union` element type requires python >= 3.7"
                 )

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -17,8 +17,8 @@ from ._utils import (
     _is_none,
     _is_special,
     _resolve_optional,
-    get_ref_type,
     get_structured_config_data,
+    get_type_hint,
     get_value_kind,
     get_yaml_loader,
     is_container_annotation,
@@ -283,7 +283,7 @@ class BaseContainer(Container, ABC):
         assert isinstance(dest, DictConfig)
         assert isinstance(src, DictConfig)
         src_type = src._metadata.object_type
-        src_ref_type = get_ref_type(src)
+        src_ref_type = get_type_hint(src)
         assert src_ref_type is not None
 
         # If source DictConfig is:

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -25,7 +25,7 @@ from ._utils import (
     is_dict_annotation,
     is_list_annotation,
     is_primitive_dict,
-    is_primitive_type,
+    is_primitive_type_annotation,
     is_structured_config,
     is_tuple_annotation,
     is_union_annotation,
@@ -568,7 +568,10 @@ class BaseContainer(Container, ABC):
                     and target_node_ref._has_ref_type()
                 )
                 or (target_is_vnode and not isinstance(target_node_ref, AnyNode))
-                or (isinstance(target_node_ref, AnyNode) and is_primitive_type(value))
+                or (
+                    isinstance(target_node_ref, AnyNode)
+                    and is_primitive_type_annotation(value)
+                )
             )
             if should_set_value:
                 if special_value and isinstance(value, Node):
@@ -839,7 +842,7 @@ def _shallow_validate_type_hint(node: Node, type_hint: Any) -> None:
     elif vk in (ValueKind.MANDATORY_MISSING, ValueKind.INTERPOLATION):
         return
     elif vk == ValueKind.VALUE:
-        if is_primitive_type(ref_type) and isinstance(node, ValueNode):
+        if is_primitive_type_annotation(ref_type) and isinstance(node, ValueNode):
             value = node._value()
             if not isinstance(value, ref_type):
                 raise ValidationError(

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -126,13 +126,15 @@ class AnyNode(ValueNode):
         )
 
     def _validate_and_convert_impl(self, value: Any) -> Any:
-        from ._utils import is_primitive_type
+        from ._utils import is_primitive_type_annotation
 
         # allow_objects is internal and not an official API. use at your own risk.
         # Please be aware that this support is subject to change without notice.
         # If this is deemed useful and supportable it may become an official API.
 
-        if self._get_flag("allow_objects") is not True and not is_primitive_type(value):
+        if self._get_flag(
+            "allow_objects"
+        ) is not True and not is_primitive_type_annotation(value):
             t = get_type_of(value)
             raise UnsupportedValueType(
                 f"Value '{t.__name__}' is not a supported primitive type"

--- a/tests/structured_conf/test_structured_basic.py
+++ b/tests/structured_conf/test_structured_basic.py
@@ -14,7 +14,7 @@ from omegaconf import (
     _utils,
     flag_override,
 )
-from omegaconf._utils import _is_optional, get_ref_type
+from omegaconf._utils import _is_optional, get_type_hint
 from omegaconf.errors import ConfigKeyError, UnsupportedValueType
 from tests import IllegalType
 
@@ -139,7 +139,7 @@ class TestStructured:
     def test_get_type(self, module: Any) -> None:
         cfg1 = OmegaConf.create(module.LinkedList)
         assert OmegaConf.get_type(cfg1) == module.LinkedList
-        assert _utils.get_ref_type(cfg1, "next") == Optional[module.LinkedList]
+        assert _utils.get_type_hint(cfg1, "next") == Optional[module.LinkedList]
         assert OmegaConf.get_type(cfg1, "next") is None
 
         assert cfg1.next is None
@@ -147,7 +147,7 @@ class TestStructured:
 
         cfg2 = OmegaConf.create(module.MissingTest.Missing1)
         assert OmegaConf.is_missing(cfg2, "head")
-        assert _utils.get_ref_type(cfg2, "head") == module.LinkedList
+        assert _utils.get_type_hint(cfg2, "head") == module.LinkedList
         assert OmegaConf.get_type(cfg2, "head") is None
 
     def test_merge_structured_into_dict(self, module: Any) -> None:
@@ -164,7 +164,7 @@ class TestStructured:
         # type of name becomes str
         assert c2 == {"user": {"name": "7", "age": "???"}}
         assert isinstance(c2, DictConfig)
-        assert get_ref_type(c2, "user") == module.User
+        assert get_type_hint(c2, "user") == module.User
 
     def test_merge_structured_into_dict_nested2(self, module: Any) -> None:
         c1 = OmegaConf.create({"user": {"name": IntegerNode(value=7)}})
@@ -173,7 +173,7 @@ class TestStructured:
         # type of name remains int
         assert c2 == {"user": {"name": 7, "age": "???"}}
         assert isinstance(c2, DictConfig)
-        assert get_ref_type(c2, "user") == module.User
+        assert get_type_hint(c2, "user") == module.User
 
     def test_merge_structured_into_dict_nested3(self, module: Any) -> None:
         c1 = OmegaConf.create({"user": {"name": "alice"}})
@@ -182,7 +182,7 @@ class TestStructured:
         # name is not changed
         assert c2 == {"user": {"name": "alice", "age": "???"}}
         assert isinstance(c2, DictConfig)
-        assert get_ref_type(c2, "user") == module.UserWithDefaultName
+        assert get_type_hint(c2, "user") == module.UserWithDefaultName
 
     def test_merge_missing_object_onto_typed_dictconfig(self, module: Any) -> None:
         c1 = OmegaConf.structured(module.DictOfObjects)
@@ -207,7 +207,7 @@ class TestStructured:
         c1 = OmegaConf.create({"user": {"name": "bob"}})
         c2 = OmegaConf.merge(c1, module.OptionalUser(module.User(name="alice")))
         assert c2.user.name == "alice"
-        assert get_ref_type(c2, "user") == Optional[module.User]
+        assert get_type_hint(c2, "user") == Optional[module.User]
         assert isinstance(c2, DictConfig)
         c2_user = c2._get_node("user")
         assert isinstance(c2_user, Node)
@@ -229,9 +229,9 @@ class TestStructured:
         src.user_3 = None
         c2 = OmegaConf.merge(c1, src)
         assert c2.user_2.name == "bob"
-        assert get_ref_type(c2, "user_2") == Any
+        assert get_type_hint(c2, "user_2") == Any
         assert c2.user_3 is None
-        assert get_ref_type(c2, "user_3") == Any
+        assert get_type_hint(c2, "user_3") == Any
 
     @mark.parametrize("resolve", [True, False])
     def test_interpolation_to_structured(self, module: Any, resolve: bool) -> None:
@@ -263,24 +263,24 @@ class TestStructured:
             cfg = OmegaConf.create(module.PluginHolder)
 
             assert _is_optional(cfg, "none")
-            assert _utils.get_ref_type(cfg, "none") == Optional[module.Plugin]
+            assert _utils.get_type_hint(cfg, "none") == Optional[module.Plugin]
             assert OmegaConf.get_type(cfg, "none") is None
 
             assert not _is_optional(cfg, "missing")
-            assert _utils.get_ref_type(cfg, "missing") == module.Plugin
+            assert _utils.get_type_hint(cfg, "missing") == module.Plugin
             assert OmegaConf.get_type(cfg, "missing") is None
 
             assert not _is_optional(cfg, "plugin")
-            assert _utils.get_ref_type(cfg, "plugin") == module.Plugin
+            assert _utils.get_type_hint(cfg, "plugin") == module.Plugin
             assert OmegaConf.get_type(cfg, "plugin") == module.Plugin
 
             cfg.plugin = module.ConcretePlugin()
             assert not _is_optional(cfg, "plugin")
-            assert _utils.get_ref_type(cfg, "plugin") == module.Plugin
+            assert _utils.get_type_hint(cfg, "plugin") == module.Plugin
             assert OmegaConf.get_type(cfg, "plugin") == module.ConcretePlugin
 
             assert not _is_optional(cfg, "plugin2")
-            assert _utils.get_ref_type(cfg, "plugin2") == module.Plugin
+            assert _utils.get_type_hint(cfg, "plugin2") == module.Plugin
             assert OmegaConf.get_type(cfg, "plugin2") == module.ConcretePlugin
 
         def test_plugin_merge(self, module: Any) -> None:

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -108,7 +108,7 @@ class TestConfigs:
         cfg = OmegaConf.structured(module.NestedWithNone)
         assert cfg == {"plugin": None}
         assert OmegaConf.get_type(cfg, "plugin") is None
-        assert _utils.get_ref_type(cfg, "plugin") == Optional[module.Plugin]
+        assert _utils.get_type_hint(cfg, "plugin") == Optional[module.Plugin]
 
     def test_nested_config(self, module: Any) -> None:
         def validate(cfg: DictConfig) -> None:
@@ -519,11 +519,11 @@ class TestConfigs:
 
     def test_merge_with_subclass_into_missing(self, module: Any) -> None:
         base = OmegaConf.structured(module.PluginHolder)
-        assert _utils.get_ref_type(base, "missing") == module.Plugin
+        assert _utils.get_type_hint(base, "missing") == module.Plugin
         assert OmegaConf.get_type(base, "missing") is None
         res = OmegaConf.merge(base, {"missing": module.Plugin})
         assert OmegaConf.get_type(res) == module.PluginHolder
-        assert _utils.get_ref_type(base, "missing") == module.Plugin
+        assert _utils.get_type_hint(base, "missing") == module.Plugin
         assert OmegaConf.get_type(res, "missing") == module.Plugin
 
     def test_merged_with_nons_subclass(self, module: Any) -> None:
@@ -924,15 +924,15 @@ class TestConfigs:
 
     def test_create_untyped_dict(self, module: Any) -> None:
         cfg = OmegaConf.structured(module.UntypedDict)
-        assert _utils.get_ref_type(cfg, "dict") == Dict[Any, Any]
-        assert _utils.get_ref_type(cfg, "opt_dict") == Optional[Dict[Any, Any]]
+        assert _utils.get_type_hint(cfg, "dict") == Dict[Any, Any]
+        assert _utils.get_type_hint(cfg, "opt_dict") == Optional[Dict[Any, Any]]
         assert cfg.dict == {"foo": "var"}
         assert cfg.opt_dict is None
 
     def test_create_untyped_list(self, module: Any) -> None:
         cfg = OmegaConf.structured(module.UntypedList)
-        assert _utils.get_ref_type(cfg, "list") == List[Any]
-        assert _utils.get_ref_type(cfg, "opt_list") == Optional[List[Any]]
+        assert _utils.get_type_hint(cfg, "list") == List[Any]
+        assert _utils.get_type_hint(cfg, "opt_list") == Optional[List[Any]]
         assert cfg.list == [1, 2]
         assert cfg.opt_list is None
 
@@ -994,7 +994,7 @@ class TestDictSubclass:
         with warns_dict_subclass_deprecated(module.DictSubclass.Str2Str):
             cfg = OmegaConf.create({"foo": module.DictSubclass.Str2Str})
         assert OmegaConf.get_type(cfg.foo) == module.DictSubclass.Str2Str
-        assert _utils.get_ref_type(cfg.foo) == Any
+        assert _utils.get_type_hint(cfg.foo) == Any
 
         cfg.foo.hello = "world"
         assert cfg.foo.hello == "world"
@@ -1028,7 +1028,7 @@ class TestDictSubclass:
         with warns_dict_subclass_deprecated(module.DictSubclass.Int2Str):
             cfg = OmegaConf.create({"foo": module.DictSubclass.Int2Str})
         assert OmegaConf.get_type(cfg.foo) == module.DictSubclass.Int2Str
-        assert _utils.get_ref_type(cfg.foo) == Any
+        assert _utils.get_type_hint(cfg.foo) == Any
 
         cfg.foo[10] = "ten"
         assert cfg.foo[10] == "ten"

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -953,7 +953,7 @@ def test_get_type() -> None:
     ],
 )
 def test_get_ref_type(cfg: Any, expected_ref_type: Any) -> None:
-    assert _utils.get_ref_type(cfg.plugin) == expected_ref_type
+    assert _utils.get_type_hint(cfg.plugin) == expected_ref_type
 
 
 def test_get_ref_type_with_conflict() -> None:
@@ -962,11 +962,11 @@ def test_get_ref_type_with_conflict() -> None:
     )
 
     assert OmegaConf.get_type(cfg.user) == User
-    assert _utils.get_ref_type(cfg.user) == Any
+    assert _utils.get_type_hint(cfg.user) == Any
 
     # Interpolation inherits both type and ref type from the target
     assert OmegaConf.get_type(cfg.inter) == User
-    assert _utils.get_ref_type(cfg.inter) == Any
+    assert _utils.get_type_hint(cfg.inter) == Any
 
 
 def test_is_missing() -> None:
@@ -1010,17 +1010,17 @@ def test_assign_to_reftype_none_or_any(ref_type: Any, assign: Any) -> None:
 class TestAssignAndMergeIntoReftypePlugin:
     def _test_assign(self, ref_type: Any, value: Any, assign: Any) -> None:
         cfg = OmegaConf.create({"foo": DictConfig(ref_type=ref_type, content=value)})
-        assert _utils.get_ref_type(cfg, "foo") == Optional[ref_type]
+        assert _utils.get_type_hint(cfg, "foo") == Optional[ref_type]
         cfg.foo = assign
         assert cfg.foo == assign
-        assert _utils.get_ref_type(cfg, "foo") == Optional[ref_type]
+        assert _utils.get_type_hint(cfg, "foo") == Optional[ref_type]
 
     def _test_merge(self, ref_type: Any, value: Any, assign: Any) -> None:
         cfg = OmegaConf.create({"foo": DictConfig(ref_type=ref_type, content=value)})
         cfg2 = OmegaConf.merge(cfg, {"foo": assign})
         assert isinstance(cfg2, DictConfig)
         assert cfg2.foo == assign
-        assert _utils.get_ref_type(cfg2, "foo") == Optional[ref_type]
+        assert _utils.get_type_hint(cfg2, "foo") == Optional[ref_type]
 
     def test_assign_to_reftype_plugin1(self, ref_type: Any, assign: Any) -> None:
         self._test_assign(ref_type, ref_type, assign)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -282,17 +282,17 @@ def test_create_unmodified_loader() -> None:
 
 
 def test_create_untyped_list() -> None:
-    from omegaconf._utils import get_ref_type
+    from omegaconf._utils import get_type_hint
 
     cfg = ListConfig(ref_type=List, content=[])
-    assert get_ref_type(cfg) == Optional[List]
+    assert get_type_hint(cfg) == Optional[List]
 
 
 def test_create_untyped_dict() -> None:
-    from omegaconf._utils import get_ref_type
+    from omegaconf._utils import get_type_hint
 
     cfg = DictConfig(ref_type=Dict, content={})
-    assert get_ref_type(cfg) == Optional[Dict]
+    assert get_type_hint(cfg) == Optional[Dict]
 
 
 @mark.parametrize(

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Type
 from pytest import mark, param, raises
 
 from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
-from omegaconf._utils import get_ref_type
+from omegaconf._utils import get_type_hint
 from omegaconf.errors import OmegaConfBaseException
 from tests import (
     Color,
@@ -139,7 +139,7 @@ def test_pickle(obj: Any) -> None:
         fp.seek(0)
         c1 = pickle.load(fp)
         assert c == c1
-        assert get_ref_type(c1) == Any
+        assert get_type_hint(c1) == Any
         assert c1._metadata.element_type is Any
         assert c1._metadata.optional is True
         if isinstance(c, DictConfig):
@@ -349,7 +349,7 @@ def test_pickle_untyped(
                 return cfg._get_node(key)
 
         assert cfg == cfg2
-        assert get_ref_type(get_node(cfg2, node)) == ref_type
+        assert get_type_hint(get_node(cfg2, node)) == ref_type
         assert get_node(cfg2, node)._metadata.element_type == element_type
         assert get_node(cfg2, node)._metadata.optional == optional
         if isinstance(input_, DictConfig):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -510,7 +510,7 @@ def test_get_key_value_types(
     ],
 )
 def test_is_primitive_type(type_: Any, is_primitive: bool) -> None:
-    assert _utils.is_primitive_type(type_) == is_primitive
+    assert _utils.is_primitive_type_annotation(type_) == is_primitive
 
 
 @mark.parametrize("optional", [False, True])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -755,7 +755,7 @@ def test_is_tuple_annotation(type_: Any, expected: Any) -> Any:
     ],
 )
 def test_get_ref_type(obj: Any, expected: Any) -> None:
-    assert _utils.get_ref_type(obj) == expected
+    assert _utils.get_type_hint(obj) == expected
 
 
 @mark.parametrize(
@@ -769,12 +769,12 @@ def test_get_ref_type(obj: Any, expected: Any) -> None:
 )
 def test_get_node_ref_type(obj: Any, key: str, expected: Any) -> None:
     cfg = OmegaConf.create(obj)
-    assert _utils.get_ref_type(cfg, key) == expected
+    assert _utils.get_type_hint(cfg, key) == expected
 
 
 def test_get_ref_type_error() -> None:
     with raises(ValueError):
-        _utils.get_ref_type(AnyNode(), "foo")
+        _utils.get_type_hint(AnyNode(), "foo")
 
 
 @mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -287,9 +287,9 @@ class _TestUserClass:
     ],
 )
 def test_valid_value_annotation_type(type_: type, expected: bool) -> None:
-    from omegaconf._utils import valid_value_annotation_type
+    from omegaconf._utils import is_valid_value_annotation
 
-    assert valid_value_annotation_type(type_) == expected
+    assert is_valid_value_annotation(type_) == expected
 
 
 class TestGetStructuredConfigInfo:


### PR DESCRIPTION
Renaming some internal functions for consistency

- rename `_utils._is_union` -> `_utils.is_union_annotation`
- rename `_utils.valid_value_annotation_type` -> `_utils.is_valid_value_annotation`
- rename `_utils.is_primitive_type` -> `_utils.is_primitive_type_annotation`

The above renamings are for consistency with the functions `is_container_annotation`, `is_dict_annotation`, `is_list_annotation`.

- rename `_utils.get_ref_type` -> `_utils.get_type_hint`:
  this is for consistency with other uses of variable name `ref_type` in the codebase. Normally `ref_type` in OmegaConf's codebase refers to a type annotation that has had `typing.Optional` stripped away, and `type_hint` refers to a type annotation that *is* possible wrapped in `typing.Optional[...]`. 

I'll squash these into a single commit before merging.