### PR TITLE
Cherry pick from master to 2.2 branch

### DIFF
--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -30,7 +30,7 @@ in the input class.
 
 
 Currently, type hints supported in OmegaConf’s structured configs include:
- - primitive types (``int``, ``float``, ``bool``, ``str``, ``Path``) and enum types
+ - primitive types (``int``, ``float``, ``bool``, ``str``, ``bytes``, ``Path``) and enum types
    (user-defined subclasses of ``enum.Enum``). See the :ref:`simple_types` section below.
  - unions of primitive/enum types, e.g. ``Union[float, bool, MyEnum]``.
    See :ref:`union_types` below.

--- a/news/950.bugfix
+++ b/news/950.bugfix
@@ -1,0 +1,1 @@
+ListConfig sliced assignment now avoids partial updates upon error

--- a/news/963.bugfix
+++ b/news/963.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that caused OmegaConf to crash when processing attr classes whose field annotations contained forward-references.

--- a/news/991.bugfix
+++ b/news/991.bugfix
@@ -1,0 +1,1 @@
+Improve error message when certain illegal type annotations (such as `typing.Sequence`) are used in structured configs.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -909,29 +909,16 @@ def type_str(t: Any, include_module_name: bool = False) -> str:
     if t is ...:
         return "..."
 
-    if sys.version_info < (3, 7, 0):  # pragma: no cover
-        # Python 3.6
-        if hasattr(t, "__name__"):
-            name = str(t.__name__)
-        else:
-            if t.__origin__ is not None:
-                name = type_str(t.__origin__)
-            else:
-                name = str(t)
-                if name.startswith("typing."):
-                    name = name[len("typing.") :]
-    else:  # pragma: no cover
-        # Python >= 3.7
-        if hasattr(t, "__name__"):
-            name = str(t.__name__)
-        else:
-            if t._name is None:
-                if t.__origin__ is not None:
-                    name = type_str(
-                        t.__origin__, include_module_name=include_module_name
-                    )
-            else:
-                name = str(t._name)
+    if hasattr(t, "__name__"):
+        name = str(t.__name__)
+    elif getattr(t, "_name", None) is not None:  # pragma: no cover
+        name = str(t._name)
+    elif getattr(t, "__origin__", None) is not None:  # pragma: no cover
+        name = type_str(t.__origin__)
+    else:
+        name = str(t)
+        if name.startswith("typing."):  # pragma: no cover
+            name = name[len("typing.") :]
 
     args = getattr(t, "__args__", None)
     if args is not None:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -9,7 +9,17 @@ import warnings
 from contextlib import contextmanager
 from enum import Enum
 from textwrap import dedent
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    get_type_hints,
+)
 
 import yaml
 
@@ -326,9 +336,10 @@ def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, A
     obj_type = obj if is_type else type(obj)
     dummy_parent = OmegaConf.create({}, flags=flags)
     dummy_parent._metadata.object_type = obj_type
+    resolved_hints = get_type_hints(obj_type)
 
     for name, attrib in attr.fields_dict(obj_type).items():
-        is_optional, type_ = _resolve_optional(attrib.type)
+        is_optional, type_ = _resolve_optional(resolved_hints[name])
         type_ = _resolve_forward(type_, obj.__module__)
         if not is_type:
             value = getattr(obj, name)
@@ -368,8 +379,6 @@ def get_dataclass_init_field_names(obj: Any) -> List[str]:
 def get_dataclass_data(
     obj: Any, allow_objects: Optional[bool] = None
 ) -> Dict[str, Any]:
-    from typing import get_type_hints
-
     from omegaconf.omegaconf import MISSING, OmegaConf, _maybe_wrap
 
     flags = {"allow_objects": allow_objects} if allow_objects is not None else {}

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -265,20 +265,26 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                     curr_index = self_indices[0] - 1
                     val_i = -1
 
+                work_copy = self.copy()  # For atomicity manipulate a copy
+
                 # Delete and optionally replace non empty slices
                 only_removed = 0
                 for val_i, i in enumerate(indexes):
                     curr_index = i - only_removed
-                    del self[curr_index]
+                    del work_copy[curr_index]
                     if val_i < len(value):
-                        self.insert(curr_index, value[val_i])
+                        work_copy.insert(curr_index, value[val_i])
                     else:
                         only_removed += 1
 
                 # Insert any remaining input items
                 for val_i in range(val_i + 1, len(value)):
                     curr_index += 1
