### PR TITLE
mypy: update python_version and type: ignore comments

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,8 +1,7 @@
 import copy
 from typing import Any, Dict, List
 
-from pytest import lazy_fixture  # type: ignore
-from pytest import fixture, mark, param
+from pytest import fixture, lazy_fixture, mark, param
 
 from omegaconf import OmegaConf
 from omegaconf._utils import ValueKind, _is_missing_literal, get_value_kind
@@ -75,11 +74,11 @@ def small_listconfig(small_list: Any) -> Any:
 @mark.parametrize(
     "data",
     [
-        lazy_fixture("small_dict"),
-        lazy_fixture("large_dict"),
-        lazy_fixture("small_dict_config"),
-        lazy_fixture("large_dict_config"),
-        lazy_fixture("dict_config_with_list_leaf"),
+        lazy_fixture("small_dict"),  # type: ignore
+        lazy_fixture("large_dict"),  # type: ignore
+        lazy_fixture("small_dict_config"),  # type: ignore
+        lazy_fixture("large_dict_config"),  # type: ignore
+        lazy_fixture("dict_config_with_list_leaf"),  # type: ignore
     ],
 )
 def test_omegaconf_create(data: Any, benchmark: Any) -> None:
@@ -100,8 +99,8 @@ def test_omegaconf_merge(merge_function: Any, merge_data: Any, benchmark: Any) -
 @mark.parametrize(
     "lst",
     [
-        lazy_fixture("small_list"),
-        lazy_fixture("small_listconfig"),
+        lazy_fixture("small_list"),  # type: ignore
+        lazy_fixture("small_listconfig"),  # type: ignore
     ],
 )
 def test_list_in(lst: List[Any], benchmark: Any) -> None:
@@ -111,8 +110,8 @@ def test_list_in(lst: List[Any], benchmark: Any) -> None:
 @mark.parametrize(
     "lst",
     [
-        lazy_fixture("small_list"),
-        lazy_fixture("small_listconfig"),
+        lazy_fixture("small_list"),  # type: ignore
+        lazy_fixture("small_listconfig"),  # type: ignore
     ],
 )
 def test_list_iter(lst: List[Any], benchmark: Any) -> None:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -392,7 +392,7 @@ def get_dataclass_data(
         is_optional, type_ = _resolve_optional(resolved_hints[field.name])
         type_ = _resolve_forward(type_, obj.__module__)
         has_default = field.default != dataclasses.MISSING
-        has_default_factory = field.default_factory != dataclasses.MISSING  # type: ignore
+        has_default_factory = field.default_factory != dataclasses.MISSING
 
         if not is_type:
             value = getattr(obj, name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 test=pytest
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 mypy_path=.stubs
 exclude = build/
 

--- a/tests/examples/dataclass_postponed_annotations.py
+++ b/tests/examples/dataclass_postponed_annotations.py
@@ -1,6 +1,6 @@
 # `from __future__` has to be the very first thing in a module
 # otherwise a syntax error is raised
-from __future__ import annotations  # type: ignore # noqa  # Python 3.6 linters complain
+from __future__ import annotations  # noqa  # Python 3.6 linters complain
 
 from dataclasses import dataclass, fields
 from enum import Enum


### PR DESCRIPTION
Mypy no longer officially supports python3.6.
Updating the `python_version` setting in the mypy config
avoids some errors that were only showing up when mypy was
installed with python3.6.

Fixes the test failure [here](https://app.circleci.com/pipelines/github/omry/omegaconf/2823/workflows/1e961ad3-1a9f-4ddd-92df-5a3e873e67c6/jobs/10776?invite=true#step-103-364).