### PR TITLE
Bump version -> v2.3.0.dev3

### DIFF
--- a/omegaconf/version.py
+++ b/omegaconf/version.py
@@ -1,6 +1,6 @@
 import sys  # pragma: no cover
 
-__version__ = "2.3.0.dev2"
+__version__ = "2.3.0.dev3"
 
 msg = """OmegaConf 2.0 and above is compatible with Python 3.6 and newer.
 You have the following options:


### PR DESCRIPTION
Dev version 2.3.0.dev2 has been [released to pypi](https://pypi.org/project/omegaconf/2.3.0.dev2/).
This PR bumps to v2.3.0.dev3.