### PR TITLE
docs: use :local: directive for page TOCs

### DIFF
--- a/docs/source/custom_resolvers.rst
+++ b/docs/source/custom_resolvers.rst
@@ -3,6 +3,7 @@ Resolvers
 =========
 
 .. contents::
+   :local:
 
 .. testsetup:: *
 

--- a/docs/source/grammar.rst
+++ b/docs/source/grammar.rst
@@ -3,6 +3,7 @@ The OmegaConf grammar
 =====================
 
 .. contents::
+   :local:
 
 .. testsetup:: *
 

--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -3,6 +3,7 @@ Structured Configs
 ==================
 
 .. contents::
+   :local:
 
 .. _structured_configs:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -3,6 +3,7 @@ Usage
 =====
 
 .. contents::
+   :local:
 
 .. testsetup:: *
 


### PR DESCRIPTION
This prevents the title of each page from appearing in its own table of
contents.
