### PR TITLE
2.1_branch: Fix oc.dict.values behavior for relative dotpaths

### DIFF
--- a/omegaconf/resolvers/oc/dict.py
+++ b/omegaconf/resolvers/oc/dict.py
@@ -35,6 +35,8 @@ def values(key: str, _root_: BaseContainer, _parent_: Container) -> ListConfig:
     assert isinstance(content, dict)
 
     ret = ListConfig([])
+    if key.startswith("."):
+        key = f".{key}"  # extra dot to compensate for extra level of nesting within ret ListConfig
     for k in content:
         ref_node = AnyNode(f"${{{key}.{k}}}")
         ret.append(ref_node)

--- a/tests/interpolation/built_in_resolvers/test_oc_dict.py
+++ b/tests/interpolation/built_in_resolvers/test_oc_dict.py
@@ -261,6 +261,36 @@ def test_readonly_parent(cfg: Any, expected: Any) -> None:
     ("cfg", "expected"),
     [
         param(
+            {"outer": {"x": "${oc.dict.values:.y}", "y": {"a": 1}}},
+            [1],
+            id="values_inter",
+        ),
+        param(
+            {"outer": {"x": "${oc.dict.keys:.y}", "y": {"a": 1}}},
+            ["a"],
+            id="keys_inter",
+        ),
+        param(
+            {"outer": {"x": "${oc.dict.values:..y}"}, "y": {"a": 1}},
+            [1],
+            id="parent_values_inter",
+        ),
+        param(
+            {"outer": {"x": "${oc.dict.keys:..y}"}, "y": {"a": 1}},
+            ["a"],
+            id="parent_keys_inter",
+        ),
+    ],
+)
+def test_relative_path(cfg: Any, expected: Any) -> None:
+    cfg = OmegaConf.create(cfg)
+    assert cfg.outer.x == expected
+
+
+@mark.parametrize(
+    ("cfg", "expected"),
+    [
+        param(
             {"x": "${sum:${oc.dict.values:y}}", "y": {"one": 1, "two": 2}},
             3,
             id="values",


### PR DESCRIPTION
Cherry picked from #946 to `2.1_branch`.