### PR TITLE
feat: add deep merging for lists

### DIFF
--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -1155,7 +1155,7 @@
     "Currently there are three different merge modes:\n",
     "* `REPLACE`: Replaces the target list with the new one (default)\n",
     "* `EXTEND`: Extends the target list with the new one\n",
-    "* `APPEND_UNIQUE_VALUE`: Appends items that do not already exist in the target list"
+    "* `EXTEND_UNIQUE`: Extends the target list items with items not present in it"
    ]
   },
   {
@@ -1191,7 +1191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you load them and merge them with `list_merge_mode=ListMergeMode.APPEND_UNIQUE_VALUE` you will get this:\n"
+    "If you load them and merge them with `list_merge_mode=ListMergeMode.EXTEND_UNIQUE` you will get this:\n"
    ]
   },
   {
@@ -1205,7 +1205,7 @@
     "cfg_example2 = OmegaConf.load('../source/example2.yaml')\n",
     "cfg_example4 = OmegaConf.load('../source/example4.yaml')\n",
     "\n",
-    "conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode=ListMergeMode.APPEND_UNIQUE_VALUE)\n",
+    "conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode=ListMergeMode.EXTEND_UNIQUE)\n",
     "print(OmegaConf.to_yaml(conf))"
    ]
   },

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -14,6 +15,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -45,6 +47,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -79,6 +82,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -112,6 +116,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -149,6 +154,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -190,6 +196,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -227,6 +234,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -265,6 +273,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -303,6 +312,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -334,6 +344,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -365,6 +376,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -396,6 +408,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -416,6 +429,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -436,6 +450,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -456,6 +471,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -487,6 +503,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -523,6 +540,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -534,6 +552,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -594,6 +613,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -627,6 +647,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -661,6 +682,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -694,6 +716,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -714,6 +737,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -771,6 +795,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -811,6 +836,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -818,6 +844,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -876,6 +903,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -883,6 +911,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -917,6 +946,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -946,6 +976,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1004,6 +1035,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1112,6 +1144,84 @@
     "conf.merge_with_cli()\n",
     "print(OmegaConf.to_yaml(conf))"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The default behavior for lists is that the list from the last config overwrites the others. \n",
+    "Use `OmegaConf.merge(cfg1, cfg2, extend_lists=True)` to merge the lists by extending them. \n",
+    "You can specify whether duplicate entries are allowed with the flag `allow_duplicates`. \n",
+    "This is false, by default, but is only compatible with `extend_lists` activated."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`example2.yaml` file:\n",
+    "```yaml\n",
+    "server:\n",
+    "  port: 80\n",
+    "users:\n",
+    "  - user1\n",
+    "  - user2\n",
+    "```"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`example4.yaml` file:\n",
+    "```yaml\n",
+    "users:\n",
+    "  - user3\n",
+    "  - user2\n",
+    "```"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you load them and merge them with both attributes set to `True` you will get this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from omegaconf import OmegaConf\n",
+    "\n",
+    "cfg_example2 = OmegaConf.load('../source/example2.yaml')\n",
+    "cfg_example4 = OmegaConf.load('../source/example4.yaml')\n",
+    "\n",
+    "conf = OmegaConf.merge(cfg_example2, cfg_example4, extend_lists=True, allow_duplicates=True)\n",
+    "print(OmegaConf.to_yaml(conf))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```yaml\n",
+    "server:\n",
+    "  port: 80\n",
+    "users:\n",
+    "- user1\n",
+    "- user2\n",
+    "- user3\n",
+    "- user2\n",
+    "```"
+   ]
   }
  ],
  "metadata": {
@@ -1130,7 +1240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.8"
   },
   "pycharm": {
    "stem_cell": {

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -1153,9 +1153,9 @@
     "By default, `merge()` is replacing the target list with the source list.\n",
     "Use `list_merge_mode` to control the merge behavior for lists.\n",
     "Currently there are three different merge modes:\n",
-    "* `OVERRIDE`: content from newer list gets taken (default)\n",
-    "* `EXTEND`: lists get extended\n",
-    "* `EXTEND_IGNORE_DUPLICATES`: only new (unique) elements get extended"
+    "* `REPLACE`: Replaces the target list with the new one (default)\n",
+    "* `EXTEND`: Extends the target list with the new one\n",
+    "* `APPEND_UNIQUE_VALUE`: Appends items that do not already exist in the target list"
    ]
   },
   {
@@ -1191,7 +1191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you load them and merge them with `list_merge_mode=ListMergeMode.EXTEND_IGNORE_DUPLICATES` you will get this:\n"
+    "If you load them and merge them with `list_merge_mode=ListMergeMode.APPEND_UNIQUE_VALUE` you will get this:\n"
    ]
   },
   {
@@ -1205,7 +1205,7 @@
     "cfg_example2 = OmegaConf.load('../source/example2.yaml')\n",
     "cfg_example4 = OmegaConf.load('../source/example4.yaml')\n",
     "\n",
-    "conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode=ListMergeMode.EXTEND_IGNORE_DUPLICATES)\n",
+    "conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode=ListMergeMode.APPEND_UNIQUE_VALUE)\n",
     "print(OmegaConf.to_yaml(conf))"
    ]
   },

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -1152,7 +1152,7 @@
    "source": [
     "The default behavior for lists is that the list from the last config overwrites the others. \n",
     "Use `OmegaConf.merge(cfg1, cfg2, extend_lists=True)` to merge the lists by extending them. \n",
-    "You can specify whether duplicate entries are allowed with the flag `allow_duplicates`. \n",
+    "You can specify whether duplicate entries should removed or not with the flag `remove_duplicates`. \n",
     "This is false, by default, but is only compatible with `extend_lists` activated."
    ]
   },
@@ -1203,7 +1203,7 @@
     "cfg_example2 = OmegaConf.load('../source/example2.yaml')\n",
     "cfg_example4 = OmegaConf.load('../source/example4.yaml')\n",
     "\n",
-    "conf = OmegaConf.merge(cfg_example2, cfg_example4, extend_lists=True, allow_duplicates=True)\n",
+    "conf = OmegaConf.merge(cfg_example2, cfg_example4, extend_lists=True, remove_duplicates=True)\n",
     "print(OmegaConf.to_yaml(conf))"
    ]
   },
@@ -1219,7 +1219,6 @@
     "- user1\n",
     "- user2\n",
     "- user3\n",
-    "- user2\n",
     "```"
    ]
   }

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -1191,7 +1191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you load them and merge them with `list_merge_mode=\"EXTEND_IGNORE_DUPLICATES\"` you will get this:\n"
+    "If you load them and merge them with `list_merge_mode=ListMergeMode.EXTEND_IGNORE_DUPLICATES` you will get this:\n"
    ]
   },
   {
@@ -1200,12 +1200,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from omegaconf import OmegaConf\n",
+    "from omegaconf import OmegaConf, ListMergeMode\n",
     "\n",
     "cfg_example2 = OmegaConf.load('../source/example2.yaml')\n",
     "cfg_example4 = OmegaConf.load('../source/example4.yaml')\n",
     "\n",
-    "conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode=\"EXTEND_IGNORE_DUPLICATES\")\n",
+    "conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode=ListMergeMode.EXTEND_IGNORE_DUPLICATES)\n",
     "print(OmegaConf.to_yaml(conf))"
    ]
   },

