### PR TITLE
Fix some tests which fail on Windows

### DIFF
--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -989,7 +989,7 @@ class TestConfigs:
     def test_has_bad_annotation2(self, module: Any) -> None:
         with raises(
             ValidationError,
-            match="Unexpected type annotation: <object object at 0x[a-f0-9]*>",
+            match="Unexpected type annotation: <object object at 0x[a-fA-F0-9]*>",
         ):
             OmegaConf.structured(module.HasBadAnnotation2)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -662,8 +662,8 @@ def test_type_str(
 @mark.parametrize(
     "type_, expected",
     [
-        (object(), r"<object object at 0x[a-f0-9]*>"),
-        (IllegalType(), "<tests.IllegalType object at 0x[a-f0-9]*>"),
+        (object(), r"<object object at 0x[a-fA-F0-9]*>"),
+        (IllegalType(), "<tests.IllegalType object at 0x[a-fA-F0-9]*>"),
     ],
 )
 def test_type_str_regex(type_: Any, expected: str) -> None:


### PR DESCRIPTION
On Windows, the addresses of objects are for whatever reason represented with capital hexadecimals. This is causing [tests to fail](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=553925&view=logs&jobId=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&j=171a126d-c574-5c8c-1269-ff3b989e923d&t=1183ba29-a0b5-5324-8463-2a49ace9e213) on conda-forge.

Note: I don't have Windows myself, so I can't test this, but it seems straightforward enough.