### PR TITLE
remove support for OmegaConf.is_none()

### DIFF
--- a/news/547.api_change
+++ b/news/547.api_change
@@ -1,0 +1,1 @@
+Removed support for `OmegaConf.is_none(cfg, "key")`.  Please use `cfg.key is None` instead.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -32,7 +32,6 @@ from . import DictConfig, DictKeyType, ListConfig
 from ._utils import (
     _DEFAULT_MARKER_,
     _ensure_container,
-    _is_none,
     format_and_raise,
     get_dict_key_value_types,
     get_list_element_type,
@@ -626,20 +625,6 @@ class OmegaConf:
             return obj._is_optional()
         else:
             return True
-
-    # DEPRECATED: remove in 2.2
-    @staticmethod
-    def is_none(obj: Any, key: Optional[Union[int, DictKeyType]] = None) -> bool:
-        warnings.warn(
-            "`OmegaConf.is_none()` is deprecated, see https://github.com/omry/omegaconf/issues/547",
-            stacklevel=2,
-        )
-
-        if key is not None:
-            assert isinstance(obj, Container)
-            obj = obj._get_node(key)
-
-        return _is_none(obj, resolve=True, throw_on_resolution_failure=False)
 
     @staticmethod
     def is_interpolation(node: Any, key: Optional[Union[int, str]] = None) -> bool:

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 from typing import Any, Optional
 
-from pytest import mark, raises, warns
+from pytest import mark, raises
 
 from omegaconf import (
     BooleanNode,
@@ -49,8 +49,6 @@ def verify(
         assert cfg.get(key) == exp
 
     assert OmegaConf.is_missing(cfg, key) == missing
-    with warns(UserWarning):
-        assert OmegaConf.is_none(cfg, key) == none_public
     assert _is_optional(cfg, key) == opt
     assert OmegaConf.is_interpolation(cfg, key) == inter
 

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -301,18 +301,10 @@ def test_is_none(fac: Any, is_none: bool) -> None:
 )
 def test_is_none_interpolation(cfg: Any, key: str, is_none: bool) -> None:
     cfg = OmegaConf.create(cfg)
-    with warns(UserWarning):
-        assert OmegaConf.is_none(cfg, key) == is_none
     check = _is_none(
         cfg._get_node(key), resolve=True, throw_on_resolution_failure=False
     )
     assert check == is_none
-
-
-def test_is_none_invalid_node() -> None:
-    cfg = OmegaConf.create({})
-    with warns(UserWarning):
-        assert OmegaConf.is_none(cfg, "invalid")
 
 
 @mark.parametrize(


### PR DESCRIPTION
Was slated for removal in 2.2

The deprecation was handled in issue #547
This addresses issue #821