### PR TITLE
include attrs dependency in requirements/dev.txt

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 -r base.txt
 -r docs.txt
+attrs
 black
 build
 coveralls


### PR DESCRIPTION
Some CI tests were failing because the `attrs` dependency was not installed by `noxfile.py`.
This PR addes `attrs` to `requirements/dev.txt` so that the tests will run.