-                    self.insert(curr_index, value[val_i])
+                    work_copy.insert(curr_index, value[val_i])
+
+                # Reinitialize self with work_copy
+                self.clear()
+                self.extend(work_copy)
             else:
                 self._set_at_index(index, value)
         except Exception as e:

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1050,7 +1050,24 @@ def _node_wrap(
         node = PathNode(value=value, key=key, parent=parent, is_optional=is_optional)
     else:
         if parent is not None and parent._get_flag("allow_objects") is True:
-            node = AnyNode(value=value, key=key, parent=parent)
+            if type(value) in (list, tuple):
+                node = ListConfig(
+                    content=value,
+                    key=key,
+                    parent=parent,
+                    ref_type=ref_type,
+                    is_optional=is_optional,
+                )
+            elif is_primitive_dict(value):
+                node = DictConfig(
+                    content=value,
+                    key=key,
+                    parent=parent,
+                    ref_type=ref_type,
+                    is_optional=is_optional,
+                )
+            else:
+                node = AnyNode(value=value, key=key, parent=parent)
         else:
             raise ValidationError(f"Unexpected type annotation: {type_str(ref_type)}")
     return node

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1028,7 +1028,7 @@ def _node_wrap(
         )
     elif ref_type == Any or ref_type is None:
         node = AnyNode(value=value, key=key, parent=parent)
-    elif issubclass(ref_type, Enum):
+    elif isinstance(ref_type, type) and issubclass(ref_type, Enum):
         node = EnumNode(
             enum_type=ref_type,
             value=value,
@@ -1052,7 +1052,7 @@ def _node_wrap(
         if parent is not None and parent._get_flag("allow_objects") is True:
             node = AnyNode(value=value, key=key, parent=parent)
         else:
-            raise ValidationError(f"Unexpected object type: {type_str(ref_type)}")
+            raise ValidationError(f"Unexpected type annotation: {type_str(ref_type)}")
     return node
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, Generic, List, NamedTuple, Optional, Tuple, TypeVar, Union
 
 import attr
 from pytest import warns
@@ -17,6 +17,13 @@ class IllegalType:
         if isinstance(other, IllegalType):
             return True
         return False
+
+
+T = TypeVar("T")
+
+
+class IllegalTypeGeneric(Generic[T]):
+    ...
 
 
 class NonCopyableIllegalType:

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -804,3 +804,17 @@ if sys.version_info >= (3, 9):
         dict_no_subscript: dict = {123: "abc"}
         list_no_subscript: list = [123]
         tuple_no_subscript: tuple = (123,)
+
+
+@attr.s(auto_attribs=True)
+class HasForwardRef:
+    @attr.s(auto_attribs=True)
+    class CA:
+        x: int = 3
+
+    @attr.s(auto_attribs=True)
+    class CB:
+        sub: "HasForwardRef.CA"
+
+    a: CA
+    b: CB

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -818,3 +818,13 @@ class HasForwardRef:
 
     a: CA
     b: CB
+
+
+@attr.s(auto_attribs=True)
+class HasBadAnnotation1:
+    data: object
+
+
+@attr.s(auto_attribs=True)
+class HasBadAnnotation2:
+    data: object()  # type: ignore

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -841,3 +841,17 @@ if sys.version_info >= (3, 9):
         dict_no_subscript: dict = field(default_factory=lambda: {123: "abc"})
         list_no_subscript: list = field(default_factory=lambda: [123])
         tuple_no_subscript: tuple = (123,)
+
+
+@dataclass
+class HasForwardRef:
+    @dataclass
+    class CA:
+        x: int = 3
+
+    @dataclass
+    class CB:
+        sub: "HasForwardRef.CA"
+
+    a: CA
+    b: CB

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -855,3 +855,13 @@ class HasForwardRef:
 
     a: CA
     b: CB
+
+
+@dataclass
+class HasBadAnnotation1:
+    data: object
+
+
+@dataclass
+class HasBadAnnotation2:
+    data: object()  # type: ignore

--- a/tests/structured_conf/test_structured_basic.py
+++ b/tests/structured_conf/test_structured_basic.py
@@ -38,7 +38,7 @@ class TestStructured:
         def test_error_on_non_structured_nested_config_class(self, module: Any) -> None:
             with raises(
                 ValidationError,
-                match=re.escape("Unexpected object type: NotStructuredConfig"),
+                match=re.escape("Unexpected type annotation: NotStructuredConfig"),
             ):
                 OmegaConf.structured(module.StructuredWithInvalidField)
 

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1010,6 +1010,12 @@ def test_frozen(module: Any) -> None:
     validate_frozen_impl(OmegaConf.structured(FrozenClass()))
 
 
+def test_forward_ref(module: Any) -> None:
+    C = module.HasForwardRef
+    obj = C(a=C.CA(), b=C.CB(C.CA(x=33)))
+    OmegaConf.create(obj)
+
+
 class TestDictSubclass:
     def test_str2str(self, module: Any) -> None:
         with warns_dict_subclass_deprecated(module.DictSubclass.Str2Str):

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -981,6 +981,17 @@ class TestConfigs:
         assert cfg.list == [1, 2]
         assert cfg.opt_list is None
 
+    def test_has_bad_annotation1(self, module: Any) -> None:
+        with raises(ValidationError, match="Unexpected type annotation: object"):
+            OmegaConf.structured(module.HasBadAnnotation1)
+
+    def test_has_bad_annotation2(self, module: Any) -> None:
+        with raises(
+            ValidationError,
+            match="Unexpected type annotation: <object object at 0x[a-f0-9]*>",
+        ):
+            OmegaConf.structured(module.HasBadAnnotation2)
+
 
 def validate_frozen_impl(conf: DictConfig) -> None:
     with raises(ReadonlyConfigError):

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -908,6 +908,13 @@ def test_getitem_slice(sli: slice) -> None:
         ),
         param(
             ["a", "b", "c", "d"],
+            slice(1, 3),
+            [object()],
+            raises(UnsupportedValueType),
+            id="partially-valid-input",
+        ),
+        param(
+            ["a", "b", "c", "d"],
             slice(1, 3, 1),
             ["x", "y", "z"],
             ["a", "x", "y", "z", "d"],
@@ -969,8 +976,15 @@ def test_setitem_slice(
         cfg[idx] = value
         assert cfg == expected
     else:
+        expected_exception: Any = expected.expected_exception
+        if type(constructor) == type(list) and issubclass(
+            expected_exception, UnsupportedValueType
+        ):
+            return  # standard list() can accept object() so skip
+        orig_cfg = cfg[:]
         with expected:
             cfg[idx] = value
+        assert cfg == orig_cfg
 
 
 @mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,6 +48,7 @@ from tests import (
     Dataframe,
     DictSubclass,
     IllegalType,
+    IllegalTypeGeneric,
     ListSubclass,
     Plugin,
     Shape,
@@ -636,6 +637,12 @@ def test_is_primitive_type_annotation(type_: Any, is_primitive: bool) -> None:
         (Union[str, int, Color], True, "Union[str, int, tests.Color]"),
         (Union[int], False, "int"),
         (Union[int], True, "int"),
+        (IllegalType, False, "IllegalType"),
+        (IllegalType, True, "tests.IllegalType"),
+        (IllegalTypeGeneric, False, "IllegalTypeGeneric"),
+        (IllegalTypeGeneric, True, "tests.IllegalTypeGeneric"),
+        (IllegalTypeGeneric[int], False, "IllegalTypeGeneric[int]"),
+        (IllegalTypeGeneric[int], True, "tests.IllegalTypeGeneric[int]"),
     ],
 )
 def test_type_str(
@@ -652,6 +659,17 @@ def test_type_str(
         )
 
 
+@mark.parametrize(
+    "type_, expected",
+    [
+        (object(), r"<object object at 0x[a-f0-9]*>"),
+        (IllegalType(), "<tests.IllegalType object at 0x[a-f0-9]*>"),
+    ],
+)
+def test_type_str_regex(type_: Any, expected: str) -> None:
+    assert re.match(expected, _utils.type_str(type_))
+
+
 def test_type_str_ellipsis() -> None:
     assert _utils.type_str(...) == "..."
 
@@ -663,6 +681,11 @@ def test_type_str_ellipsis() -> None:
         param(NoneType, "NoneType", id="nonetype"),
         (Union[float, bool, None], "Optional[Union[float, bool]]"),
         (Union[float, bool, NoneType], "Optional[Union[float, bool]]"),
+        (object, "object"),
+        (
+            Optional[object],  # python3.6 treats `Optional[object]` as `object`
+            "Optional[object]" if sys.version_info >= (3, 7) else "object",
+        ),
     ],
 )
 def test_type_str_nonetype(type_: Any, expected: str) -> None:


### PR DESCRIPTION
This PR cherry-picks several commits from `master` to `2.2_branch`.

- Update structured config docs: mention `bytes` (#947)
- use typing.get_type_hints for attr classes (#979)
- ensure atomic updates for ListConfig sliced assignment (#950)
- make _utils.type_str robust against unsupported types ([#993](https://github.com/omry/omegaconf/pull/993))
- Handle unsupported type annotation gracefully ([#993](https://github.com/omry/omegaconf/pull/993))
- revert allow_objects behavior for unsupported annotations ([#993](https://github.com/omry/omegaconf/pull/993))
