### PR TITLE
preliminary UnionNode implementation

### DIFF
--- a/news/144.feature
+++ b/news/144.feature
@@ -1,0 +1,1 @@
+Support unions of primitive types in structured config type hints (`typing.Union`)

--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -1,4 +1,4 @@
-from .base import Container, DictKeyType, Node, SCMode
+from .base import Container, DictKeyType, Node, SCMode, UnionNode
 from .dictconfig import DictConfig
 from .errors import (
     KeyValidationError,
@@ -39,6 +39,7 @@ __all__ = [
     "UnsupportedValueType",
     "KeyValidationError",
     "Container",
+    "UnionNode",
     "ListConfig",
     "DictConfig",
     "DictKeyType",

--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -7,7 +7,7 @@ from ._utils import _DEFAULT_MARKER_, _get_value
 
 
 def _resolve_container_value(cfg: Container, key: Any) -> None:
-    node = cfg._get_node(key)
+    node = cfg._get_child(key)
     assert isinstance(node, Node)
     if node._is_interpolation():
         try:

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -395,7 +395,9 @@ class Box(Node):
             content = self.__dict__["_content"]
             if isinstance(content, Node):
                 content._set_parent(self)
-                if isinstance(content, Box):
+                if isinstance(content, Box):  # pragma: no cover
+                    # No coverage here as support for containers inside
+                    # UnionNode is not yet implemented
                     content._re_parent()
 
 

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -38,7 +38,7 @@ from ._utils import (
     is_structured_config_frozen,
     type_str,
 )
-from .base import Container, ContainerMetadata, DictKeyType, Node
+from .base import Box, Container, ContainerMetadata, DictKeyType, Node
 from .basecontainer import BaseContainer
 from .errors import (
     ConfigAttributeError,
@@ -63,7 +63,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         self,
         content: Union[Dict[DictKeyType, Any], "DictConfig", Any],
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         ref_type: Union[Any, Type[Any]] = Any,
         key_type: Union[Any, Type[Any]] = Any,
         element_type: Union[Any, Type[Any]] = Any,
@@ -441,7 +441,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         self, key: DictKeyType, default_value: Any, validate_key: bool = True
     ) -> Any:
         try:
-            node = self._get_node(
+            node = self._get_child(
                 key=key, throw_on_missing_key=True, validate_key=validate_key
             )
         except (ConfigAttributeError, ConfigKeyError):
@@ -495,7 +495,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
                     f"{type_str(self._metadata.object_type)} (DictConfig) does not support pop"
                 )
             key = self._validate_and_normalize_key(key)
-            node = self._get_node(key=key, validate_access=False)
+            node = self._get_child(key=key, validate_access=False)
             if node is not None:
                 assert isinstance(node, Node)
                 value = self._resolve_with_default(
@@ -539,7 +539,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             return False
 
         try:
-            node = self._get_node(key)
+            node = self._get_child(key)
             assert node is None or isinstance(node, Node)
         except (KeyError, AttributeError):
             node = None
@@ -737,7 +737,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         non_init_field_items: Dict[str, Any] = {}
         for k in self.keys():
             assert isinstance(k, str)
-            node = self._get_node(k)
+            node = self._get_child(k)
             assert isinstance(node, Node)
             try:
                 node = node._dereference_node()

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -26,7 +26,7 @@ from ._utils import (
     is_structured_config,
     type_str,
 )
-from .base import Container, ContainerMetadata, Node
+from .base import Box, ContainerMetadata, Node
 from .basecontainer import BaseContainer
 from .errors import (
     ConfigAttributeError,
@@ -47,7 +47,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
         self,
         content: Union[List[Any], Tuple[Any, ...], "ListConfig", str, None],
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         element_type: Union[Type[Any], Any] = Any,
         is_optional: bool = True,
         ref_type: Union[Type[Any], Any] = Any,
@@ -460,7 +460,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                 raise MissingMandatoryValue("Cannot pop from a missing ListConfig")
 
             assert isinstance(self.__dict__["_content"], list)
-            node = self._get_node(index)
+            node = self._get_child(index)
             assert isinstance(node, Node)
             ret = self._resolve_with_default(key=index, value=node, default_value=None)
             del self.__dict__["_content"][index]

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -14,14 +14,14 @@ from omegaconf._utils import (
     is_primitive_container,
     type_str,
 )
-from omegaconf.base import Container, DictKeyType, Metadata, Node
+from omegaconf.base import Box, DictKeyType, Metadata, Node
 from omegaconf.errors import ReadonlyConfigError, UnsupportedValueType, ValidationError
 
 
 class ValueNode(Node):
     _val: Any
 
-    def __init__(self, parent: Optional[Container], value: Any, metadata: Metadata):
+    def __init__(self, parent: Optional[Box], value: Any, metadata: Metadata):
         from omegaconf import read_write
 
         super().__init__(parent=parent, metadata=metadata)
@@ -129,7 +129,7 @@ class AnyNode(ValueNode):
         self,
         value: Any = None,
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         flags: Optional[Dict[str, bool]] = None,
     ):
         super().__init__(
@@ -167,7 +167,7 @@ class StringNode(ValueNode):
         self,
         value: Any = None,
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         is_optional: bool = True,
         flags: Optional[Dict[str, bool]] = None,
     ):
@@ -205,7 +205,7 @@ class PathNode(ValueNode):
         self,
         value: Any = None,
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         is_optional: bool = True,
         flags: Optional[Dict[str, bool]] = None,
     ):
@@ -246,7 +246,7 @@ class IntegerNode(ValueNode):
         self,
         value: Any = None,
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         is_optional: bool = True,
         flags: Optional[Dict[str, bool]] = None,
     ):
@@ -285,7 +285,7 @@ class BytesNode(ValueNode):
         self,
         value: Any = None,
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         is_optional: bool = True,
         flags: Optional[Dict[str, bool]] = None,
     ):