--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -1150,10 +1150,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The default behavior for lists is that the list from the last config overwrites the others. \n",
-    "Use `OmegaConf.merge(cfg1, cfg2, extend_lists=True)` to merge the lists by extending them. \n",
-    "You can specify whether duplicate entries should removed or not with the flag `remove_duplicates`. \n",
-    "This is false, by default, but is only compatible with `extend_lists` activated."
+    "By default, `merge()` is replacing the target list with the source list.\n",
+    "Use `list_merge_mode` to control the merge behavior for lists.\n",
+    "Currently there are three different merge modes:\n",
+    "* `OVERRIDE`: content from newer list gets taken (default)\n",
+    "* `EXTEND`: lists get extended\n",
+    "* `EXTEND_IGNORE_DUPLICATES`: only new (unique) elements get extended"
    ]
   },
   {
@@ -1189,7 +1191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you load them and merge them with both attributes set to `True` you will get this:"
+    "If you load them and merge them with `list_merge_mode=\"EXTEND_IGNORE_DUPLICATES\"` you will get this:\n"
    ]
   },
   {
@@ -1203,7 +1205,7 @@
     "cfg_example2 = OmegaConf.load('../source/example2.yaml')\n",
     "cfg_example4 = OmegaConf.load('../source/example4.yaml')\n",
     "\n",
-    "conf = OmegaConf.merge(cfg_example2, cfg_example4, extend_lists=True, remove_duplicates=True)\n",
+    "conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode=\"EXTEND_IGNORE_DUPLICATES\")\n",
     "print(OmegaConf.to_yaml(conf))"
    ]
   },

--- a/docs/source/example4.yaml
+++ b/docs/source/example4.yaml
@@ -1,0 +1,3 @@
+users:
+  - user3
+  - user2

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -497,7 +497,7 @@ Use ``list_merge_mode`` to control the merge behavior for lists.
 This Enum is defined in ``omegaconf.ListMergeMode`` and defines the following modes:
 * ``REPLACE``: Replaces the target list with the new one (default)
 * ``EXTEND``: Extends the target list with the new one
-* ``APPEND_UNIQUE_VALUE``: Appends items that do not already exist in the target list
+* ``EXTEND_UNIQUE``: Extends the target list items with items not present in it
 
 **example2.yaml** file:
 
@@ -509,7 +509,7 @@ This Enum is defined in ``omegaconf.ListMergeMode`` and defines the following mo
 .. include:: example4.yaml
    :code: yaml
 
-If you load them and merge them with ``list_merge_mode=ListMergeMode.APPEND_UNIQUE_VALUE`` you will get this:
+If you load them and merge them with ``list_merge_mode=ListMergeMode.EXTEND_UNIQUE`` you will get this:
 
 .. doctest::
 
@@ -518,7 +518,7 @@ If you load them and merge them with ``list_merge_mode=ListMergeMode.APPEND_UNIQ
     >>> cfg_1 = OmegaConf.load('source/example2.yaml')
     >>> cfg_2 = OmegaConf.load('source/example4.yaml')
     >>> 
-    >>> mode = ListMergeMode.APPEND_UNIQUE_VALUE
+    >>> mode = ListMergeMode.EXTEND_UNIQUE
     >>> conf = OmegaConf.merge(cfg_1, cfg_2, list_merge_mode=mode)
     >>> print(OmegaConf.to_yaml(conf))
     server:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -493,7 +493,8 @@ Note how the port changes to 82, and how the users lists are combined.
     <BLANKLINE>
 
 By default, ``merge()`` is replacing the target list with the source list.
-Use ``list_merge_mode`` to control the merge behavior for lists.
+Use ``list_merge_mode`` to control the merge behavior for lists. 
+You can access the regarding enum with ``from omegaconf import ListMergeMode``.
 Currently there are three different merge modes:
 * ``OVERRIDE``: content from newer list gets taken (default)
 * ``EXTEND``: lists get extended
@@ -509,16 +510,16 @@ Currently there are three different merge modes:
 .. include:: example4.yaml
    :code: yaml
 
-If you load them and merge them with ``list_merge_mode="EXTEND_IGNORE_DUPLICATES"`` you will get this:
+If you load them and merge them with ``list_merge_mode=ListMergeMode.EXTEND_IGNORE_DUPLICATES`` you will get this:
 
 .. doctest::
 
-    >>> from omegaconf import OmegaConf
+    >>> from omegaconf import OmegaConf, ListMergeMode
     >>>
     >>> cfg_example2 = OmegaConf.load('source/example2.yaml')
     >>> cfg_example4 = OmegaConf.load('source/example4.yaml')
     >>> 
-    >>> conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode="EXTEND_IGNORE_DUPLICATES")
+    >>> conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode=ListMergeMode.EXTEND_IGNORE_DUPLICATES)
     >>> print(OmegaConf.to_yaml(conf))
     server:
       port: 80

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -492,6 +492,41 @@ Note how the port changes to 82, and how the users lists are combined.
       file: log.txt
     <BLANKLINE>
 
+The default behavior for lists is that the list from the last config overwrites the others. 
+Use ``OmegaConf.merge(cfg1, cfg2, extend_lists=True)`` to merge the lists by extending them. 
+You can specify whether duplicate entries are allowed with the flag ``allow_duplicates``. 
+This is false, by default, but is only compatible with ``extend_lists`` activated.
+
+**example2.yaml** file:
+
+.. include:: example2.yaml
+   :code: yaml
+
+**example4.yaml** file:
+
+.. include:: example4.yaml
+   :code: yaml
+
+If you load them and merge them with both attributes set to ``True`` you will get this:
+
+.. doctest::
+
+    >>> from omegaconf import OmegaConf
+    >>>
+    >>> cfg_example2 = OmegaConf.load('source/example2.yaml')
+    >>> cfg_example4 = OmegaConf.load('source/example4.yaml')
+    >>> 
+    >>> conf = OmegaConf.merge(cfg_example2, cfg_example4, extend_lists=True, allow_duplicates=True)
+    >>> print(OmegaConf.to_yaml(conf))
+    server:
+      port: 80
+    users:
+    - user1
+    - user2
+    - user3
+    - user2
+    <BLANKLINE>
+
 OmegaConf.unsafe_merge()
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -492,10 +492,12 @@ Note how the port changes to 82, and how the users lists are combined.
       file: log.txt
     <BLANKLINE>
 
-By default, merge is replacing the target list with the source list.
-Use ``OmegaConf.merge(cfg1, cfg2, extend_lists=True)`` to merge the lists by extending them. 
-You can specify whether duplicate entries should be removed or not with the flag ``remove_duplicates``. 
-This is false, by default, and is ignored unless ``extend_lists=True`` .
+By default, ``merge()`` is replacing the target list with the source list.
+Use ``list_merge_mode`` to control the merge behavior for lists.
+Currently there are three different merge modes:
+* ``OVERRIDE``: content from newer list gets taken (default)
+* ``EXTEND``: lists get extended
+* ``EXTEND_IGNORE_DUPLICATES``: only new (unique) elements get extended
 
 **example2.yaml** file:
 
@@ -507,7 +509,7 @@ This is false, by default, and is ignored unless ``extend_lists=True`` .
 .. include:: example4.yaml
    :code: yaml
 
-If you load them and merge them with both attributes set to ``True`` you will get this:
+If you load them and merge them with ``list_merge_mode="EXTEND_IGNORE_DUPLICATES"`` you will get this:
 
 .. doctest::
 
@@ -516,7 +518,7 @@ If you load them and merge them with both attributes set to ``True`` you will ge
     >>> cfg_example2 = OmegaConf.load('source/example2.yaml')
     >>> cfg_example4 = OmegaConf.load('source/example4.yaml')
     >>> 
