### PR TITLE
ensure atomic updates for ListConfig sliced assignment (#950)

### DIFF
--- a/news/950.bugfix
+++ b/news/950.bugfix
@@ -1,0 +1,1 @@
+ListConfig sliced assignment now avoids partial updates upon error

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -265,20 +265,26 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                     curr_index = self_indices[0] - 1
                     val_i = -1
 
+                work_copy = self.copy()  # For atomicity manipulate a copy
+
                 # Delete and optionally replace non empty slices
                 only_removed = 0
                 for val_i, i in enumerate(indexes):
                     curr_index = i - only_removed
-                    del self[curr_index]
+                    del work_copy[curr_index]
                     if val_i < len(value):
-                        self.insert(curr_index, value[val_i])
+                        work_copy.insert(curr_index, value[val_i])
                     else:
                         only_removed += 1
 
                 # Insert any remaining input items
                 for val_i in range(val_i + 1, len(value)):
                     curr_index += 1
-                    self.insert(curr_index, value[val_i])
+                    work_copy.insert(curr_index, value[val_i])
+
+                # Reinitialize self with work_copy
+                self.clear()
+                self.extend(work_copy)
             else:
                 self._set_at_index(index, value)
         except Exception as e:

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -908,6 +908,13 @@ def test_getitem_slice(sli: slice) -> None:
         ),
         param(
             ["a", "b", "c", "d"],
+            slice(1, 3),
+            [object()],
+            raises(UnsupportedValueType),
+            id="partially-valid-input",
+        ),
+        param(
+            ["a", "b", "c", "d"],
             slice(1, 3, 1),
             ["x", "y", "z"],
             ["a", "x", "y", "z", "d"],
@@ -969,8 +976,15 @@ def test_setitem_slice(
         cfg[idx] = value
         assert cfg == expected
     else:
+        expected_exception: Any = expected.expected_exception
+        if type(constructor) == type(list) and issubclass(
+            expected_exception, UnsupportedValueType
+        ):
+            return  # standard list() can accept object() so skip
+        orig_cfg = cfg[:]
         with expected:
             cfg[idx] = value
+        assert cfg == orig_cfg
 
 
 @mark.parametrize(


### PR DESCRIPTION
* omegaconf/listconfig.py (__setitem__): Operate on a copy
so any changes due to validation errors etc. are discarded.
Fixes issue #950