### PR TITLE
docs how-to guide: use sphinx-tabs for yaml/python

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,6 +53,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
+    "sphinx_tabs.tabs",
 ]
 
 

--- a/docs/source/how_to_guides.rst
+++ b/docs/source/how_to_guides.rst
@@ -23,35 +23,78 @@ First, register the ``builtins.eval`` function as a new resolver:
 
 Now, define a config and perform some arithmetic using the ``eval`` resolver:
 
-.. doctest::
+.. tabs::
 
-    >>> yaml_data = """
-    ... ten_squared: ${eval:'10 ** 2'}
-    ... """
-    >>> cfg = OmegaConf.create(yaml_data)
-    >>> assert cfg.ten_squared == 100
+    .. tab:: yaml
+
+        .. doctest::
+
+            >>> yaml_data = """
+            ... ten_squared: ${eval:'10 ** 2'}
+            ... """
+            >>> cfg = OmegaConf.create(yaml_data)
+            >>> assert cfg.ten_squared == 100
+
+    .. tab:: python
+
+        .. doctest::
+
+            >>> cfg = OmegaConf.create({
+            ...     "ten_squared": "${eval:'10 ** 2'}",
+            ... })
+            >>> assert cfg.ten_squared == 100
 
 You can use :ref:`nested interpolation<nested-interpolation>` to perform computation that involves other values from your config:
 
-.. doctest::
+.. tabs::
 
-    >>> yaml_data = """
-    ... side_1: 5
-    ... side_2: 6
-    ... rectangle_area: ${eval:'${side_1} * ${side_2}'}
-    ... """
-    >>> cfg = OmegaConf.create(yaml_data)
-    >>> assert cfg.rectangle_area == 30
+    .. tab:: yaml
+
+        .. doctest::
+
+            >>> yaml_data = """
+            ... side_1: 5
+            ... side_2: 6
+            ... rectangle_area: ${eval:'${side_1} * ${side_2}'}
+            ... """
+            >>> cfg = OmegaConf.create(yaml_data)
+            >>> assert cfg.rectangle_area == 30
+
+    .. tab:: python
+
+        .. doctest::
+
+            >>> cfg = OmegaConf.create({
+            ...     "side_1": 5,
+            ...     "side_2": 6,
+            ...     "rectangle_area": "${eval:'${side_1} * ${side_2}'}",
+            ... })
+            >>> assert cfg.rectangle_area == 30
 
 To pass string data to ``eval``, you'll need to use a nested pair of quotes:
 
-.. doctest::
+.. tabs::
 
-    >>> cfg = OmegaConf.create({
-    ...   "cow_say": "moo",
-    ...   "three_cows": """${eval:'3 * "${cow_say}"'}"""
-    ... })
-    >>> assert cfg.three_cows == "moomoomoo"
+    .. tab:: yaml
+
+        .. doctest::
+
+            >>> yaml_data = """
+            ... cow_say: moo
+            ... three_cows: ${eval:'3 * "${cow_say}"'}
+            ... """
+            >>> cfg = OmegaConf.create(yaml_data)
+            >>> assert cfg.three_cows == "moomoomoo"
+
+    .. tab:: python
+
+        .. doctest::
+
+            >>> cfg = OmegaConf.create({
+            ...   "cow_say": "moo",
+            ...   "three_cows": """${eval:'3 * "${cow_say}"'}"""
+            ... })
+            >>> assert cfg.three_cows == "moomoomoo"
 
 The double quotes around ``"${cow_say}"`` guarantee that ``eval`` will
 interpret ``"moo"`` as a string instead of as a variable ``moo``. See

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,6 +13,7 @@ pytest-benchmark
 pytest-lazy-fixture
 pytest-mock
 sphinx
+sphinx-tabs
 towncrier
 twine
 pydevd


### PR DESCRIPTION
Update code examples from our [How-To Guides](https://omegaconf.readthedocs.io/en/2.3_branch/how_to_guides.html) docs page to use [Sphinx tabs](https://sphinx-tabs.readthedocs.io/en/latest/).

Before:
<img width="684" alt="Screen Shot 2022-12-20 at 7 04 39 AM" src="https://user-images.githubusercontent.com/8935917/208674912-f441c062-39db-49c0-a77d-3a16a4cb3c69.png">

After:
<img width="691" alt="Screen Shot 2022-12-20 at 7 08 55 AM" src="https://user-images.githubusercontent.com/8935917/208674941-c29c454d-4289-42aa-92df-bd4470bda1d4.png">
<img width="675" alt="Screen Shot 2022-12-20 at 7 09 01 AM" src="https://user-images.githubusercontent.com/8935917/208674955-2f038e95-530f-400d-9531-3ac4f4dec8ca.png">



Todo after merge:
  - [ ] cherry pick to 2.3_branch