-    >>> conf = OmegaConf.merge(cfg_example2, cfg_example4, extend_lists=True, remove_duplicates=True)
+    >>> conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode="EXTEND_IGNORE_DUPLICATES")
     >>> print(OmegaConf.to_yaml(conf))
     server:
       port: 80

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -494,7 +494,7 @@ Note how the port changes to 82, and how the users lists are combined.
 
 By default, merge is replacing the target list with the source list.
 Use ``OmegaConf.merge(cfg1, cfg2, extend_lists=True)`` to merge the lists by extending them. 
-You can specify whether duplicate entries are allowed with the flag ``allow_duplicates``. 
+You can specify whether duplicate entries should be removed or not with the flag ``remove_duplicates``. 
 This is false, by default, and is ignored unless ``extend_lists=True`` .
 
 **example2.yaml** file:
@@ -516,7 +516,7 @@ If you load them and merge them with both attributes set to ``True`` you will ge
     >>> cfg_example2 = OmegaConf.load('source/example2.yaml')
     >>> cfg_example4 = OmegaConf.load('source/example4.yaml')
     >>> 
-    >>> conf = OmegaConf.merge(cfg_example2, cfg_example4, extend_lists=True, allow_duplicates=True)
+    >>> conf = OmegaConf.merge(cfg_example2, cfg_example4, extend_lists=True, remove_duplicates=True)
     >>> print(OmegaConf.to_yaml(conf))
     server:
       port: 80
@@ -524,7 +524,6 @@ If you load them and merge them with both attributes set to ``True`` you will ge
     - user1
     - user2
     - user3
-    - user2
     <BLANKLINE>
 
 OmegaConf.unsafe_merge()

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -493,9 +493,8 @@ Note how the port changes to 82, and how the users lists are combined.
     <BLANKLINE>
 
 By default, ``merge()`` is replacing the target list with the source list.
-Use ``list_merge_mode`` to control the merge behavior for lists. 
-You can access the regarding enum with ``from omegaconf import ListMergeMode``.
-Currently there are three different merge modes:
+Use ``list_merge_mode`` to control the merge behavior for lists.
+This Enum is defined in ``omegaconf.ListMergeMode`` and defines the following modes:
 * ``OVERRIDE``: content from newer list gets taken (default)
 * ``EXTEND``: lists get extended
 * ``EXTEND_IGNORE_DUPLICATES``: only new (unique) elements get extended

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -492,10 +492,10 @@ Note how the port changes to 82, and how the users lists are combined.
       file: log.txt
     <BLANKLINE>
 
-The default behavior for lists is that the list from the last config overwrites the others. 
+By default, merge is replacing the target list with the source list.
 Use ``OmegaConf.merge(cfg1, cfg2, extend_lists=True)`` to merge the lists by extending them. 
 You can specify whether duplicate entries are allowed with the flag ``allow_duplicates``. 
-This is false, by default, but is only compatible with ``extend_lists`` activated.
+This is false, by default, and is ignored unless ``extend_lists=True`` .
 
 **example2.yaml** file:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -495,9 +495,9 @@ Note how the port changes to 82, and how the users lists are combined.
 By default, ``merge()`` is replacing the target list with the source list.
 Use ``list_merge_mode`` to control the merge behavior for lists.
 This Enum is defined in ``omegaconf.ListMergeMode`` and defines the following modes:
-* ``OVERRIDE``: content from newer list gets taken (default)
-* ``EXTEND``: lists get extended
-* ``EXTEND_IGNORE_DUPLICATES``: only new (unique) elements get extended
+* ``REPLACE``: Replaces the target list with the new one (default)
+* ``EXTEND``: Extends the target list with the new one
+* ``APPEND_UNIQUE_VALUE``: Appends items that do not already exist in the target list
 
 **example2.yaml** file:
 
@@ -509,16 +509,17 @@ This Enum is defined in ``omegaconf.ListMergeMode`` and defines the following mo
 .. include:: example4.yaml
    :code: yaml
 
-If you load them and merge them with ``list_merge_mode=ListMergeMode.EXTEND_IGNORE_DUPLICATES`` you will get this:
+If you load them and merge them with ``list_merge_mode=ListMergeMode.APPEND_UNIQUE_VALUE`` you will get this:
 
 .. doctest::
 
     >>> from omegaconf import OmegaConf, ListMergeMode
     >>>
-    >>> cfg_example2 = OmegaConf.load('source/example2.yaml')
-    >>> cfg_example4 = OmegaConf.load('source/example4.yaml')
+    >>> cfg_1 = OmegaConf.load('source/example2.yaml')
+    >>> cfg_2 = OmegaConf.load('source/example4.yaml')
     >>> 
-    >>> conf = OmegaConf.merge(cfg_example2, cfg_example4, list_merge_mode=ListMergeMode.EXTEND_IGNORE_DUPLICATES)
+    >>> mode = ListMergeMode.APPEND_UNIQUE_VALUE
+    >>> conf = OmegaConf.merge(cfg_1, cfg_2, list_merge_mode=mode)
     >>> print(OmegaConf.to_yaml(conf))
     server:
       port: 80

--- a/news/1082.feature
+++ b/news/1082.feature
@@ -1,1 +1,1 @@
-OmegaConf.merge() can now concat lists instead of replacing the target list
+OmegaConf.merge() can now takes a list_merge_mode parameter that controls the strategy for merging lists (replace, extend and more).

--- a/news/1082.feature
+++ b/news/1082.feature
@@ -1,1 +1,1 @@
-This change enables deep merging for ListConfigs. Usage: `OmegaConf.merge(cfg1, cfg2, extend_lists=True)`
+OmegaConf.merge() can now concat lists instead of replacing the target list

--- a/news/1082.feature
+++ b/news/1082.feature
@@ -1,1 +1,1 @@
-OmegaConf.merge() can now takes a list_merge_mode parameter that controls the strategy for merging lists (replace, extend and more).
+OmegaConf.merge() can now take a list_merge_mode parameter that controls the strategy for merging lists (replace, extend and more).

--- a/news/1082.feature
+++ b/news/1082.feature
@@ -1,0 +1,1 @@
+This change enables deep merging for ListConfigs. Usage: `OmegaConf.merge(cfg1, cfg2, extend_lists=True)`

