### PR TITLE
remove support for OmegaConf.get_resolver()

### DIFF
--- a/news/608.api_change
+++ b/news/608.api_change
@@ -1,0 +1,1 @@
+Removed `OmegaConf.get_resolver()`.  Please use `OmegaConf.has_resolver()` instead.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -449,22 +449,6 @@ class OmegaConf:
     def has_resolver(cls, name: str) -> bool:
         return cls._get_resolver(name) is not None
 
-    # DEPRECATED: remove in 2.2
-    @classmethod
-    def get_resolver(
-        cls,
-        name: str,
-    ) -> Optional[
-        Callable[[Container, Container, Node, Tuple[Any, ...], Tuple[str, ...]], Any]
-    ]:
-        warnings.warn(
-            "`OmegaConf.get_resolver()` is deprecated (see https://github.com/omry/omegaconf/issues/608)",
-            UserWarning,
-            stacklevel=2,
-        )
-
-        return cls._get_resolver(name)
-
     # noinspection PyProtectedMember
     @staticmethod
     def clear_resolvers() -> None:

--- a/tests/interpolation/test_custom_resolvers.py
+++ b/tests/interpolation/test_custom_resolvers.py
@@ -100,13 +100,6 @@ def test_clear_resolvers_and_has_resolver_legacy(restore_resolvers: Any) -> None
     assert not OmegaConf.has_resolver("foo")
 
 
-def test_get_resolver_deprecation() -> None:
-    with warns(
-        UserWarning, match=re.escape("https://github.com/omry/omegaconf/issues/608")
-    ):
-        assert OmegaConf.get_resolver("foo") is None
-
-
 def test_register_resolver_1(restore_resolvers: Any) -> None:
     OmegaConf.register_new_resolver("plus_10", lambda x: x + 10)
     c = OmegaConf.create(


### PR DESCRIPTION
Users should use OmegaConf.has_resolver() instead.

Was slated for removal in 2.2

The deprecation was handled in issue #608
This addresses issue #821