### PR TITLE
Add CLI param parsing for missed formats

### DIFF
--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -543,3 +543,9 @@ class InterpolationResultNode(ValueNode):
     def _is_interpolation(self) -> bool:
         # The result of an interpolation cannot be itself an interpolation.
         return False
+
+
+class CliArgType(Enum):
+    DEFAULT = "DEFAULT"
+    POSIX_SPACE = "POSIX_SPACE"
+    POSIX_EQUAL = "POSIX_EQUAL"

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -71,6 +71,7 @@ from .nodes import (
     PathNode,
     StringNode,
     ValueNode,
+    CliArgType,
 )
 
 MISSING: Any = "???"
@@ -226,10 +227,18 @@ class OmegaConf:
             raise TypeError("Unexpected file type")
 
     @staticmethod
-    def from_cli(args_list: Optional[List[str]] = None) -> DictConfig:
+    def from_cli(args_list: Optional[List[str]] = None, arg_type: CliArgType = CliArgType.DEFAULT) -> DictConfig:
         if args_list is None:
             # Skip program name
             args_list = sys.argv[1:]
+
+        if arg_type == CliArgType.POSIX_EQUAL:
+            args_list = [param.lstrip("-") for param in args_list]
+        elif arg_type == CliArgType.POSIX_SPACE:
+            # chunk by pairs
+            iterator = iter(args_list)
+            args_list = [f"{key.lstrip('-')}={value}" for key, value in zip(iterator, iterator)]
+
         return OmegaConf.from_dotlist(args_list)
 
     @staticmethod

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -12,6 +12,7 @@ from pytest import mark, param, raises
 
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from omegaconf.errors import UnsupportedValueType, ValidationError
+from omegaconf.nodes import CliArgType
 from tests import (
     ConcretePlugin,
     DictOfAny,
@@ -196,6 +197,16 @@ def test_create_from_cli() -> None:
 def test_cli_passing() -> None:
     args_list = ["a=1", "b.c=2"]
     c = OmegaConf.from_cli(args_list)
+    assert {"a": 1, "b": {"c": 2}} == c
+
+
+def test_create_from_cli_posix() -> None:
+    sys.argv = ["program.py", "--a=1", "--b.c=2"]
+    c = OmegaConf.from_cli(arg_type=CliArgType.POSIX_EQUAL)
+    assert {"a": 1, "b": {"c": 2}} == c
+
+    sys.argv = ["program.py", "--a", "1", "--b.c", "2"]
+    c = OmegaConf.from_cli(arg_type=CliArgType.POSIX_SPACE)
     assert {"a": 1, "b": {"c": 2}} == c
 
 


### PR DESCRIPTION
I encountered the problem when use `OmegaConf.from_cli()` for params in following format:
`python script.py --param1 value 1  --param2 value2`.

The purpose of this PR is to cover more variants of passed CLI arguments. 