### PR TITLE
sphinx-tabs followup: readthedocs install requirements/docs.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,3 +20,4 @@ python:
   install:
     - method: pip
       path: .
+    - requirements: requirements/docs.txt

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,10 +12,12 @@ PYTHON_VERSIONS = os.environ.get(
 nox.options.error_on_missing_interpreters = True
 
 
-def deps(session: Session, editable_install: bool) -> None:
+def deps(
+    session: Session, editable_install: bool, requirements: str = "requirements/dev.txt"
+) -> None:
     session.install("--upgrade", "setuptools", "pip")
     extra_flags = ["-e"] if editable_install else []
-    session.install("-r", "requirements/dev.txt", *extra_flags, ".", silent=True)
+    session.install("-r", requirements, *extra_flags, ".", silent=True)
 
 
 @nox.session(python=PYTHON_VERSIONS)  # type: ignore
@@ -32,10 +34,11 @@ def benchmark(session: Session) -> None:
 
 @nox.session  # type: ignore
 def docs(session: Session) -> None:
-    deps(session, editable_install=True)
+    deps(session, False, "requirements/docs.txt")
     session.chdir("docs")
-    session.run("sphinx-build", "-W", "-b", "doctest", "source", "build")
     session.run("sphinx-build", "-W", "-b", "html", "source", "build")
+    session.install("pytest")  # required for `sphinx-build -b doctest`:
+    session.run("sphinx-build", "-W", "-b", "doctest", "source", "build")
 
 
 @nox.session(python=PYTHON_VERSIONS)  # type: ignore

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 -r base.txt
+-r docs.txt
 black
 build
 coveralls
@@ -12,8 +13,6 @@ pytest
 pytest-benchmark
 pytest-lazy-fixture
 pytest-mock
-sphinx
-sphinx-tabs
 towncrier
 twine
 pydevd

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-tabs


### PR DESCRIPTION
Follow-up to #1045 to rectify failing readthedocs.io build.
Here's the output from the failed build:
```
/latest/bin/python -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
Running Sphinx v1.8.6
loading translations [en]... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/omegaconf/envs/latest/lib/python3.7/site-packages/sphinx/registry.py", line 472, in load_extension
    mod = __import__(extname, None, None, ['setup'])
ModuleNotFoundError: No module named 'sphinx_tabs'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/omegaconf/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 303, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/home/docs/checkouts/readthedocs.org/user_builds/omegaconf/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 228, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/omegaconf/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 449, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/omegaconf/envs/latest/lib/python3.7/site-packages/sphinx/registry.py", line 475, in load_extension
    raise ExtensionError(__('Could not import extension %s') % extname, err)
sphinx.errors.ExtensionError: Could not import extension sphinx_tabs.tabs (exception: No module named 'sphinx_tabs')

Extension error:
Could not import extension sphinx_tabs.tabs (exception: No module named 'sphinx_tabs')
```