### PR TITLE
pin flake8 >= v4

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ attrs
 black
 build
 coveralls
-flake8
+flake8>=4
 isort~=5.0
 mypy
 nox


### PR DESCRIPTION
CI lints for python3.7 were failing due to an issue with flake8 (related
to https://github.com/python/importlib_metadata/issues/406); see the
example test failure below. The failure is resolved by ensuring that
the installed version of flake8 is >= 4.0.

<details>
<summary>
Example test failure
</summary>

```text
nox > [2023-04-14 23:08:38,999] Running session lint-3.7
nox > [2023-04-14 23:08:39,000] Creating virtual environment (virtualenv) using python3.7 in .nox/lint-3-7
nox > [2023-04-14 23:08:39,252] python -m pip install --upgrade 'setuptools<=66' pip
nox > [2023-04-14 23:08:43,005] python -m pip install -r requirements/dev.txt -e .
nox > [2023-04-14 23:09:01,123] mypy . --strict --install-types --non-interactive
nox > [2023-04-14 23:09:16,755] isort . --check
nox > [2023-04-14 23:09:17,201] black --check .
nox > [2023-04-14 23:09:21,432] flake8
Traceback (most recent call last):
  File "/home/circleci/project/.nox/lint-3-7/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/home/circleci/project/.nox/lint-3-7/lib/python3.7/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File "/home/circleci/project/.nox/lint-3-7/lib/python3.7/site-packages/flake8/main/application.py", line 363, in run
    self._run(argv)
  File "/home/circleci/project/.nox/lint-3-7/lib/python3.7/site-packages/flake8/main/application.py", line 350, in _run
    self.initialize(argv)
  File "/home/circleci/project/.nox/lint-3-7/lib/python3.7/site-packages/flake8/main/application.py", line 330, in initialize
    self.find_plugins(config_finder)
  File "/home/circleci/project/.nox/lint-3-7/lib/python3.7/site-packages/flake8/main/application.py", line 153, in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
  File "/home/circleci/project/.nox/lint-3-7/lib/python3.7/site-packages/flake8/plugins/manager.py", line 357, in __init__
    self.namespace, local_plugins=local_plugins
  File "/home/circleci/project/.nox/lint-3-7/lib/python3.7/site-packages/flake8/plugins/manager.py", line 238, in __init__
    self._load_entrypoint_plugins()
  File "/home/circleci/project/.nox/lint-3-7/lib/python3.7/site-packages/flake8/plugins/manager.py", line 254, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
AttributeError: 'EntryPoints' object has no attribute 'get'
nox > [2023-04-14 23:09:21,536] Command flake8  failed with exit code 1
nox > [2023-04-14 23:09:21,537] Session lint-3.7 failed.
```
</details>
