### PR TITLE
Change noxfile.py setuptools pin from ==66 to <=66

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def deps(
 ) -> None:
     session.install(
         "--upgrade",
-        "setuptools==66",  # pinned due to DeprecationWarning, see https://github.com/omry/omegaconf/issues/1068
+        "setuptools<=66",  # pinned due to DeprecationWarning, see https://github.com/omry/omegaconf/issues/1068
         "pip",
     )
     extra_flags = ["-e"] if editable_install else []


### PR DESCRIPTION
This is a followup to https://github.com/omry/omegaconf/pull/1069
that accomodates old versions of python ( python3.6 ).
