### PR TITLE
Raise error if there are conflicting keys after merge

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -137,6 +137,7 @@ def get_yaml_loader() -> Any:
     class OmegaConfLoader(yaml.SafeLoader):  # type: ignore
         def construct_mapping(self, node: yaml.Node, deep: bool = False) -> Any:
             keys = set()
+            constructor = super().construct_mapping(node, deep=deep)
             for key_node, value_node in node.value:
                 if key_node.tag != yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG:
                     continue
@@ -148,7 +149,7 @@ def get_yaml_loader() -> Any:
                         key_node.start_mark,
                     )
                 keys.add(key_node.value)
-            return super().construct_mapping(node, deep=deep)
+            return constructor
 
     loader = OmegaConfLoader
     loader.add_implicit_resolver(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -424,30 +424,26 @@ def test_yaml_merge() -> None:
             c:
                 <<: *A
                 <<: *B
-                x: 3
                 z: 1
             """
         )
     )
-    assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 3, "y": 2, "z": 1}}
+    assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 1, "y": 2, "z": 1}}
+
 
 def test_yaml_merge_with_conflict() -> None:
-    import pdb; pdb.set_trace()
-    cfg = OmegaConf.create(
-        dedent(
-            """\
-            a: &A
-                x: 1
-            b: &B
-                y: 2
-            c:
-                <<: *A
-                <<: *B
-                x: 3
-                z: 1
-            """
+    with raises(yaml.constructor.ConstructorError):
+        OmegaConf.create(
+            dedent(
+                """\
+                a: &A
+                    x: 1
+                c:
+                    <<: *A
+                    x: 3
+                """
+            )
         )
-    )
 
 @mark.parametrize(
     "path_type",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -429,7 +429,7 @@ def test_yaml_merge() -> None:
             """
         )
     )
-    assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 1, "y": 2, "w": 3, "z": 1}}
+    assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"w": 3, "y": 2, "z": 1}}
 
 
 def test_yaml_merge_with_conflict() -> None:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -431,6 +431,23 @@ def test_yaml_merge() -> None:
     )
     assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 3, "y": 2, "z": 1}}
 
+def test_yaml_merge_with_conflict() -> None:
+    import pdb; pdb.set_trace()
+    cfg = OmegaConf.create(
+        dedent(
+            """\
+            a: &A
+                x: 1
+            b: &B
+                y: 2
+            c:
+                <<: *A
+                <<: *B
+                x: 3
+                z: 1
+            """
+        )
+    )
 
 @mark.parametrize(
     "path_type",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -446,6 +446,7 @@ def test_yaml_merge_with_conflict() -> None:
             )
         )
 
+
 @mark.parametrize(
     "path_type",
     [

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -429,7 +429,7 @@ def test_yaml_merge() -> None:
             """
         )
     )
-    assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"w": 3, "y": 2, "z": 1}}
+    assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 1, "y": 2, "w": 3, "z": 1}}
 
 
 def test_yaml_merge_with_conflict() -> None:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -424,11 +424,12 @@ def test_yaml_merge() -> None:
             c:
                 <<: *A
                 <<: *B
+                w: 3
                 z: 1
             """
         )
     )
-    assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 1, "y": 2, "z": 1}}
+    assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 1, "y": 2, "w": 3, "z": 1}}
 
 
 def test_yaml_merge_with_conflict() -> None:


### PR DESCRIPTION
## What?

Change the default behavior of merge to raise an error when there is a conflict in the key names after merge.
Right now, if there is a key conflict after merge, the last key specified silently overwrites the other. As shown in the test case below.

https://github.com/omry/omegaconf/blob/master/tests/test_create.py#L416
```
def test_yaml_merge() -> None:
    cfg = OmegaConf.create(
        dedent(
            """\
            a: &A
                x: 1
            b: &B
                y: 2
            c:
                <<: *A
                <<: *B
                x: 3
                z: 1
            """
        )
    )
    assert cfg == {"a": {"x": 1}, "b": {"y": 2}, "c": {"x": 3, "y": 2, "z": 1}}
```

## Why?

I think there are two main points to justify this change:
1. Duplicated keys are syntactically invalid for YAML files, as shown in the quote below (from https://yaml.org/spec/1.2-old/spec.html#id2764044)
> The content of a mapping node is an unordered set of key: value node pairs, with the restriction that each of the keys is unique.

2. This behavior can cause unexpected problems in running time for OmegaConf's users.

---

I executed the tests in a Windows 10 machine, using Python 3.10.8 running in a Conda env.

I hope this PR is useful :)