--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -1,4 +1,4 @@
-from .base import Container, DictKeyType, Node, SCMode, UnionNode
+from .base import Container, DictKeyType, ListMergeMode, Node, SCMode, UnionNode
 from .dictconfig import DictConfig
 from .errors import (
     KeyValidationError,
@@ -46,6 +46,7 @@ __all__ = [
     "OmegaConf",
     "Resolver",
     "SCMode",
+    "ListMergeMode",
     "flag_override",
     "read_write",
     "open_dict",

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -798,8 +798,8 @@ class SCMode(Enum):
 class ListMergeMode(Enum):
     REPLACE = 1  # Replaces the target list with the new one (default)
     EXTEND = 2  # Extends the target list with the new one
-    APPEND_UNIQUE_VALUE = (
-        3  # Appends items that do not already exist in the target list
+    EXTEND_UNIQUE = (
+        3  # Extends the target list items with items not present in it
     )
 
 

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -795,6 +795,12 @@ class SCMode(Enum):
     INSTANTIATE = 3  # Create a dataclass or attrs class instance
 
 
+class ListMergeMode(Enum):
+    OVERRIDE = 1  # content from newer list gets taken (default)
+    EXTEND = 2  # lists get extended
+    EXTEND_IGNORE_DUPLICATES = 3  # only new (unique) elements get extended
+
+
 class UnionNode(Box):
     """
     This class handles Union type hints. The `_content` attribute is either a

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -796,9 +796,11 @@ class SCMode(Enum):
 
 
 class ListMergeMode(Enum):
-    OVERRIDE = 1  # content from newer list gets taken (default)
-    EXTEND = 2  # lists get extended
-    EXTEND_IGNORE_DUPLICATES = 3  # only new (unique) elements get extended
+    REPLACE = 1  # Replaces the target list with the new one (default)
+    EXTEND = 2  # Extends the target list with the new one
+    APPEND_UNIQUE_VALUE = (
+        3  # Appends items that do not already exist in the target list
+    )
 
 
 class UnionNode(Box):

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -485,7 +485,7 @@ class BaseContainer(Container, ABC):
 
             if list_merge_mode == ListMergeMode.EXTEND:
                 dest.__dict__["_content"].extend(temp_target.__dict__["_content"])
-            elif list_merge_mode == ListMergeMode.APPEND_UNIQUE_VALUE:
+            elif list_merge_mode == ListMergeMode.EXTEND_UNIQUE:
                 for entry in temp_target.__dict__["_content"]:
                     if entry not in dest.__dict__["_content"]:
                         dest.__dict__["_content"].append(entry)

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -308,7 +308,7 @@ class BaseContainer(Container, ABC):
     def _map_merge(
         dest: "BaseContainer",
         src: "BaseContainer",
-        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
+        list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
     ) -> None:
         """merge src into dest and return a new copy, does not modified input"""
         from omegaconf import AnyNode, DictConfig, ValueNode
@@ -452,7 +452,7 @@ class BaseContainer(Container, ABC):
     def _list_merge(
         dest: Any,
         src: Any,
-        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
+        list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
     ) -> None:
         from omegaconf import DictConfig, ListConfig, OmegaConf
 
@@ -485,11 +485,11 @@ class BaseContainer(Container, ABC):
 
             if list_merge_mode == ListMergeMode.EXTEND:
                 dest.__dict__["_content"].extend(temp_target.__dict__["_content"])
-            elif list_merge_mode == ListMergeMode.EXTEND_IGNORE_DUPLICATES:
+            elif list_merge_mode == ListMergeMode.APPEND_UNIQUE_VALUE:
                 for entry in temp_target.__dict__["_content"]:
                     if entry not in dest.__dict__["_content"]:
                         dest.__dict__["_content"].append(entry)
-            else:  # OVERRIDE (default)
+            else:  # REPLACE (default)
                 dest.__dict__["_content"] = temp_target.__dict__["_content"]
 
         # explicit flags on the source config are replacing the flag values in the destination
@@ -504,7 +504,7 @@ class BaseContainer(Container, ABC):
         *others: Union[
             "BaseContainer", Dict[str, Any], List[Any], Tuple[Any, ...], Any
         ],
-        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
+        list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
     ) -> None:
         try:
             self._merge_with(
@@ -519,7 +519,7 @@ class BaseContainer(Container, ABC):
         *others: Union[
             "BaseContainer", Dict[str, Any], List[Any], Tuple[Any, ...], Any
         ],
-        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
+        list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
     ) -> None:
         from .dictconfig import DictConfig
         from .listconfig import ListConfig

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -34,6 +34,7 @@ from .base import (
     Container,
     ContainerMetadata,
     DictKeyType,
+    ListMergeMode,
     Node,
     SCMode,
     UnionNode,
@@ -307,7 +308,7 @@ class BaseContainer(Container, ABC):
     def _map_merge(
         dest: "BaseContainer",
         src: "BaseContainer",
-        list_merge_mode="OVERWRITE",
+        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
     ) -> None:
         """merge src into dest and return a new copy, does not modified input"""
         from omegaconf import AnyNode, DictConfig, ValueNode
@@ -451,7 +452,7 @@ class BaseContainer(Container, ABC):
     def _list_merge(
         dest: Any,
         src: Any,
-        list_merge_mode="OVERWRITE",
+        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
     ) -> None:
         from omegaconf import DictConfig, ListConfig, OmegaConf
 
@@ -482,9 +483,9 @@ class BaseContainer(Container, ABC):
                 for item in src._iter_ex(resolve=False):
                     temp_target.append(item)
 
-            if list_merge_mode == "EXTEND":
+            if list_merge_mode == ListMergeMode.EXTEND:
                 dest.__dict__["_content"].extend(temp_target.__dict__["_content"])
-            elif list_merge_mode == "EXTEND_IGNORE_DUPLICATES":
+            elif list_merge_mode == ListMergeMode.EXTEND_IGNORE_DUPLICATES:
                 for entry in temp_target.__dict__["_content"]:
                     if entry not in dest.__dict__["_content"]:
                         dest.__dict__["_content"].append(entry)
@@ -503,7 +504,7 @@ class BaseContainer(Container, ABC):
         *others: Union[
             "BaseContainer", Dict[str, Any], List[Any], Tuple[Any, ...], Any
         ],
-        list_merge_mode="OVERWRITE",
+        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
     ) -> None:
         try:
             self._merge_with(
@@ -518,7 +519,7 @@ class BaseContainer(Container, ABC):
         *others: Union[
             "BaseContainer", Dict[str, Any], List[Any], Tuple[Any, ...], Any
         ],
-        list_merge_mode="OVERWRITE",
+        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
     ) -> None:
         from .dictconfig import DictConfig
         from .listconfig import ListConfig

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -484,7 +484,6 @@ class BaseContainer(Container, ABC):
 
             if extend_lists:
                 if remove_duplicates:
-                    # remove duplicate entries
                     for entry in temp_target.__dict__["_content"]:
                         if entry not in dest.__dict__["_content"]:
                             dest.__dict__["_content"].append(entry)

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -308,7 +308,7 @@ class BaseContainer(Container, ABC):
         dest: "BaseContainer",
         src: "BaseContainer",
         extend_lists: bool = False,
-        allow_duplicates: bool = False,
+        remove_duplicates: bool = False,
     ) -> None:
         """merge src into dest and return a new copy, does not modified input"""
         from omegaconf import AnyNode, DictConfig, ValueNode
@@ -404,7 +404,7 @@ class BaseContainer(Container, ABC):
                         dest_node._merge_with(
                             src_node,
                             extend_lists=extend_lists,
-                            allow_duplicates=allow_duplicates,
+                            remove_duplicates=remove_duplicates,
                         )
                     elif not src_node_missing:
                         dest.__setitem__(key, src_node)
@@ -451,7 +451,7 @@ class BaseContainer(Container, ABC):
 
     @staticmethod
     def _list_merge(
-        dest: Any, src: Any, extend_lists: bool = False, allow_duplicates: bool = False
+        dest: Any, src: Any, extend_lists: bool = False, remove_duplicates: bool = False
     ) -> None:
         from omegaconf import DictConfig, ListConfig, OmegaConf
 
@@ -483,7 +483,7 @@ class BaseContainer(Container, ABC):
                     temp_target.append(item)
 
             if extend_lists:
-                if not allow_duplicates:
+                if remove_duplicates:
                     # remove duplicate entries
                     for entry in temp_target.__dict__["_content"]:
                         if entry not in dest.__dict__["_content"]:
@@ -506,11 +506,11 @@ class BaseContainer(Container, ABC):
             "BaseContainer", Dict[str, Any], List[Any], Tuple[Any, ...], Any
         ],
         extend_lists: bool = False,
-        allow_duplicates: bool = False,
+        remove_duplicates: bool = False,
     ) -> None:
         try:
             self._merge_with(
-                *others, extend_lists=extend_lists, allow_duplicates=allow_duplicates
+                *others, extend_lists=extend_lists, remove_duplicates=remove_duplicates
             )
         except Exception as e:
             self._format_and_raise(key=None, value=None, cause=e)
@@ -521,7 +521,7 @@ class BaseContainer(Container, ABC):
             "BaseContainer", Dict[str, Any], List[Any], Tuple[Any, ...], Any
         ],
         extend_lists: bool = False,
-        allow_duplicates: bool = False,
+        remove_duplicates: bool = False,
     ) -> None:
         from .dictconfig import DictConfig
         from .listconfig import ListConfig
@@ -541,14 +541,14 @@ class BaseContainer(Container, ABC):
                     self,
                     other,
                     extend_lists=extend_lists,
-                    allow_duplicates=allow_duplicates,
+                    remove_duplicates=remove_duplicates,
                 )
             elif isinstance(self, ListConfig) and isinstance(other, ListConfig):
                 BaseContainer._list_merge(
                     self,
                     other,
                     extend_lists=extend_lists,
-                    allow_duplicates=allow_duplicates,
+                    remove_duplicates=remove_duplicates,
                 )
             else:
                 raise TypeError("Cannot merge DictConfig with ListConfig")

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -304,7 +304,9 @@ class BaseContainer(Container, ABC):
         assert False
 
     @staticmethod
-    def _map_merge(dest: "BaseContainer", src: "BaseContainer") -> None:
+    def _map_merge(
+        dest: "BaseContainer", src: "BaseContainer", extend_lists: bool = False
+    ) -> None:
         """merge src into dest and return a new copy, does not modified input"""
         from omegaconf import AnyNode, DictConfig, ValueNode
 
@@ -396,7 +398,7 @@ class BaseContainer(Container, ABC):
             if dest_node is not None:
                 if isinstance(dest_node, BaseContainer):
                     if isinstance(src_node, BaseContainer):
-                        dest_node._merge_with(src_node)
+                        dest_node._merge_with(src_node, extend_lists=extend_lists)
                     elif not src_node_missing:
                         dest.__setitem__(key, src_node)
                 else:
@@ -441,7 +443,7 @@ class BaseContainer(Container, ABC):
                 dest._set_flag(flag, value)
 
     @staticmethod
-    def _list_merge(dest: Any, src: Any) -> None:
+    def _list_merge(dest: Any, src: Any, extend_lists: bool = False) -> None:
         from omegaconf import DictConfig, ListConfig, OmegaConf
 
         assert isinstance(dest, ListConfig)
@@ -485,9 +487,10 @@ class BaseContainer(Container, ABC):
         *others: Union[
             "BaseContainer", Dict[str, Any], List[Any], Tuple[Any, ...], Any
         ],
+        extend_lists: bool = False,
     ) -> None:
         try:
-            self._merge_with(*others)
+            self._merge_with(*others, extend_lists=extend_lists)
         except Exception as e:
             self._format_and_raise(key=None, value=None, cause=e)
 
@@ -496,6 +499,7 @@ class BaseContainer(Container, ABC):
         *others: Union[
             "BaseContainer", Dict[str, Any], List[Any], Tuple[Any, ...], Any
         ],
+        extend_lists: bool = False,
     ) -> None:
         from .dictconfig import DictConfig
         from .listconfig import ListConfig
@@ -511,9 +515,9 @@ class BaseContainer(Container, ABC):
             other = _ensure_container(other, flags=my_flags)
 
             if isinstance(self, DictConfig) and isinstance(other, DictConfig):
-                BaseContainer._map_merge(self, other)
+                BaseContainer._map_merge(self, other, extend_lists=extend_lists)
             elif isinstance(self, ListConfig) and isinstance(other, ListConfig):
-                BaseContainer._list_merge(self, other)
+                BaseContainer._list_merge(self, other, extend_lists=extend_lists)
             else:
                 raise TypeError("Cannot merge DictConfig with ListConfig")
 

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -499,7 +499,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
             else:
 
                 def key1(x: Any) -> Any:
-                    return key(x._value())  # type: ignore
+                    return key(x._value())
 
             assert isinstance(self.__dict__["_content"], list)
             self.__dict__["_content"].sort(key=key1, reverse=reverse)

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -267,7 +267,7 @@ class OmegaConf:
             OVERRIDE: content from newer list gets taken (default)
             EXTEND: lists get extended
             EXTEND_IGNORE_DUPLICATES: only new (unique) elements get extended
-            hint: `import ListMergeMode` to access the feature
+            hint: use `from omegaconf import ListMergeMode` to access the merge mode
         :return: the merged config object.
         """
         assert len(configs) > 0
@@ -309,7 +309,7 @@ class OmegaConf:
             OVERRIDE: content from newer list gets taken (default)
             EXTEND: lists get extended
             EXTEND_IGNORE_DUPLICATES: only new (unique) elements get extended
-            hint: `from omegaconf.omegaconf import ListMergeMode` to access the merge mode
+            hint: use `from omegaconf import ListMergeMode` to access the merge mode
         :return: the merged config object.
         """
         assert len(configs) > 0

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -265,7 +265,7 @@ class OmegaConf:
 
         :param configs: Input configs
         :param extend_lists: flag to deep merge ListConfigs
-        :param allow_duplicates: lists entries are unique
+        :param allow_duplicates: lists entries are unique. This flag is ignored unless `extend_lists=True`
         :return: the merged config object.
         """
         assert len(configs) > 0

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -257,11 +257,13 @@ class OmegaConf:
             Tuple[Any, ...],
             Any,
         ],
+        extend_lists: bool = False,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
 
         :param configs: Input configs
+        :param extend_lists: flag to deep merge ListConfigs
         :return: the merged config object.
         """
         assert len(configs) > 0
@@ -270,7 +272,7 @@ class OmegaConf:
         assert isinstance(target, (DictConfig, ListConfig))
 
         with flag_override(target, "readonly", False):
-            target.merge_with(*configs[1:])
+            target.merge_with(*configs[1:], extend_lists=extend_lists)
             turned_readonly = target._get_flag("readonly") is True
 
         if turned_readonly:
@@ -288,6 +290,7 @@ class OmegaConf:
             Tuple[Any, ...],
             Any,
         ],
+        extend_lists: bool = False,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
@@ -295,6 +298,7 @@ class OmegaConf:
         However, the input configs must not be used after this operation as will become inconsistent.
 
         :param configs: Input configs
+        :param extend_lists: flag to deep merge ListConfigs
         :return: the merged config object.
         """
         assert len(configs) > 0

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -257,16 +257,16 @@ class OmegaConf:
             Tuple[Any, ...],
             Any,
         ],
-        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
+        list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
 
         :param configs: Input configs
         :param list_merge_mode: Behavior for merging lists
-            OVERRIDE: content from newer list gets taken (default)
-            EXTEND: lists get extended
-            EXTEND_IGNORE_DUPLICATES: only new (unique) elements get extended
+            REPLACE: Replaces the target list with the new one (default)
+            EXTEND: Extends the target list with the new one
+            APPEND_UNIQUE_VALUE: Appends items that do not already exist in the target list
             hint: use `from omegaconf import ListMergeMode` to access the merge mode
         :return: the merged config object.
         """
@@ -297,7 +297,7 @@ class OmegaConf:
             Tuple[Any, ...],
             Any,
         ],
-        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
+        list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
@@ -306,9 +306,9 @@ class OmegaConf:
 
         :param configs: Input configs
         :param list_merge_mode: Behavior for merging lists
-            OVERRIDE: content from newer list gets taken (default)
-            EXTEND: lists get extended
-            EXTEND_IGNORE_DUPLICATES: only new (unique) elements get extended
+            REPLACE: Replaces the target list with the new one (default)
+            EXTEND: Extends the target list with the new one
+            APPEND_UNIQUE_VALUE: Appends items that do not already exist in the target list
             hint: use `from omegaconf import ListMergeMode` to access the merge mode
         :return: the merged config object.
         """

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -266,7 +266,7 @@ class OmegaConf:
         :param list_merge_mode: Behavior for merging lists
             REPLACE: Replaces the target list with the new one (default)
             EXTEND: Extends the target list with the new one
-            APPEND_UNIQUE_VALUE: Appends items that do not already exist in the target list
+            EXTEND_UNIQUE: Extends the target list items with items not present in it
             hint: use `from omegaconf import ListMergeMode` to access the merge mode
         :return: the merged config object.
         """
@@ -308,7 +308,7 @@ class OmegaConf:
         :param list_merge_mode: Behavior for merging lists
             REPLACE: Replaces the target list with the new one (default)
             EXTEND: Extends the target list with the new one
-            APPEND_UNIQUE_VALUE: Appends items that do not already exist in the target list
+            EXTEND_UNIQUE: Extends the target list items with items not present in it
             hint: use `from omegaconf import ListMergeMode` to access the merge mode
         :return: the merged config object.
         """

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -18,6 +18,7 @@ from typing import (
     Generator,
     Iterable,
     List,
+    Literal,
     Optional,
     Set,
     Tuple,
@@ -257,15 +258,18 @@ class OmegaConf:
             Tuple[Any, ...],
             Any,
         ],
-        extend_lists: bool = False,
-        remove_duplicates: bool = False,
+        list_merge_mode: Literal[
+            "OVERRIDE", "EXTEND", "EXTEND_IGNORE_DUPLICATES"
+        ] = "OVERRIDE",
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
 
         :param configs: Input configs
-        :param extend_lists: flag to deep merge ListConfigs
-        :param remove_duplicates: lists entries are unique. This flag is ignored unless `extend_lists=True`
+        :param list_merge_mode: Behavior for merging lists
+            OVERRIDE: content from newer list gets taken (default)
+            EXTEND: lists get extended
+            EXTEND_IGNORE_DUPLICATES: only new (unique) elements get extended
         :return: the merged config object.
         """
         assert len(configs) > 0
@@ -276,8 +280,7 @@ class OmegaConf:
         with flag_override(target, "readonly", False):
             target.merge_with(
                 *configs[1:],
-                extend_lists=extend_lists,
-                remove_duplicates=remove_duplicates,
+                list_merge_mode=list_merge_mode,
             )
             turned_readonly = target._get_flag("readonly") is True
 
@@ -296,8 +299,9 @@ class OmegaConf:
             Tuple[Any, ...],
             Any,
         ],
-        extend_lists: bool = False,
-        remove_duplicates: bool = False,
+        list_merge_mode: Literal[
+            "OVERRIDE", "EXTEND", "EXTEND_IGNORE_DUPLICATES"
+        ] = "OVERRIDE",
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
@@ -305,8 +309,10 @@ class OmegaConf:
         However, the input configs must not be used after this operation as will become inconsistent.
 
         :param configs: Input configs
-        :param extend_lists: flag to deep merge ListConfigs
-        :param remove_duplicates: lists entries are unique. This flag is ignored unless `extend_lists=True`
+        :param list_merge_mode: Behavior for merging lists
+            OVERRIDE: content from newer list gets taken (default)
+            EXTEND: lists get extended
+            EXTEND_IGNORE_DUPLICATES: only new (unique) elements get extended
         :return: the merged config object.
         """
         assert len(configs) > 0
@@ -319,8 +325,7 @@ class OmegaConf:
         ):
             target.merge_with(
                 *configs[1:],
-                extend_lists=extend_lists,
-                remove_duplicates=remove_duplicates,
+                list_merge_mode=list_merge_mode,
             )
             turned_readonly = target._get_flag("readonly") is True
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -18,7 +18,6 @@ from typing import (
     Generator,
     Iterable,
     List,
-    Literal,
     Optional,
     Set,
     Tuple,
@@ -54,7 +53,7 @@ from ._utils import (
     split_key,
     type_str,
 )
-from .base import Box, Container, Node, SCMode, UnionNode
+from .base import Box, Container, ListMergeMode, Node, SCMode, UnionNode
 from .basecontainer import BaseContainer
 from .errors import (
     MissingMandatoryValue,
@@ -258,9 +257,7 @@ class OmegaConf:
             Tuple[Any, ...],
             Any,
         ],
-        list_merge_mode: Literal[
-            "OVERRIDE", "EXTEND", "EXTEND_IGNORE_DUPLICATES"
-        ] = "OVERRIDE",
+        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
@@ -270,6 +267,7 @@ class OmegaConf:
             OVERRIDE: content from newer list gets taken (default)
             EXTEND: lists get extended
             EXTEND_IGNORE_DUPLICATES: only new (unique) elements get extended
+            hint: `import ListMergeMode` to access the feature
         :return: the merged config object.
         """
         assert len(configs) > 0
@@ -299,9 +297,7 @@ class OmegaConf:
             Tuple[Any, ...],
             Any,
         ],
-        list_merge_mode: Literal[
-            "OVERRIDE", "EXTEND", "EXTEND_IGNORE_DUPLICATES"
-        ] = "OVERRIDE",
+        list_merge_mode: ListMergeMode = ListMergeMode.OVERRIDE,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
@@ -313,6 +309,7 @@ class OmegaConf:
             OVERRIDE: content from newer list gets taken (default)
             EXTEND: lists get extended
             EXTEND_IGNORE_DUPLICATES: only new (unique) elements get extended
+            hint: `from omegaconf.omegaconf import ListMergeMode` to access the merge mode
         :return: the merged config object.
         """
         assert len(configs) > 0

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -258,12 +258,14 @@ class OmegaConf:
             Any,
         ],
         extend_lists: bool = False,
