### PR TITLE
tests: fix lint error in tests

### DIFF
--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -273,7 +273,7 @@ def test_map_expansion() -> None:
     def foo(a: int, b: int) -> int:
         return a + b
 
-    assert 12 == foo(**c)  # type: ignore[misc]
+    assert 12 == foo(**c)  # type: ignore[misc] # (known mypi error with dict unpacking)
 
 
 def test_items_iterator_behavior() -> None:

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -267,17 +267,13 @@ class TestGetWithDefault:
 
 
 def test_map_expansion() -> None:
-    c = OmegaConf.create({"a": 2, "b": 10})
+    c = OmegaConf.create("{a: 2, b: 10}")
     assert isinstance(c, DictConfig)
 
     def foo(a: int, b: int) -> int:
         return a + b
 
-    a = {**c}["a"]
-    b = {**c}["b"]
-
-    # assert 12 == foo(**c) works as well, but gives lint error
-    assert 12 == foo(a, b)
+    assert 12 == foo(**c)  # type: ignore[misc]
 
 
 def test_items_iterator_behavior() -> None:

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -267,13 +267,17 @@ class TestGetWithDefault:
 
 
 def test_map_expansion() -> None:
-    c = OmegaConf.create("{a: 2, b: 10}")
+    c = OmegaConf.create({"a": 2, "b": 10})
     assert isinstance(c, DictConfig)
 
     def foo(a: int, b: int) -> int:
         return a + b
 
-    assert 12 == foo(**c)
+    a = {**c}["a"]
+    b = {**c}["b"]
+
+    # assert 12 == foo(**c) works as well, but gives lint error
+    assert 12 == foo(a, b)
 
 
 def test_items_iterator_behavior() -> None:


### PR DESCRIPTION
There was a lint error in the tests:

```
tests/test_basic_ops_dict.py:276: error: Keywords must be strings  [misc]
Installing missing stub packages:
/home/circleci/project/.nox/lint-3-10/bin/python -m pip install types-Pygments types-colorama types-setuptools


Found 1 error in 1 file (checked 81 source files)
```
The problem is, that mypy detects the dict unpacking operator `**` in the function call as syntax error. So I adjusted the test, that the unpacking is still tested, but it don't happen in the function call anymore.

This is by the way a common requested feature / bugfix in mypy.
References:
* https://stackoverflow.com/questions/47632128/how-to-get-mypy-to-accept-an-unpacked-dict
* https://github.com/python/mypy/issues/5869
* https://github.com/python/mypy/issues/10023