### PR TITLE
Add docstring for `OmegaConf.clear_resolvers` method

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -458,6 +458,9 @@ class OmegaConf:
     # noinspection PyProtectedMember
     @staticmethod
     def clear_resolvers() -> None:
+        """
+        Clear(remove) all OmegaConf resolvers, then re-register OmegaConf's default resolvers.
+        """
         BaseContainer._resolvers = {}
         register_default_resolvers()
 


### PR DESCRIPTION
The `OmegaConf.clear_resolvers` method was not showing up on the API Reference page of OmegaConf's website.
After adding a docstring, sphinx autodoc picks up on the method.