+        allow_duplicates: bool = False,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
 
         :param configs: Input configs
         :param extend_lists: flag to deep merge ListConfigs
+        :param allow_duplicates: lists entries are unique
         :return: the merged config object.
         """
         assert len(configs) > 0
@@ -272,7 +274,11 @@ class OmegaConf:
         assert isinstance(target, (DictConfig, ListConfig))
 
         with flag_override(target, "readonly", False):
-            target.merge_with(*configs[1:], extend_lists=extend_lists)
+            target.merge_with(
+                *configs[1:],
+                extend_lists=extend_lists,
+                allow_duplicates=allow_duplicates,
+            )
             turned_readonly = target._get_flag("readonly") is True
 
         if turned_readonly:
@@ -291,6 +297,7 @@ class OmegaConf:
             Any,
         ],
         extend_lists: bool = False,
+        allow_duplicates: bool = False,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
@@ -299,6 +306,7 @@ class OmegaConf:
 
         :param configs: Input configs
         :param extend_lists: flag to deep merge ListConfigs
+        :param allow_duplicates: lists entries are unique
         :return: the merged config object.
         """
         assert len(configs) > 0
@@ -309,7 +317,11 @@ class OmegaConf:
         with flag_override(
             target, ["readonly", "no_deepcopy_set_nodes"], [False, True]
         ):