@@ -319,7 +319,7 @@ class FloatNode(ValueNode):
         self,
         value: Any = None,
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         is_optional: bool = True,
         flags: Optional[Dict[str, bool]] = None,
     ):
@@ -375,7 +375,7 @@ class BooleanNode(ValueNode):
         self,
         value: Any = None,
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         is_optional: bool = True,
         flags: Optional[Dict[str, bool]] = None,
     ):
@@ -432,7 +432,7 @@ class EnumNode(ValueNode):  # lgtm [py/missing-equals] : Intentional.
         enum_type: Type[Enum],
         value: Optional[Union[Enum, str]] = None,
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         is_optional: bool = True,
         flags: Optional[Dict[str, bool]] = None,
     ):
@@ -513,7 +513,7 @@ class InterpolationResultNode(ValueNode):
         self,
         value: Any,
         key: Any = None,
-        parent: Optional[Container] = None,
+        parent: Optional[Box] = None,
         flags: Optional[Dict[str, bool]] = None,
     ):
         super().__init__(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -142,7 +142,7 @@ class StructuredWithMissing:
 
 @dataclass
 class UnionError:
-    x: Union[int, str] = 10
+    x: Union[int, List[str]] = 10
 
 
 @dataclass
@@ -278,6 +278,12 @@ class NestedContainers:
     list_of_list: List[List[int]] = field(default_factory=lambda: [[123]])
     dict_of_list: Dict[str, List[int]] = field(default_factory=lambda: {"foo": [123]})
     list_of_dict: List[Dict[str, int]] = field(default_factory=lambda: [{"bar": 123}])
+
+
+@dataclass
+class UnionAnnotations:
+    ubf: Union[bool, float] = True
+    oubf: Optional[Union[bool, float]] = None
 
 
 def warns_dict_subclass_deprecated(dict_subclass: Any) -> Any:

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -574,7 +574,7 @@ class NestedWithNone:
 
 @attr.s(auto_attribs=True)
 class UnionError:
-    x: Union[int, str] = 10
+    x: Union[int, List[str]] = 10
 
 
 @attr.s(auto_attribs=True)
@@ -701,3 +701,86 @@ class NestedContainers:
     @attr.s(auto_attribs=True)
     class WithDefault:
         dsolx_default: Dict[str, Optional[List[User]]] = {"lx": [User()], "n": None}
+
+
+class UnionsOfPrimitveTypes:
+    @attr.s(auto_attribs=True)
+    class Simple:
+        uis: Union[int, str]
+        ubc: Union[bool, Color]
+        uxf: Union[bytes, float]
+        ouis: Optional[Union[int, str]]
+        uois: Union[Optional[int], str]
+        uisn: Union[int, str, None]
+        uisN: Union[int, str, type(None)]  # type: ignore
+
+    @attr.s(auto_attribs=True)
+    class WithDefaults:
+        uis: Union[int, str] = "abc"
+        ubc1: Union[bool, Color] = True
+        ubc2: Union[bool, Color] = Color.RED
+        uxf: Union[bytes, float] = 1.2
+        ouis: Optional[Union[int, str]] = None
+        uisn: Union[int, str, None] = 123
+        uisN: Union[int, str, type(None)] = "abc"  # type: ignore
+
+    @attr.s(auto_attribs=True)
+    class WithExplicitMissing:
+        uis_missing: Union[int, str] = MISSING
+
+    @attr.s(auto_attribs=True)
+    class WithBadDefaults1:
+        uis: Union[int, str] = None  # type: ignore
+
+    @attr.s(auto_attribs=True)
+    class WithBadDefaults2:
+        ubc: Union[bool, Color] = "abc"  # type: ignore
+
+    @attr.s(auto_attribs=True)
+    class WithBadDefaults3:
+        uxf: Union[bytes, float] = True
+
+    @attr.s(auto_attribs=True)
+    class WithBadDefaults4:
+        oufb: Optional[Union[float, bool]] = Color.RED  # type: ignore
+
+    @attr.s(auto_attribs=True)
+    class ContainersOfUnions:
+        lubc: List[Union[bool, Color]]
+        dsubf: Dict[str, Union[bool, float]]
+        dsoubf: Dict[str, Optional[Union[bool, float]]]
+        lubc_with_default: List[Union[bool, Color]] = [True, Color.RED]
+        dsubf_with_default: Dict[str, Union[bool, float]] = {"abc": True, "xyz": 1.2}
+
+    @attr.s(auto_attribs=True)
+    class InterpolationFromUnion:
+        ubi: Union[bool, int]
+        oubi: Optional[Union[bool, int]]
+        an_int: int = 123
+        a_string: str = "abc"
+        missing: int = MISSING
+        none: Optional[int] = None
+        ubi_with_default: Union[bool, int] = II("an_int")
+        oubi_with_default: Optional[Union[bool, int]] = II("none")
+
+    @attr.s(auto_attribs=True)
+    class InterpolationToUnion:
+        a_float: float = II("ufs")
+        bad_int_interp: bool = II("ufs")
+        ufs: Union[float, str] = 10.1
+
+    @attr.s(auto_attribs=True)
+    class BadInterpolationFromUnion:
+        a_float: float = 10.1
+        ubi: Union[bool, int] = II("a_float")
+
+    if sys.version_info >= (3, 10):
+
+        @attr.s(auto_attribs=True)
+        class SupportPEP604:
+            """https://peps.python.org/pep-0604/"""
+
+            uis: int | str
+            ouis: Optional[int | str]
+            uisn: int | str | None = None
+            uis_with_default: int | str = 123

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -595,7 +595,7 @@ class NestedWithNone:
 
 @dataclass
 class UnionError:
-    x: Union[int, str] = 10
+    x: Union[int, List[str]] = 10
 
 
 @dataclass
@@ -734,3 +734,90 @@ class NestedContainers:
         dsolx_default: Dict[str, Optional[List[User]]] = field(
             default_factory=lambda: {"lx": [User()], "n": None}
         )
+
+
+class UnionsOfPrimitveTypes:
+    @dataclass
+    class Simple:
+        uis: Union[int, str]
+        ubc: Union[bool, Color]
+        uxf: Union[bytes, float]
+        ouis: Optional[Union[int, str]]
+        uois: Union[Optional[int], str]
+        uisn: Union[int, str, None]
+        uisN: Union[int, str, type(None)]  # type: ignore
+
+    @dataclass
+    class WithDefaults:
+        uis: Union[int, str] = "abc"
+        ubc1: Union[bool, Color] = True
+        ubc2: Union[bool, Color] = Color.RED
+        uxf: Union[bytes, float] = 1.2
+        ouis: Optional[Union[int, str]] = None
+        uisn: Union[int, str, None] = 123
+        uisN: Union[int, str, type(None)] = "abc"  # type: ignore
+
+    @dataclass
+    class WithExplicitMissing:
+        uis_missing: Union[int, str] = MISSING
+
+    @dataclass
+    class WithBadDefaults1:
+        uis: Union[int, str] = None  # type: ignore
+
+    @dataclass
+    class WithBadDefaults2:
+        ubc: Union[bool, Color] = "abc"  # type: ignore
+
+    @dataclass
+    class WithBadDefaults3:
+        uxf: Union[bytes, float] = True
+
+    @dataclass
+    class WithBadDefaults4:
+        oufb: Optional[Union[float, bool]] = Color.RED  # type: ignore
+
+    @dataclass
+    class ContainersOfUnions:
+        lubc: List[Union[bool, Color]]
+        dsubf: Dict[str, Union[bool, float]]
+        dsoubf: Dict[str, Optional[Union[bool, float]]]
+        lubc_with_default: List[Union[bool, Color]] = field(
+            default_factory=lambda: [True, Color.RED]
+        )
+        dsubf_with_default: Dict[str, Union[bool, float]] = field(
+            default_factory=lambda: {"abc": True, "xyz": 1.2}
+        )
+
+    @dataclass
+    class InterpolationFromUnion:
+        ubi: Union[bool, int]
+        oubi: Optional[Union[bool, int]]
+        an_int: int = 123
+        a_string: str = "abc"
+        missing: int = MISSING
+        none: Optional[int] = None
+        ubi_with_default: Union[bool, int] = II("an_int")
+        oubi_with_default: Optional[Union[bool, int]] = II("none")
+
+    @dataclass
+    class InterpolationToUnion:
+        a_float: float = II("ufs")
+        bad_int_interp: bool = II("ufs")
+        ufs: Union[float, str] = 10.1
+
+    @dataclass
+    class BadInterpolationFromUnion:
+        a_float: float = 10.1
+        ubi: Union[bool, int] = II("a_float")
+
+    if sys.version_info >= (3, 10):
+
+        @dataclass
+        class SupportPEP604:
+            """https://peps.python.org/pep-0604/"""
+
+            uis: int | str
+            ouis: Optional[int | str]
+            uisn: int | str | None = None
+            uis_with_default: int | str = 123

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -13,6 +13,7 @@ from omegaconf import (
     OmegaConf,
     ReadonlyConfigError,
     StringNode,
+    UnionNode,
     ValidationError,
     flag_override,
     open_dict,
@@ -505,6 +506,12 @@ class TestParentAfterCopy:
         nc = copy_func(cfg._get_node("a"))
         assert nc._get_parent() is cfg
         assert nc._get_node(0)._get_parent() is nc
+
+    def test_union_copy(self, copy_func: Any) -> None:
+        cfg = OmegaConf.create({"a": UnionNode(10.0, Union[float, bool])})
+        nc = copy_func(cfg._get_node("a"))
+        assert nc._get_parent() is cfg
+        assert nc._value()._get_parent() is nc
 
 
 def test_omegaconf_init_not_implemented() -> None:

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -997,12 +997,12 @@ def test_assign_to_reftype_none_or_any(ref_type: Any, assign: Any) -> None:
 @mark.parametrize(
     "ref_type,assign",
     [
-        (Plugin, None),
-        (Plugin, Plugin),
-        (Plugin, Plugin()),
-        (Plugin, ConcretePlugin),
-        (Plugin, ConcretePlugin()),
-        (ConcretePlugin, None),
+        param(Plugin, None, id="plugin_none"),
+        param(Plugin, Plugin, id="plugin_plugin"),
+        param(Plugin, Plugin(), id="plugin_plugin()"),
+        param(Plugin, ConcretePlugin, id="plugin_concrete"),
+        param(Plugin, ConcretePlugin(), id="plugin_concrete()"),
+        param(ConcretePlugin, None, id="concrete_none"),
         param(ConcretePlugin, ConcretePlugin, id="subclass=subclass_obj"),
         param(ConcretePlugin, ConcretePlugin(), id="subclass=subclass_obj"),
     ],

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -739,6 +739,20 @@ params = [
     ),
     param(
         Expected(
+            create=lambda: DictConfig(
+                {"bar": BytesNode(b"binary", flags={"convert": False})}
+            ),
+            op=lambda cfg: cfg.__setattr__("bar", 123.4),
+            exception_type=ValidationError,
+            msg="Value '123.4' of type 'float' is incompatible with type hint 'Optional[bytes]'",
+            key="bar",
+            full_key="bar",
+            child_node=lambda cfg: cfg._get_node("bar"),
+        ),
+        id="typed_DictConfig:assign_with_invalid_value,string_to_bytes,no_convert",
+    ),
+    param(
+        Expected(
             create=lambda: DictConfig({"bar": PathNode(Path("hello.txt"))}),
             op=lambda cfg: cfg.__setattr__("bar", 123.4),
             exception_type=ValidationError,
@@ -751,6 +765,20 @@ params = [
     ),
     param(
         Expected(
+            create=lambda: DictConfig(
+                {"bar": PathNode(Path("hello.txt"), flags={"convert": False})}
+            ),
+            op=lambda cfg: cfg.__setattr__("bar", 123.4),
+            exception_type=ValidationError,
+            msg="Value '123.4' of type 'float' is not an instance of 'pathlib.Path'",
+            key="bar",
+            full_key="bar",
+            child_node=lambda cfg: cfg._get_node("bar"),
+        ),
+        id="typed_DictConfig:assign_with_invalid_value,string_to_path,no_convert",
+    ),
+    param(
+        Expected(
             create=lambda: DictConfig({"bar": StringNode("abc123")}),
             op=lambda cfg: cfg.__setattr__("bar", b"binary"),
             exception_type=ValidationError,
@@ -760,6 +788,20 @@ params = [
             child_node=lambda cfg: cfg._get_node("bar"),
         ),
         id="typed_DictConfig:assign_with_invalid_value,bytes_to_string",
+    ),
+    param(
+        Expected(
+            create=lambda: DictConfig(
+                {"bar": StringNode("abc123")}, flags={"convert": False}
+            ),
+            op=lambda cfg: cfg.__setattr__("bar", b"binary"),
+            exception_type=ValidationError,
+            msg=r"Value 'b'binary'' of type 'bytes' is incompatible with type hint 'Optional[str]'",
+            key="bar",
+            full_key="bar",
+            child_node=lambda cfg: cfg._get_node("bar"),
+        ),
+        id="typed_DictConfig:assign_with_invalid_value,bytes_to_string,parent_no_convert",
     ),
     param(
         Expected(

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -596,7 +596,6 @@ class TestOmegaConfGrammar:
                     # grammer tests, but `resolve_parse_tree()` requires it).
                     node=AnyNode(None, parent=cfg),
                     key=None,
-                    parent=cfg,
                 )
             )
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,7 +1,7 @@
 import copy
 import re
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from pytest import mark, raises
 
@@ -16,6 +16,7 @@ from omegaconf import (
     OmegaConf,
     PathNode,
     StringNode,
+    UnionNode,
     ValidationError,
     ValueNode,
 )
@@ -71,6 +72,13 @@ def verify(
             ),
             [Color.RED],
         ),
+        # UnionNode
+        (
+            lambda value, is_optional, key=None: UnionNode(
+                value, ref_type=Union[bool, float], is_optional=is_optional, key=key
+            ),
+            [True, False, 10.0],
+        ),
         # DictConfig
         (
             lambda value, is_optional, key=None: DictConfig(
@@ -101,6 +109,7 @@ def verify(
         "StringNode",
         "PathNode",
         "EnumNode",
+        "UnionNode",
         "DictConfig",
         "ListConfig",
         "dataclass",

--- a/tests/test_nested_containers.py
+++ b/tests/test_nested_containers.py
@@ -1404,7 +1404,7 @@ def test_merge_nested_list_promotion() -> None:
     [
         param(
             [DictConfig({}, element_type=int), {"foo": "abc"}],
-            "Value 'abc' (str) is incompatible with type hint 'int'",
+            "Value 'abc' of type 'str' could not be converted to Integer",
         ),
         param(
             [DictConfig({}, element_type=Dict[str, int]), {"foo": 123}],

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -1,7 +1,7 @@
 import pathlib
 import platform
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 from pytest import mark, param, raises
 
@@ -18,6 +18,7 @@ from omegaconf import (
     OmegaConf,
     PathNode,
     StringNode,
+    UnionNode,
 )
 from omegaconf._utils import _is_none, nullcontext
 from omegaconf.errors import (
@@ -384,6 +385,10 @@ def test_is_interpolation(fac: Any) -> Any:
         ({"foo": 10.0}, float),
         ({"foo": True}, bool),
         ({"foo": b"123"}, bytes),
+        ({"foo": UnionNode(10.0, Union[float, bytes])}, float),
+        ({"foo": UnionNode(None, Union[float, bytes])}, type(None)),
+        ({"foo": FloatNode(10.0)}, float),
+        ({"foo": FloatNode(None)}, type(None)),
         (
             {"foo": Path("hello.txt")},
             pathlib.WindowsPath

--- a/tests/test_to_container.py
+++ b/tests/test_to_container.py
@@ -330,6 +330,22 @@ class TestInstantiateStructuredConfigs:
         assert nested.default_value.additional == 20
         assert nested.user_provided_default.mandatory_missing == 456
 
+    def test_unions_with_defaults_to_container(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.UnionsOfPrimitveTypes.WithDefaults)
+        obj: Any = OmegaConf.to_container(cfg)
+        assert obj["uis"] == "abc"
+        assert obj["ubc1"] is True
+        assert obj["ubc2"] == Color.RED
+        assert obj["ouis"] is None
+
+    def test_unions_with_defaults_to_object(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.UnionsOfPrimitveTypes.WithDefaults)
+        obj: Any = OmegaConf.to_object(cfg)
+        assert obj.uis == "abc"
+        assert obj.ubc1 is True
+        assert obj.ubc2 == Color.RED
+        assert obj.ouis is None
+
     def test_nested_object_with_missing(self, module: Any) -> None:
         with raises(MissingMandatoryValue):
             self.round_trip_to_object(module.NestedConfig)

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+from typing import Any, Union
+
+from pytest import mark, param, raises
+
+from omegaconf import OmegaConf, UnionNode, ValidationError
+from omegaconf._utils import _get_value
+from tests import Color
+
+
+@mark.parametrize(
+    "union_args",
+    [
+        param((int, float), id="int_float"),
+        param((float, bool), id="float_bool"),
+        param((bool, str), id="bool_str"),
+        param((str, bytes), id="str_bytes"),
+        param((bytes, Color), id="bytes_color"),
+        param((Color, int), id="color_int"),
+    ],
+)
+@mark.parametrize(
+    "input_",
+    [
+        param(123, id="123"),
+        param(10.1, id="10.1"),
+        param(b"binary", id="binary"),
+        param(True, id="true"),
+        param("abc", id="abc"),
+        param("RED", id="red_str"),
+        param("123", id="123_str"),
+        param("10.1", id="10.1_str"),
+        param(Color.RED, id="Color.RED"),
+        param(Path("hello.txt"), id="path"),
+        param(object(), id="object"),
+    ],
+)
+class TestUnionNode:
+    def test_creation(self, input_: Any, union_args: Any) -> None:
+        ref_type = Union[union_args]  # type: ignore
+        legal = type(input_) in union_args
+        if legal:
+            node = UnionNode(input_, ref_type)
+            assert _get_value(node) == input_
+        else:
+            with raises(ValidationError):
+                UnionNode(input_, ref_type)
+
+    def test_set_value(self, input_: Any, union_args: Any) -> None:
+        ref_type = Union[union_args]  # type: ignore
+        legal = type(input_) in union_args
+        node = UnionNode(None, ref_type)
+        if legal:
+            node._set_value(input_)
+            assert _get_value(node) == input_
+        else:
+            with raises(ValidationError):
+                node._set_value(input_)
+
+
+@mark.parametrize(
+    "optional", [param(True, id="optional"), param(False, id="not_optional")]
+)
+@mark.parametrize(
+    "input_",
+    [
+        param("???", id="missing"),
+        param("${interp}", id="interp"),
+        param(None, id="none"),
+    ],
+)
+class TestUnionNodeSpecial:
+    def test_creation_special(self, input_: Any, optional: bool) -> None:
+        if input_ is None and not optional:
+            with raises(ValidationError):
+                UnionNode(input_, Union[int, str], is_optional=optional)
+        else:
+            node = UnionNode(input_, Union[int, str], is_optional=optional)
+            assert node._value() == input_
+
+    def test_set_value_special(self, input_: Any, optional: bool) -> None:
+        node = UnionNode(123, Union[int, str], is_optional=optional)
+        if input_ is None and not optional:
+            with raises(ValidationError):
+                node._set_value(input_)
+        else:
+            node._set_value(input_)
+            assert node._value() == input_
+
+
+def test_get_parent_container() -> None:
+    cfg = OmegaConf.create({"foo": UnionNode(123, Union[int, str]), "bar": "baz"})
+
+    unode = cfg._get_node("foo")
+    nested_node = unode._value()  # type: ignore
+    any_node = cfg._get_node("bar")
+
+    assert unode._get_parent_container() is cfg  # type: ignore
+    assert nested_node._get_parent_container() is cfg
+    assert any_node._get_parent_container() is cfg  # type: ignore


### PR DESCRIPTION
This PR implements support for unions of primitive types (i.e. unions of `int`, `float`, `bool`, `str`, `bytes`, and `None`).

A few notes:
- `Union` can be freely mixed with `Optional` and `None`. For example, all of the following are equivalent:
  - `Optional[Union[int, str]]`
  - `Union[Optional[int], str]`
  - `Union[int, str, None]`
  - `Union[int, str, type(None)]`
- Containers of unions (e.g. `List[Union[int, str]]`, or `Dict[int, Union[str, bytes]]`) *are* supported.
- Unions of containers (e.g. `Union[List[str], Dict[str, str], MyStructuredConfig]`) *are not yet* supported. This will come in a followup PR.

Here is a demo of the API:
```python
from omegaconf import OmegaConf, ValidationError
from dataclasses import dataclass
from typing import Union
from pytest import raises
@dataclass
class Foo:
    u: Union[int, str] = 123

cfg = OmegaConf.create(Foo)
assert cfg.u == 123
cfg.u = "abc"  # ok

with raises(ValidationError):
    cfg.u = b"binary"  # bytes not compatible with union

with raises(ValidationError):
    OmegaConf.create(Foo(1.2))  # float not compatible
```

Implementation Notes:
- `UnionNode` is a "pass-through" node. That means most validation logic is delegated to a child node.
- I've introduced a new method `Container._get_child` which parallels `Container._get_node`. The difference between these methods is that `_get_child` automatically "passes over" Unions. Similarly, I've introduced `Node._get_parent_container()`, which is similar to `Node._get_parent()` except that it passes over union nodes in the parent heirarchy.
```python
from dataclasses import dataclass
from typing import Dict, Union
from omegaconf import MISSING, OmegaConf, StringNode, UnionNode

@dataclass
class Example:
    cfg: Dict[str, Union[str, int]] = MISSING

cfg = OmegaConf.create(Example({"foo": "bar"})).cfg

assert isinstance(cfg._content, dict)
assert isinstance(cfg._content["foo"], UnionNode)
assert isinstance(cfg._content["foo"]._content, StringNode)
assert isinstance(cfg._content["foo"]._content._val, str)
assert cfg._content["foo"]._content._val == "bar"

assert cfg._content["foo"]._metadata.ref_type == Union[int, str]
assert cfg._content["foo"]._content._metadata.ref_type == str

assert cfg._get_node("foo") is cfg._content["foo"]            # UnionNode
assert cfg._get_child("foo") is cfg._content["foo"]._content  # StringNode
```



TODO before merging this
- [x] docs
- [x] serialization test
- [x] Double-check usage of `_get_parent` vs `_get_parent_container` throughout the codebase.
- [x] Double-check usage of `_get_node` vs `_get_child` throughout the codebase.
