### PR TITLE
use typing.get_type_hints for attr classes

### DIFF
--- a/news/963.bugfix
+++ b/news/963.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that caused OmegaConf to crash when processing attr classes whose field annotations contained forward-references.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -9,7 +9,17 @@ import warnings
 from contextlib import contextmanager
 from enum import Enum
 from textwrap import dedent
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    get_type_hints,
+)
 
 import yaml
 
@@ -326,9 +336,10 @@ def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, A
     obj_type = obj if is_type else type(obj)
     dummy_parent = OmegaConf.create({}, flags=flags)
     dummy_parent._metadata.object_type = obj_type
+    resolved_hints = get_type_hints(obj_type)
 
     for name, attrib in attr.fields_dict(obj_type).items():
-        is_optional, type_ = _resolve_optional(attrib.type)
+        is_optional, type_ = _resolve_optional(resolved_hints[name])
         type_ = _resolve_forward(type_, obj.__module__)
         if not is_type:
             value = getattr(obj, name)
@@ -368,8 +379,6 @@ def get_dataclass_init_field_names(obj: Any) -> List[str]:
 def get_dataclass_data(
     obj: Any, allow_objects: Optional[bool] = None
 ) -> Dict[str, Any]:
-    from typing import get_type_hints
-
     from omegaconf.omegaconf import MISSING, OmegaConf, _maybe_wrap
 
     flags = {"allow_objects": allow_objects} if allow_objects is not None else {}

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -804,3 +804,17 @@ if sys.version_info >= (3, 9):
         dict_no_subscript: dict = {123: "abc"}
         list_no_subscript: list = [123]
         tuple_no_subscript: tuple = (123,)
+
+
+@attr.s(auto_attribs=True)
+class HasForwardRef:
+    @attr.s(auto_attribs=True)
+    class CA:
+        x: int = 3
+
+    @attr.s(auto_attribs=True)
+    class CB:
+        sub: "HasForwardRef.CA"
+
+    a: CA
+    b: CB

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -841,3 +841,17 @@ if sys.version_info >= (3, 9):
         dict_no_subscript: dict = field(default_factory=lambda: {123: "abc"})
         list_no_subscript: list = field(default_factory=lambda: [123])
         tuple_no_subscript: tuple = (123,)
+
+
+@dataclass
+class HasForwardRef:
+    @dataclass
+    class CA:
+        x: int = 3
+
+    @dataclass
+    class CB:
+        sub: "HasForwardRef.CA"
+
+    a: CA
+    b: CB

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1010,6 +1010,12 @@ def test_frozen(module: Any) -> None:
     validate_frozen_impl(OmegaConf.structured(FrozenClass()))
 
 
+def test_forward_ref(module: Any) -> None:
+    C = module.HasForwardRef
+    obj = C(a=C.CA(), b=C.CB(C.CA(x=33)))
+    OmegaConf.create(obj)
+
+
 class TestDictSubclass:
     def test_str2str(self, module: Any) -> None:
         with warns_dict_subclass_deprecated(module.DictSubclass.Str2Str):


### PR DESCRIPTION
This PR closes #963.

DictConfigs based on Attr classes now support forward references (whereas before only dataclasses supported forward references).