-            target.merge_with(*configs[1:])
+            target.merge_with(
+                *configs[1:],
+                extend_lists=extend_lists,
+                allow_duplicates=allow_duplicates,
+            )
             turned_readonly = target._get_flag("readonly") is True
 
         if turned_readonly:

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -258,14 +258,14 @@ class OmegaConf:
             Any,
         ],
         extend_lists: bool = False,
-        allow_duplicates: bool = False,
+        remove_duplicates: bool = False,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
 
         :param configs: Input configs
         :param extend_lists: flag to deep merge ListConfigs
-        :param allow_duplicates: lists entries are unique. This flag is ignored unless `extend_lists=True`
+        :param remove_duplicates: lists entries are unique. This flag is ignored unless `extend_lists=True`
         :return: the merged config object.
         """
         assert len(configs) > 0
@@ -277,7 +277,7 @@ class OmegaConf:
             target.merge_with(
                 *configs[1:],
                 extend_lists=extend_lists,
-                allow_duplicates=allow_duplicates,
+                remove_duplicates=remove_duplicates,
             )
             turned_readonly = target._get_flag("readonly") is True
 
@@ -297,7 +297,7 @@ class OmegaConf:
             Any,
         ],
         extend_lists: bool = False,
-        allow_duplicates: bool = False,
+        remove_duplicates: bool = False,
     ) -> Union[ListConfig, DictConfig]:
         """
         Merge a list of previously created configs into a single one
