### PR TITLE
type hints: treat dict/Dict/tuple/Tuple/list/List uniformly

### DIFF
--- a/news/973.api_change
+++ b/news/973.api_change
@@ -1,0 +1,1 @@
+In structured config type hints, OmegaConf now treats `tuple` as equivalent to `typing.Tuple`, and likewise for `dict`/`Dict` and `list`/`List`.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -254,6 +254,10 @@ def _resolve_forward(type_: Type[Any], module: str) -> Type[Any]:
             if et is not None:
                 et = _resolve_forward(et, module=module)
             return List[et]  # type: ignore
+        if is_tuple_annotation(type_):
+            its = get_tuple_item_types(type_)
+            its = tuple(_resolve_forward(it, module=module) for it in its)
+            return Tuple[its]  # type: ignore
 
         return type_
 
@@ -614,6 +618,8 @@ def is_primitive_dict(obj: Any) -> bool:
 
 
 def is_dict_annotation(type_: Any) -> bool:
+    if type_ in (dict, Dict):
+        return True
     origin = getattr(type_, "__origin__", None)
     # type_dict is a bit hard to detect.
     # this support is tentative, if it eventually causes issues in other areas it may be dropped.
@@ -626,6 +632,8 @@ def is_dict_annotation(type_: Any) -> bool:
 
 
 def is_list_annotation(type_: Any) -> bool:
+    if type_ in (list, List):
+        return True
     origin = getattr(type_, "__origin__", None)
     if sys.version_info < (3, 7, 0):
         return origin is List or type_ is List  # pragma: no cover
@@ -634,6 +642,8 @@ def is_list_annotation(type_: Any) -> bool:
 
 
 def is_tuple_annotation(type_: Any) -> bool:
+    if type_ in (tuple, Tuple):
+        return True
     origin = getattr(type_, "__origin__", None)
     if sys.version_info < (3, 7, 0):
         return origin is Tuple or type_ is Tuple  # pragma: no cover
@@ -668,6 +678,14 @@ def get_list_element_type(ref_type: Optional[Type[Any]]) -> Any:
     else:
         element_type = Any
     return element_type
+
+
+def get_tuple_item_types(ref_type: Type[Any]) -> Tuple[Any, ...]:
+    args = getattr(ref_type, "__args__", None)
+    if args in (None, ()):
+        args = (Any, ...)
+    assert isinstance(args, tuple)
+    return args
 
 
 def get_dict_key_value_types(ref_type: Any) -> Tuple[Any, Any]:

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -200,13 +200,11 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             raise ValidationError(
                 f"Cannot assign {type_str(value_type)} to {type_str(target_type)}"
             )
-        validation_error = (
-            target_type is not None
-            and value_type is not None
-            and not issubclass(value_type, target_type)
-        )
-        if validation_error:
-            self._raise_invalid_value(value, value_type, target_type)
+
+        if target_type is not None and value_type is not None:
+            origin = getattr(target_type, "__origin__", target_type)
+            if not issubclass(value_type, origin):
+                self._raise_invalid_value(value, value_type, target_type)
 
     def _validate_merge(self, value: Any) -> None:
         from omegaconf import OmegaConf

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -784,3 +784,23 @@ class UnionsOfPrimitveTypes:
             ouis: Optional[int | str]
             uisn: int | str | None = None
             uis_with_default: int | str = 123
+
+
+if sys.version_info >= (3, 9):
+
+    @attr.s(auto_attribs=True)
+    class SupportPEP585:
+        """
+        PEP 585 – Type Hinting Generics In Standard Collections
+        https://peps.python.org/pep-0585/
+
+        This means lower-case dict/list/tuple annotations
+        can be used instad of uppercase Dict/List/Tuple.
+        """
+
+        dict_: dict[int, str] = {123: "abc"}
+        list_: list[int] = [123]
+        tuple_: tuple[int] = (123,)
+        dict_no_subscript: dict = {123: "abc"}
+        list_no_subscript: list = [123]
+        tuple_no_subscript: tuple = (123,)

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -821,3 +821,23 @@ class UnionsOfPrimitveTypes:
             ouis: Optional[int | str]
             uisn: int | str | None = None
             uis_with_default: int | str = 123
+
+
+if sys.version_info >= (3, 9):
+
+    @dataclass
+    class SupportPEP585:
+        """
+        PEP 585 – Type Hinting Generics In Standard Collections
+        https://peps.python.org/pep-0585/
+
+        This means lower-case dict/list/tuple annotations
+        can be used instad of uppercase Dict/List/Tuple.
+        """
+
+        dict_: dict[int, str] = field(default_factory=lambda: {123: "abc"})
+        list_: list[int] = field(default_factory=lambda: [123])
+        tuple_: tuple[int] = (123,)
+        dict_no_subscript: dict = field(default_factory=lambda: {123: "abc"})
+        list_no_subscript: list = field(default_factory=lambda: [123])
+        tuple_no_subscript: tuple = (123,)

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -5,7 +5,7 @@ import re
 import sys
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from _pytest.python_api import RaisesContext
 from pytest import fixture, mark, param, raises
@@ -2274,6 +2274,17 @@ class TestUnionsOfPrimitiveTypes:
         assert _utils.get_type_hint(cfg, "uis_with_default") == Union[int, str]
         assert cfg.uisn is None
         assert cfg.uis_with_default == 123
+
+    @mark.skipif(sys.version_info < (3, 9), reason="requires Python 3.9 or newer")
+    def test_support_pep_585(self, module: Any) -> None:
+        class_ = module.SupportPEP585
+        cfg = OmegaConf.structured(class_)
+        assert _utils.get_type_hint(cfg, "dict_") == Dict[int, str]
+        assert _utils.get_type_hint(cfg, "list_") == List[int]
+        assert _utils.get_type_hint(cfg, "tuple_") == Tuple[int]
+        assert _utils.get_type_hint(cfg, "dict_no_subscript") == Dict[Any, Any]
+        assert _utils.get_type_hint(cfg, "list_no_subscript") == List[Any]
+        assert _utils.get_type_hint(cfg, "tuple_no_subscript") == Tuple[Any, ...]
 
     def test_assign_path_to_string_typed_field(self, module: Any) -> None:
         cfg = OmegaConf.create(module.StringConfig)

--- a/tests/test_nested_containers.py
+++ b/tests/test_nested_containers.py
@@ -807,7 +807,7 @@ def test_dict_assign_to_container_typed_element_special(
         param(
             DictConfig({"key": {"key2": 123}}, element_type=Dict[str, int]),
             [],
-            r"(Cannot assign list to Dict\[str, int\])"
+            r"(Invalid type assigned: list is not a subclass of Dict\[str, int\]\. value: \[\])"
             + r"|('ListConfig' is incompatible with type hint 'typing.Dict\[str, int\]')",
             id="assign_list_to_dict[str_int]",
         ),


### PR DESCRIPTION
This closes #973.
The root cause of #973 was that `tuple` was being treated differently from `Tuple`.

This PR is a move towards treating `tuple` and `Tuple` in the same way when the appear in type annotations, and likewise for `dict`/`Dict` and `list`/`List`.