### PR TITLE
Improve handling of illegal type annotations

### DIFF
--- a/news/991.bugfix
+++ b/news/991.bugfix
@@ -1,0 +1,1 @@
+Improve error message when certain illegal type annotations (such as `typing.Sequence`) are used in structured configs.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -907,29 +907,16 @@ def type_str(t: Any, include_module_name: bool = False) -> str:
     if t is ...:
         return "..."
 
-    if sys.version_info < (3, 7, 0):  # pragma: no cover
-        # Python 3.6
-        if hasattr(t, "__name__"):
-            name = str(t.__name__)
-        else:
-            if t.__origin__ is not None:
-                name = type_str(t.__origin__)
-            else:
-                name = str(t)
-                if name.startswith("typing."):
-                    name = name[len("typing.") :]
-    else:  # pragma: no cover
-        # Python >= 3.7
-        if hasattr(t, "__name__"):
-            name = str(t.__name__)
-        else:
-            if t._name is None:
-                if t.__origin__ is not None:
-                    name = type_str(
-                        t.__origin__, include_module_name=include_module_name
-                    )
-            else:
-                name = str(t._name)
+    if hasattr(t, "__name__"):
+        name = str(t.__name__)
+    elif getattr(t, "_name", None) is not None:  # pragma: no cover
+        name = str(t._name)
+    elif getattr(t, "__origin__", None) is not None:  # pragma: no cover
+        name = type_str(t.__origin__)
+    else:
+        name = str(t)
+        if name.startswith("typing."):  # pragma: no cover
+            name = name[len("typing.") :]
 
     args = getattr(t, "__args__", None)
     if args is not None:

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1050,7 +1050,24 @@ def _node_wrap(
         node = PathNode(value=value, key=key, parent=parent, is_optional=is_optional)
     else:
         if parent is not None and parent._get_flag("allow_objects") is True:
-            node = AnyNode(value=value, key=key, parent=parent)
+            if type(value) in (list, tuple):
+                node = ListConfig(
+                    content=value,
+                    key=key,
+                    parent=parent,
+                    ref_type=ref_type,
+                    is_optional=is_optional,
+                )
+            elif is_primitive_dict(value):
+                node = DictConfig(
+                    content=value,
+                    key=key,
+                    parent=parent,
+                    ref_type=ref_type,
+                    is_optional=is_optional,
+                )
+            else:
+                node = AnyNode(value=value, key=key, parent=parent)
         else:
             raise ValidationError(f"Unexpected type annotation: {type_str(ref_type)}")
     return node

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1028,7 +1028,7 @@ def _node_wrap(
         )
     elif ref_type == Any or ref_type is None:
         node = AnyNode(value=value, key=key, parent=parent)
-    elif issubclass(ref_type, Enum):
+    elif isinstance(ref_type, type) and issubclass(ref_type, Enum):
         node = EnumNode(
             enum_type=ref_type,
             value=value,
@@ -1052,7 +1052,7 @@ def _node_wrap(
         if parent is not None and parent._get_flag("allow_objects") is True:
             node = AnyNode(value=value, key=key, parent=parent)
         else:
-            raise ValidationError(f"Unexpected object type: {type_str(ref_type)}")
+            raise ValidationError(f"Unexpected type annotation: {type_str(ref_type)}")
     return node
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, Generic, List, NamedTuple, Optional, Tuple, TypeVar, Union
 
 import attr
 from pytest import warns
@@ -17,6 +17,13 @@ class IllegalType:
         if isinstance(other, IllegalType):
             return True
         return False
+
+
+T = TypeVar("T")
+
+
+class IllegalTypeGeneric(Generic[T]):
+    ...
 
 
 class NonCopyableIllegalType:

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -818,3 +818,13 @@ class HasForwardRef:
 
     a: CA
     b: CB
+
+
+@attr.s(auto_attribs=True)
+class HasBadAnnotation1:
+    data: object
+
+
+@attr.s(auto_attribs=True)
+class HasBadAnnotation2:
+    data: object()  # type: ignore

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -855,3 +855,13 @@ class HasForwardRef:
 
     a: CA
     b: CB
+
+
+@dataclass
+class HasBadAnnotation1:
+    data: object
+
+
+@dataclass
+class HasBadAnnotation2:
+    data: object()  # type: ignore

--- a/tests/structured_conf/test_structured_basic.py
+++ b/tests/structured_conf/test_structured_basic.py
@@ -38,7 +38,7 @@ class TestStructured:
         def test_error_on_non_structured_nested_config_class(self, module: Any) -> None:
             with raises(
                 ValidationError,
-                match=re.escape("Unexpected object type: NotStructuredConfig"),
+                match=re.escape("Unexpected type annotation: NotStructuredConfig"),
             ):
                 OmegaConf.structured(module.StructuredWithInvalidField)
 

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -981,6 +981,17 @@ class TestConfigs:
         assert cfg.list == [1, 2]
         assert cfg.opt_list is None
 
+    def test_has_bad_annotation1(self, module: Any) -> None:
+        with raises(ValidationError, match="Unexpected type annotation: object"):
+            OmegaConf.structured(module.HasBadAnnotation1)
+
+    def test_has_bad_annotation2(self, module: Any) -> None:
+        with raises(
+            ValidationError,
+            match="Unexpected type annotation: <object object at 0x[a-f0-9]*>",
+        ):
+            OmegaConf.structured(module.HasBadAnnotation2)
+
 
 def validate_frozen_impl(conf: DictConfig) -> None:
     with raises(ReadonlyConfigError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,6 +48,7 @@ from tests import (
     Dataframe,
     DictSubclass,
     IllegalType,
+    IllegalTypeGeneric,
     ListSubclass,
     Plugin,
     Shape,
@@ -636,6 +637,12 @@ def test_is_primitive_type_annotation(type_: Any, is_primitive: bool) -> None:
         (Union[str, int, Color], True, "Union[str, int, tests.Color]"),
         (Union[int], False, "int"),
         (Union[int], True, "int"),
+        (IllegalType, False, "IllegalType"),
+        (IllegalType, True, "tests.IllegalType"),
+        (IllegalTypeGeneric, False, "IllegalTypeGeneric"),
+        (IllegalTypeGeneric, True, "tests.IllegalTypeGeneric"),
+        (IllegalTypeGeneric[int], False, "IllegalTypeGeneric[int]"),
+        (IllegalTypeGeneric[int], True, "tests.IllegalTypeGeneric[int]"),
     ],
 )
 def test_type_str(
@@ -652,6 +659,17 @@ def test_type_str(
         )
 
 
+@mark.parametrize(
+    "type_, expected",
+    [
+        (object(), r"<object object at 0x[a-f0-9]*>"),
+        (IllegalType(), "<tests.IllegalType object at 0x[a-f0-9]*>"),
+    ],
+)
+def test_type_str_regex(type_: Any, expected: str) -> None:
+    assert re.match(expected, _utils.type_str(type_))
+
+
 def test_type_str_ellipsis() -> None:
     assert _utils.type_str(...) == "..."
 
@@ -663,6 +681,11 @@ def test_type_str_ellipsis() -> None:
         param(NoneType, "NoneType", id="nonetype"),
         (Union[float, bool, None], "Optional[Union[float, bool]]"),
         (Union[float, bool, NoneType], "Optional[Union[float, bool]]"),
+        (object, "object"),
+        (
+            Optional[object],  # python3.6 treats `Optional[object]` as `object`
+            "Optional[object]" if sys.version_info >= (3, 7) else "object",
+        ),
     ],
 )
 def test_type_str_nonetype(type_: Any, expected: str) -> None:


### PR DESCRIPTION
Three commits:
- [make _utils.type_str robust against unsupported types](https://github.com/omry/omegaconf/pull/993/commits/8749a7f43179f828ee71286dc18c959ddd9d5b2a)
- [Handle unsupported type annotation gracefully](https://github.com/omry/omegaconf/pull/993/commits/2098b51132f268af4c4dc94c6b087173bdf066fa)
- [revert allow_objects behavior for unsupported annotations](https://github.com/omry/omegaconf/pull/993/commits/ae9a0d32463b4294b4d40af93046931ea93f7fbf)


The second commit closes #991. The third commit reverts a regression in behavior for the `allow_objects` flag (details below).


## Closing #991: Improved err message for certain unsupported type annotations

Running the following example script, here is a comparison of before vs after this diff:
```python
# tmp.py
from dataclasses import dataclass
from typing import Sequence
from omegaconf import OmegaConf

@dataclass
class MLMRobertaModelConf:
    decoder_hidden_dims: Sequence[int]

OmegaConf.structured(MLMRobertaModelConf)
```
#### Before:
```python
$ python tmp.py
Traceback (most recent call last):
...
omegaconf.errors.ConfigTypeError: issubclass() arg 1 must be a class
    full_key:
    object_type=None
```
#### After:
```python
$ python tmp.py
Traceback (most recent call last):
...
omegaconf.errors.ValidationError: Unexpected type annotation: Sequence[int]
    full_key: decoder_hidden_dims
    object_type=MLMRobertaModelConf
```

## Interaction between `allow_objects` flag and unsupported type annotations

In putting together this diff, I noticed a behavior change between OC 2.1 and OC 2.2 in how the `allow_object` flag interacts with unsupported type annotations.

The difference is that, with `allow_object==True`, OC 2.1 wraps most illegally-annotated data in `AnyNode`, while `dict`/`list` data are wrapped in `DictConfig`/`ListConfig`. Meanwhile, with OC 2.2 & `master` branch, all illegally-annotated data (including `dict`/`list` data) are wrapped in `AnyNode`. The third commit in this PR reverts to the behavior from OC 2.1.

Consider the following dataclass which has a field `bad_ann` with a bad type annotation:
```python
@dataclass
class MyDataclass:
    bad_ann: object
```

### In OC 2.1 we have:
```python
OmegaConf.structured(MyDataclass, flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": AnyNode("???")})

OmegaConf.structured(MyDataclass(123), flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": AnyNode(123)})

OmegaConf.structured(MyDataclass([1, 2, 3]), flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": ListConfig([1, 2, 3], ref_type=object)})

OmegaConf.structured(MyDataclass({1: 2}), flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": DictConfig({1: 2}, ref_type=object)})

OmegaConf.structured(MyDataclass(NestedStructured), flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": OmegaConf.structured(NestedStructured)})
```
### In OC 2.2 and on `master` branch we have:
```python

OmegaConf.structured(MyDataclass, flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": AnyNode("???")})

OmegaConf.structured(MyDataclass(123), flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": AnyNode(123)})

OmegaConf.structured(MyDataclass([1, 2, 3]), flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": AnyNode([1, 2, 3])})  # this differs from OC 2.1

OmegaConf.structured(MyDataclass({1: 2}), flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": AnyNode({1: 2})})  # this differs from OC 2.1

OmegaConf.structured(MyDataclass(NestedStructured), flags={"allow_objects": True})
    ====>  DictConfig({"bad_ann": OmegaConf.structured(NestedStructured)})
```

This difference between OC 2.1 and OC 2.2 is relevant to the `hydra.utils.instantiate` function, as calling `instantiate` on a structured config object sets the `allow_objects` flag to `True`.