@@ -306,7 +306,7 @@ class OmegaConf:
 
         :param configs: Input configs
         :param extend_lists: flag to deep merge ListConfigs
-        :param allow_duplicates: lists entries are unique
+        :param remove_duplicates: lists entries are unique. This flag is ignored unless `extend_lists=True`
         :return: the merged config object.
         """
         assert len(configs) > 0
@@ -320,7 +320,7 @@ class OmegaConf:
             target.merge_with(
                 *configs[1:],
                 extend_lists=extend_lists,
-                allow_duplicates=allow_duplicates,
+                remove_duplicates=remove_duplicates,
             )
             turned_readonly = target._get_flag("readonly") is True
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1194,7 +1194,7 @@ def test_merge_list_list() -> None:
 @mark.parametrize(
     "list_merge_mode,c1,c2,expected",
     [
-        (ListMergeMode.OVERRIDE, [1, 2], [3, 4], [3, 4]),
+        (ListMergeMode.REPLACE, [1, 2], [3, 4], [3, 4]),
         (ListMergeMode.EXTEND, [{"a": 1}], [{"b": 2}], [{"a": 1}, {"b": 2}]),
         (
             ListMergeMode.EXTEND,
@@ -1211,9 +1211,9 @@ def test_merge_list_list() -> None:
         (ListMergeMode.EXTEND, [[1, 2], [3, 4]], [[5, 6]], [[1, 2], [3, 4], [5, 6]]),
         (ListMergeMode.EXTEND, [1, 2], [1, 2], [1, 2, 1, 2]),
         (ListMergeMode.EXTEND, [{"a": 1}], [{"a": 1}], [{"a": 1}, {"a": 1}]),
-        (ListMergeMode.EXTEND_IGNORE_DUPLICATES, [1, 2], [1, 3], [1, 2, 3]),
+        (ListMergeMode.APPEND_UNIQUE_VALUE, [1, 2], [1, 3], [1, 2, 3]),
         (
-            ListMergeMode.EXTEND_IGNORE_DUPLICATES,
+            ListMergeMode.APPEND_UNIQUE_VALUE,
             [{"a": 1}, {"b": 2}],
             [{"a": 1}, {"c": 3}],
             [{"a": 1}, {"b": 2}, {"c": 3}],

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -34,7 +34,7 @@ from omegaconf._utils import (
     get_value_kind,
     is_structured_config,
 )
-from omegaconf.base import Node
+from omegaconf.base import ListMergeMode, Node
 from omegaconf.errors import ConfigKeyError, UnsupportedValueType
 from omegaconf.nodes import IntegerNode
 from tests import (
@@ -1194,28 +1194,39 @@ def test_merge_list_list() -> None:
 @mark.parametrize(
     "list_merge_mode,c1,c2,expected",
     [
-        ("OVERRIDE", [1, 2], [3, 4], [3, 4]),
-        ("EXTEND", [{"a": 1}], [{"b": 2}], [{"a": 1}, {"b": 2}]),
-        ("EXTEND", {"list": [1, 2]}, {"list": [3, 4]}, {"list": [1, 2, 3, 4]}),
+        (ListMergeMode.OVERRIDE, [1, 2], [3, 4], [3, 4]),
+        (ListMergeMode.EXTEND, [{"a": 1}], [{"b": 2}], [{"a": 1}, {"b": 2}]),
         (
-            "EXTEND",
+            ListMergeMode.EXTEND,
+            {"list": [1, 2]},
+            {"list": [3, 4]},
+            {"list": [1, 2, 3, 4]},
+        ),
+        (
+            ListMergeMode.EXTEND,
             {"list1": [1, 2], "list2": [1, 2]},
             {"list1": [3, 4], "list2": [3, 4]},
             {"list1": [1, 2, 3, 4], "list2": [1, 2, 3, 4]},
         ),
-        ("EXTEND", [[1, 2], [3, 4]], [[5, 6]], [[1, 2], [3, 4], [5, 6]]),
-        ("EXTEND", [1, 2], [1, 2], [1, 2, 1, 2]),
-        ("EXTEND", [{"a": 1}], [{"a": 1}], [{"a": 1}, {"a": 1}]),
-        ("EXTEND_IGNORE_DUPLICATES", [1, 2], [1, 3], [1, 2, 3]),
+        (ListMergeMode.EXTEND, [[1, 2], [3, 4]], [[5, 6]], [[1, 2], [3, 4], [5, 6]]),
+        (ListMergeMode.EXTEND, [1, 2], [1, 2], [1, 2, 1, 2]),
+        (ListMergeMode.EXTEND, [{"a": 1}], [{"a": 1}], [{"a": 1}, {"a": 1}]),
+        (ListMergeMode.EXTEND_IGNORE_DUPLICATES, [1, 2], [1, 3], [1, 2, 3]),
         (
-            "EXTEND_IGNORE_DUPLICATES",
+            ListMergeMode.EXTEND_IGNORE_DUPLICATES,
             [{"a": 1}, {"b": 2}],
             [{"a": 1}, {"c": 3}],
             [{"a": 1}, {"b": 2}, {"c": 3}],
         ),
     ],
 )
-def test_merge_list_modes(merge, c1, c2, list_merge_mode, expected) -> None:
+def test_merge_list_modes(
+    merge: Any,
+    c1: Union[list, dict],
+    c2: Union[list, dict],
+    list_merge_mode: ListMergeMode,
+    expected: Union[list, dict],
+) -> None:
     a = OmegaConf.create(c1)
     b = OmegaConf.create(c2)
     merged = merge(a, b, list_merge_mode=list_merge_mode)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1190,6 +1190,50 @@ def test_merge_list_list() -> None:
     assert a == b
 
 
+def test_merge_list_list_extend() -> None:
+    a = OmegaConf.create([1, 2, 3])
+    b = OmegaConf.create([4, 5, 6])
+    a.merge_with(b, extend_lists=True)
+    assert a == [1, 2, 3, 4, 5, 6]
+
+
+@mark.parametrize(
+    "c1,c2,expected",
+    [
+        ([{"a": 1}], [{"b": 2}], [{"a": 1}, {"b": 2}]),
+        ({"list": [1, 2]}, {"list": [3, 4]}, {"list": [1, 2, 3, 4]}),
+        (
+            {"list1": [1, 2], "list2": [1, 2]},
+            {"list1": [3, 4], "list2": [3, 4]},
+            {"list1": [1, 2, 3, 4], "list2": [1, 2, 3, 4]},
+        ),
+        ([[1, 2], [3, 4]], [[5, 6]], [[1, 2], [3, 4], [5, 6]]),
+        # don't allow duplicate entries
+        ([1, 2], [1, 2], [1, 2]),
+        ([{"a": 1}], [{"a": 1}], [{"a": 1}]),
+    ],
+)
+def test_merge_nested_list_extend(c1: Any, c2: Any, expected: Any) -> None:
+    a = OmegaConf.create(c1)
+    b = OmegaConf.create(c2)
+    a.merge_with(b, extend_lists=True)
+    assert a == expected
+
+
+@mark.parametrize(
+    "c1,c2,expected",
+    [
+        ([1, 2], [1, 2], [1, 2, 1, 2]),
+        ([{"a": 1}], [{"a": 1}], [{"a": 1}, {"a": 1}]),
+    ],
+)
+def test_merge_list_extend_allow_duplicates(c1: Any, c2: Any, expected: Any) -> None:
+    a = OmegaConf.create(c1)
+    b = OmegaConf.create(c2)
+    a.merge_with(b, extend_lists=True, allow_duplicates=True)
+    assert a == expected
+
+
 @mark.parametrize("merge_func", [OmegaConf.merge, OmegaConf.unsafe_merge])
 @mark.parametrize(
     "base, merge, exception",

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1211,9 +1211,9 @@ def test_merge_list_list() -> None:
         (ListMergeMode.EXTEND, [[1, 2], [3, 4]], [[5, 6]], [[1, 2], [3, 4], [5, 6]]),
         (ListMergeMode.EXTEND, [1, 2], [1, 2], [1, 2, 1, 2]),
         (ListMergeMode.EXTEND, [{"a": 1}], [{"a": 1}], [{"a": 1}, {"a": 1}]),
-        (ListMergeMode.APPEND_UNIQUE_VALUE, [1, 2], [1, 3], [1, 2, 3]),
+        (ListMergeMode.EXTEND_UNIQUE, [1, 2], [1, 3], [1, 2, 3]),
         (
-            ListMergeMode.APPEND_UNIQUE_VALUE,
+            ListMergeMode.EXTEND_UNIQUE,
             [{"a": 1}, {"b": 2}],
             [{"a": 1}, {"c": 3}],
             [{"a": 1}, {"b": 2}, {"c": 3}],

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1216,8 +1216,8 @@ def test_merge_list_list_extend() -> None:
 def test_merge_nested_list_extend(c1: Any, c2: Any, expected: Any) -> None:
     a = OmegaConf.create(c1)
     b = OmegaConf.create(c2)
-    a.merge_with(b, extend_lists=True)
-    assert a == expected
+    merged = OmegaConf.merge(a, b, extend_lists=True)
+    assert merged == expected
 
 
 @mark.parametrize(
@@ -1230,8 +1230,8 @@ def test_merge_nested_list_extend(c1: Any, c2: Any, expected: Any) -> None:
 def test_merge_list_extend_allow_duplicates(c1: Any, c2: Any, expected: Any) -> None:
     a = OmegaConf.create(c1)
     b = OmegaConf.create(c2)
-    a.merge_with(b, extend_lists=True, allow_duplicates=True)
-    assert a == expected
+    merged = OmegaConf.merge(a, b, extend_lists=True, allow_duplicates=True)
+    assert merge == expected
 
 
 @mark.parametrize("merge_func", [OmegaConf.merge, OmegaConf.unsafe_merge])

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1222,10 +1222,10 @@ def test_merge_list_list() -> None:
 )
 def test_merge_list_modes(
     merge: Any,
-    c1: Union[list, dict],
-    c2: Union[list, dict],
+    c1: Any,
+    c2: Any,
     list_merge_mode: ListMergeMode,
-    expected: Union[list, dict],
+    expected: Any,
 ) -> None:
     a = OmegaConf.create(c1)
     b = OmegaConf.create(c2)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1222,8 +1222,8 @@ def test_merge_nested_list_extend(c1: Any, c2: Any, expected: Any) -> None:
 @mark.parametrize(
     "c1,c2,expected",
     [
-        ([1, 2], [1, 2], [1, 2]),
-        ([{"a": 1}], [{"a": 1}], [{"a": 1}]),
+        ([1, 2], [1, 3], [1, 2, 3]),
+        ([{"a": 1}, {"b": 2}], [{"a": 1}, {"c": 3}], [{"a": 1}, {"b": 2}, {"c": 3}]),
     ],
 )
 def test_merge_list_extend_remove_duplicates(c1: Any, c2: Any, expected: Any) -> None:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1194,9 +1194,8 @@ def test_merge_list_list() -> None:
 @mark.parametrize(
     "list_merge_mode,c1,c2,expected",
     [
-        ("OVERRIDE", [1, 2], [3, 4], [3, 4])(
-            "EXTEND", [{"a": 1}], [{"b": 2}], [{"a": 1}, {"b": 2}]
-        ),
+        ("OVERRIDE", [1, 2], [3, 4], [3, 4]),
+        ("EXTEND", [{"a": 1}], [{"b": 2}], [{"a": 1}, {"b": 2}]),
         ("EXTEND", {"list": [1, 2]}, {"list": [3, 4]}, {"list": [1, 2, 3, 4]}),
         (
             "EXTEND",

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1208,9 +1208,8 @@ def test_merge_list_list_extend() -> None:
             {"list1": [1, 2, 3, 4], "list2": [1, 2, 3, 4]},
         ),
         ([[1, 2], [3, 4]], [[5, 6]], [[1, 2], [3, 4], [5, 6]]),
-        # don't allow duplicate entries
-        ([1, 2], [1, 2], [1, 2]),
-        ([{"a": 1}], [{"a": 1}], [{"a": 1}]),
+        ([1, 2], [1, 2], [1, 2, 1, 2]),
+        ([{"a": 1}], [{"a": 1}], [{"a": 1}, {"a": 1}]),
     ],
 )
 def test_merge_nested_list_extend(c1: Any, c2: Any, expected: Any) -> None:
@@ -1223,15 +1222,15 @@ def test_merge_nested_list_extend(c1: Any, c2: Any, expected: Any) -> None:
 @mark.parametrize(
     "c1,c2,expected",
     [
-        ([1, 2], [1, 2], [1, 2, 1, 2]),
-        ([{"a": 1}], [{"a": 1}], [{"a": 1}, {"a": 1}]),
+        ([1, 2], [1, 2], [1, 2]),
+        ([{"a": 1}], [{"a": 1}], [{"a": 1}]),
     ],
 )
-def test_merge_list_extend_allow_duplicates(c1: Any, c2: Any, expected: Any) -> None:
+def test_merge_list_extend_remove_duplicates(c1: Any, c2: Any, expected: Any) -> None:
     a = OmegaConf.create(c1)
     b = OmegaConf.create(c2)
-    merged = OmegaConf.merge(a, b, extend_lists=True, allow_duplicates=True)
-    assert merge == expected
+    merged = OmegaConf.merge(a, b, extend_lists=True, remove_duplicates=True)
+    assert merged == expected
 
 
 @mark.parametrize("merge_func", [OmegaConf.merge, OmegaConf.unsafe_merge])


### PR DESCRIPTION
Fixes #1080 

## Proposed changes
* new flags in the `OmegaConf.merge()` function
  * `extend_lists`: this enables (deep) merge support for `ListConfigs` (default: False to ensure backwards compability)
  * `allow_duplicates`:  this controls, if two equal items can be in a list (default: False)

## Examples
If you have a config:
```yaml
list:
   - a
```
and 
```yaml
list:
  - b
```
you will get with the enabled flag `extend_lists` this result:
```yaml
list:
  - a
  - b
```
The functionality of `allow_duplicates` is self explanatory, i guess.

## Tests and Documentation
* Added some basic tests and tests for edge cases (nested objects)
* @omry Where should I add the documentation for this? In `docs/source/usage.rst` or in `docs/notebook/Tutorial.ipynb` or somewhere else?

--- 
### Contributed by  [<img src="https://www.nexenio.com/wp-content/uploads/2021/10/001-nexenio-logo-white-rgb@2x-e1636042495927.png" height="15em" />](https://www.nexenio.com)