### PR TITLE
Add support for 4 merging modes of DictConfig

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -388,6 +388,128 @@ def test_merge(
         with expected:
             merge_function(*configs)
 
+@mark.parametrize(
+    ("config1", "config2", "how", "expected"),
+    [
+        param(
+            {"a": 1, "b": {"b1": 1, "b2": 2}, "d": 5},
+            {"a":2, "b": 3, "c": 4}, 
+            "left",
+            {"a": 2, "b": {"b1": 1, "b2": 2}, "d": 5},
+            id="left"
+        ),
+        param(
+            {"a":2, "b": 3, "c": 4},
+            {"a": 1, "b": {"b1": 1, "b2": 2}, "d": 5},
+            "left-reverse",
+            {"a": 1, "b": 3, "c": 4},
+            id="left-reverse"
+        ),
+        param(
+            {"a": 1, "b": {"b1": 1, "b2": 2}, "d": 5},
+            {"a":2, "b": 3, "c": 4},
+            "inner",
+            {"a": 2},
+            id="inner"
+        ),
+        param(
+            {"a":2, "b": 3, "c": 4},
+            {"a": 1, "b": {"b1": 1, "b2": 2}, "d": 5},
+            "inner",
+            {"a": 1},
+            id="inner-reverse"
+        ),
+        param(
+            {"a": 1, "b": {"b1": 1, "b2": 2}, "d": 5},
+            {"a":2, "b": 3, "c": 4}, 
+            "outer-left",
+            {"a": 2, "b": {"b1": 1, "b2": 2}, "c": 4, "d": 5},
+            id="outer-left"
+        ),
+        param(
+            {"a":2, "b": 3, "c": 4}, 
+            {"a": 1, "b": {"b1": 1, "b2": 2}, "d": 5},
+            "outer-left",
+            {"a": 1, "b": 3, "c": 4, "d": 5},
+            id="outer-left-reverse"
+        ),
+        param(
+            {"a": 1, "b": {"b1": 1, "b2": 2}, "d": 5}, 
+            {"a":2, "b": 3, "c": 4},
+            "outer-right",
+            {"a": 2, "b": 3, "c": 4, "d": 5},
+            id="outer-right"  
+        ),
+        param(
+            {"a":2, "b": 3, "c": 4},
+            {"a": 1, "b": {"b1": 1, "b2": 2}, "d": 5}, 
+            "outer-right",
+            {"a": 1, "b": {"b1": 1, "b2": 2}, "c": 4, "d": 5},
+            id="outer-right-reverse"
+        ),
+        param(
+            {"a1" : 1, "a2": {"b1": 2, "b2": {"c1": 3, "c2": 4}}},
+            {"a2": {"b2": {"c2": 14, "c3": 15}}},
+            "left",
+            {"a1" : 1, "a2": {"b1": 2, "b2": {"c1": 3, "c2": 14}}},
+            id="nested-left"
+        ),
+        param(
+            {"a1": {"b1": 1}},
+            {"a1": {"b2": 2}},
+            "left",
+            {"a1": {"b1": 1}},
+            id="nested-left"
+        ),
+        param(
+            {"a1": {"b1": 1}},
+            {"a2": {"b1": 2}},
+            "left",
+            {"a1": {"b1": 1}},
+            id="nested-left"
+        ),
+        param(
+            {"a1" : 1, "a2": {"b1": 2, "b2": {"c1": 3, "c2": 4}}},
+            {"a2": {"b2": {"c2": 14, "c3": 15}}},
+            "inner",
+            {"a2": {"b2": {"c2": 14}}},
+            id="nested-inner"
+        ),
+        param(
+            {"a1": {"b1": 1}},
+            {"a1": {"b2": 2}},
+            "inner",
+            {"a1": {}},
+            id="nested-inner"
+        ),
+        param(
+            {"a1": {"b1": 1}},
+            {"a2": {"b1": 2}},
+            "inner",
+            {},
+            id="nested-inner"
+        ),
+        param(
+            {"a1" : 1, "a2": {"b1": 2, "b2": {"c1": 3, "c2": 4}}},
+            {"a2": {"b2": {"c2": 14, "c3": 15}}},
+            "outer-left",
+            {"a1" : 1, "a2": {"b1": 2, "b2": {"c1": 3, "c2": 14, "c3": 15}}},
+            id="nested-outer-left"
+        ),
+        param(
+            {"a1" : 1, "a2": {"b1": 2, "b2": {"c1": 3, "c2": 4}}},
+            {"a2": {"b2": {"c2": 14, "c3": 15}}},
+            "outer-left",
+            {"a1" : 1, "a2": {"b1": 2, "b2": {"c1": 3, "c2": 14, "c3": 15}}},
+            id="nested-outer-right"
+        ),
+    ]
+)
+def test_merge_how(config1, config2, how, expected) -> None:
+    config1 = OmegaConf.create(config1)
+    config2 = OmegaConf.create(config2)
+    merge_config = OmegaConf.merge(config1, config2, how=how)
+    assert merge_config == expected
 
 @mark.parametrize(
     "inputs,expected,ref_type,is_optional",
@@ -821,7 +943,7 @@ def test_merge_list_list() -> None:
     b = OmegaConf.create([4, 5, 6])
     a.merge_with(b)
     assert a == b
-
+    
 
 @mark.parametrize("merge_func", [OmegaConf.merge, OmegaConf.unsafe_merge])
 @mark.parametrize(


### PR DESCRIPTION
See the description of [omegaconf/omegaconf.py](https://github.com/luisherrmann/omegaconf/blob/7a26f2297c31c88376d8084f958b31e87b9a3d4a/omegaconf/omegaconf.py#L260-L282). Essentially, the idea is to introduce 4 different modes of merging DictConfigs on their keys, where the keys are to be understood as __nested keys__. E.g. the dictionary
- a1: 1
- a2:
  - b1: 2
  - b2:
    - c1: 3
    - c2: 4

or ```{a1: 1, a2: {b1: 2, b2: {c1: 3, c2: 4}}}``` can be understood as a dictionary mapping nested keys to values as

- a1: 1
- a2.b1: 2
- a2.b2.c1: 3
- a2.b2.c2: 4

The way of merging can be provided through the `how` keyword in `OmegaConf.merge()`, for example as `OmegaConf.merge(config1, config2, how='left')`. 

The four different modes are as follows:

### 1. __left__:   
Only merge on keys from the left DictConfig. E.g.
        ```
        {a1: 1, a2: {b1: 2, b2: 3}}, 
        {a2: {b2: 11, b2: 12}, a3: 13} 
        -> {a1: 1, a2: {b1: 2, b2: 11}}```
### 2. __inner__: 
Only merge on keys from both DictConfigs. E.g.
        ```
        {a1: 1, a2: {b1: 2, b2: 3}},
        {a2: {b2: 11, b2: 12}, a3: 13} 
        -> {a2: {b2: 11}}```
### 3. __outer-left__: 
Merge on keys from both DictConfigs. E.g.
        ```
        {a1: 1, a2: {b1: 2, b2: 3}},
        {a2: {b2: 11, b2: 12}, a3: 13} 
        -> {a1: 1, a2: {b1: 2, b2: 11, b3: }}```
        If nesting levels conflict, use keys on the left. E.g.
        ```{a1: {b1: 9}}, {a1: {b1: {c1: 21}}, a2: 22}
        -> {a1: {b1: 9}, a2: 22}```
### 4. __outer-right__: 
Merge on keys from both DictConfigs (see outer-left).
If nesting levels conflict, use keys on the right. E.g.
        ```{a1: {b1: 9}}, {a1: {b1: {c1: 21}}, a2: 22}
        -> {a1: {b1: {c1: 21}}, a2: 22}```

The current default is `"outer-right"`, which corresponds to the current Omegaconf merging behavior.
