### PR TITLE
skip structured conf fields with "omegaconf_ignore" metadata

### DIFF
--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -595,3 +595,25 @@ This will cause a validation error when merging the config from the file with th
     >>> with raises(ValidationError):
     ...     OmegaConf.merge(schema, conf)
 
+
+Using Metadata to Ignore Fields
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+OmegaConf inspects the metadata of dataclasss / attr class fields,
+ignoring any fields where ``metadata["omegaconf_ignore"]`` is ``True``.
+When defining a dataclass or attr class, fields can be given metadata by passing the
+``metadata`` keyword argument to the ``dataclasses.field`` function or the ``attrs.field`` function:
+
+.. doctest::
+
+    >>> @dataclass
+    ... class HasIgnoreMetadata:
+    ...     normal_field: int = 1
+    ...     field_ignored: int = field(default=2, metadata={"omegaconf_ignore": True})
+    ...     field_not_ignored: int = field(default=3, metadata={"omegaconf_ignore": False})
+    ...
+    >>> cfg = OmegaConf.create(HasIgnoreMetadata)
+    >>> cfg
+    {'normal_field': 1, 'field_not_ignored': 3}
+
+In the above example, ``field_ignored`` is ignored by OmegaConf.

--- a/news/984.feature
+++ b/news/984.feature
@@ -1,0 +1,1 @@
+OmegaConf now inspects the metadata of structured config fields and ignores fields where `metadata["omegaconf_ignore"]` is `True`.

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -761,7 +761,16 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             else:
                 non_init_field_items[k] = v
 
-        result = object_type(**init_field_items)
+        try:
+            result = object_type(**init_field_items)
+        except TypeError as exc:
+            self._format_and_raise(
+                key=None,
+                value=None,
+                cause=exc,
+                msg="Could not create instance of `$OBJECT_TYPE`: " + str(exc),
+            )
+
         for k, v in non_init_field_items.items():
             setattr(result, k, v)
         return result

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -828,3 +828,16 @@ class HasBadAnnotation1:
 @attr.s(auto_attribs=True)
 class HasBadAnnotation2:
     data: object()  # type: ignore
+
+
+@attr.s(auto_attribs=True)
+class HasIgnoreMetadataRequired:
+    ignore: int = attr.field(metadata={"omegaconf_ignore": True})
+    no_ignore: int = attr.field(metadata={"omegaconf_ignore": False})
+
+
+@attr.s(auto_attribs=True)
+class HasIgnoreMetadataWithDefault:
+
+    ignore: int = attr.field(default=1, metadata={"omegaconf_ignore": True})
+    no_ignore: int = attr.field(default=2, metadata={"omegaconf_ignore": False})

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -865,3 +865,15 @@ class HasBadAnnotation1:
 @dataclass
 class HasBadAnnotation2:
     data: object()  # type: ignore
+
+
+@dataclass
+class HasIgnoreMetadataRequired:
+    ignore: int = field(metadata={"omegaconf_ignore": True})
+    no_ignore: int = field(metadata={"omegaconf_ignore": False})
+
+
+@dataclass
+class HasIgnoreMetadataWithDefault:
+    ignore: int = field(default=1, metadata={"omegaconf_ignore": True})
+    no_ignore: int = field(default=2, metadata={"omegaconf_ignore": False})

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1348,6 +1348,22 @@ class TestConfigs2:
         with raises(ValidationError):
             c3.missing.append("xx")
 
+    def test_ignore_metadata_class_with_required_args(self, module: Any) -> None:
+        cfg = OmegaConf.create(module.HasIgnoreMetadataRequired)
+        assert cfg == {"no_ignore": "???"}
+
+    def test_ignore_metadata_instance_with_required_args(self, module: Any) -> None:
+        cfg = OmegaConf.create(module.HasIgnoreMetadataRequired(3, 4))
+        assert cfg == {"no_ignore": 4}
+
+    def test_ignore_metadata_class_with_default_args(self, module: Any) -> None:
+        cfg = OmegaConf.create(module.HasIgnoreMetadataWithDefault)
+        assert cfg == {"no_ignore": 2}
+
+    def test_ignore_metadata_instance_with_default_args(self, module: Any) -> None:
+        cfg = OmegaConf.create(module.HasIgnoreMetadataWithDefault(3, 4))
+        assert cfg == {"no_ignore": 4}
+
 
 class TestStructredConfigInheritance:
     def test_leaf_node_inheritance(self, module: Any) -> None:


### PR DESCRIPTION
This PR implements the `"omegaconf_ignore"` metadata inspection proposed in #984.

TODO:
- [x] docs
- [x] integration test with `OmegaConf.to_object`