### PR TITLE
pin setuptools to avoid DeprecationWarning

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,11 @@ nox.options.error_on_missing_interpreters = True
 def deps(
     session: Session, editable_install: bool, requirements: str = "requirements/dev.txt"
 ) -> None:
-    session.install("--upgrade", "setuptools", "pip")
+    session.install(
+        "--upgrade",
+        "setuptools==66",  # pinned due to DeprecationWarning, see https://github.com/omry/omegaconf/issues/1068
+        "pip",
+    )
     extra_flags = ["-e"] if editable_install else []
     session.install("-r", requirements, *extra_flags, ".", silent=True)
 


### PR DESCRIPTION
Pin the version of `setuptools` installed in `noxfile.py` to work around https://github.com/omry/omegaconf/issues/1068.

Since the `DeprecationWarnining` that's causing CI failure is emitted by a 3rd
party dependency of `setuptools`, this failure mode should resolve itself when
some future version of `setuptools` is released. At that time, we can remove
the pin introduced by this PR.
