### PR TITLE
Forward flags when loading to creation

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -184,7 +184,7 @@ class OmegaConf:
     @staticmethod
     def load(
         file_: Union[str, pathlib.Path, IO[Any]],
-        flags: Optional[Dict[str, bool]] = None
+        flags: Optional[Dict[str, bool]] = None,
     ) -> Union[DictConfig, ListConfig]:
         from ._utils import get_yaml_loader
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -182,7 +182,10 @@ class OmegaConf:
         )
 
     @staticmethod
-    def load(file_: Union[str, pathlib.Path, IO[Any]]) -> Union[DictConfig, ListConfig]:
+    def load(
+        file_: Union[str, pathlib.Path, IO[Any]],
+        flags: Optional[Dict[str, bool]] = None
+    ) -> Union[DictConfig, ListConfig]:
         from ._utils import get_yaml_loader
 
         if isinstance(file_, (str, pathlib.Path)):
@@ -200,9 +203,9 @@ class OmegaConf:
 
         ret: Union[DictConfig, ListConfig]
         if obj is None:
-            ret = OmegaConf.create()
+            ret = OmegaConf.create(flags=flags)
         else:
-            ret = OmegaConf.create(obj)
+            ret = OmegaConf.create(obj, flags=flags)
         return ret
 
     @staticmethod


### PR DESCRIPTION
## What?
This is a minimal PR providing the possibibility to pass the same flags to `OmegaConf.load()` that can be used when calling `OmegaConf.create()`.

## Why?
I created a custom resolver that allows setting tuples as config values.
It worked perfectly when testing it like this `OmegaConf.create("tup: ${as_tuple:1,2,3}")`.
However, it failed when loading the config file
```yaml
tup:  ${as_tuple:1,2,3}
```

since I am calling `OmegaConf.resolve()` after `OmegaConf.load()` (for a good reason that is out of scope here).
The error was
```shell
omegaconf.errors.UnsupportedValueType: Value 'tuple' is not a supported primitive type
```

I could resolve that error by altering the `allow_objects` flag
```py
config._set_flag("allow_objects", True)
```

Despite the disclaimers in the comments about the flags API, I think it would be nice to be able to directly set them when creating a config from a file the same way we can do it when creating it programmatically.

What do you think? Did I miss anything?

## How?
Please see the code. The change is straightforward.