### PR TITLE
remove support for OmegaConf.is_optional()

### DIFF
--- a/news/698.api_change
+++ b/news/698.api_change
@@ -1,0 +1,1 @@
+Removed support for `OmegaConf.is_optional()`.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -594,21 +594,6 @@ class OmegaConf:
         except (UnsupportedInterpolationType, KeyError, AttributeError):
             return False
 
-    # DEPRECATED: remove in 2.2
-    @staticmethod
-    def is_optional(obj: Any, key: Optional[Union[int, str]] = None) -> bool:
-        warnings.warn(
-            "`OmegaConf.is_optional()` is deprecated, see https://github.com/omry/omegaconf/issues/698",
-            stacklevel=2,
-        )
-        if key is not None:
-            assert isinstance(obj, Container)
-            obj = obj._get_node(key)
-        if isinstance(obj, Node):
-            return obj._is_optional()
-        else:
-            return True
-
     @staticmethod
     def is_interpolation(node: Any, key: Optional[Union[int, str]] = None) -> bool:
         if key is not None:

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -1,10 +1,9 @@
 import pathlib
 import platform
-import re
 from pathlib import Path
 from typing import Any
 
-from pytest import mark, param, raises, warns
+from pytest import mark, param, raises
 
 from omegaconf import (
     MISSING,
@@ -225,21 +224,6 @@ def test_is_list(cfg: Any, expected: bool) -> None:
 )
 def test_is_dict(cfg: Any, expected: bool) -> None:
     assert OmegaConf.is_dict(cfg) == expected
-
-
-def test_is_optional_deprecation() -> None:
-    with warns(UserWarning, match=re.escape("`OmegaConf.is_optional()` is deprecated")):
-        OmegaConf.is_optional("xxx")
-
-
-def test_coverage_for_deprecated_OmegaConf_is_optional() -> None:
-    cfg = OmegaConf.create({"node": 123})
-    with warns(UserWarning):
-        assert OmegaConf.is_optional(cfg)
-    with warns(UserWarning):
-        assert OmegaConf.is_optional(cfg, "node")
-    with warns(UserWarning):
-        assert OmegaConf.is_optional("not_a_node")
 
 
 @mark.parametrize("is_none", [True, False])


### PR DESCRIPTION
Was slated for removal in 2.2

The deprecation was handled in issue #698
This addresses issue #821