### PR TITLE
unsafe_merge: detect value with no root

### DIFF
--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -531,8 +531,12 @@ class BaseContainer(Container, ABC):
         if isinstance(value, Node):
             do_deepcopy = not self._get_flag("no_deepcopy_set_nodes")
             if not do_deepcopy and isinstance(value, Box):
+                # Detect the special case where value has no root:
+                value_has_root = (
+                    isinstance(value, Container) or value._get_parent() is not None
+                )
                 # if value is from the same config, perform a deepcopy no matter what.
-                if self._get_root() is value._get_root():
+                if value_has_root and self._get_root() is value._get_root():
                     do_deepcopy = True
 
             if do_deepcopy:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,6 +1,7 @@
 import copy
 import re
 import sys
+from dataclasses import dataclass
 from textwrap import dedent
 from typing import (
     Any,
@@ -1410,6 +1411,26 @@ def test_merge_with_other_as_interpolation(
 ) -> None:
     res = merge(dst, other)
     assert OmegaConf.is_interpolation(res, node)
+
+
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+def test_merge_with_nested_structured_config_and_union_type(
+    merge: Any,
+) -> None:
+    @dataclass
+    class Inner:
+        x: Union[int, str]
+
+    @dataclass
+    class Outer:
+        inner: Inner
+
+    dst = OmegaConf.structured(Outer)
+    src = OmegaConf.create({"inner": {"x": 10}})
+    res = merge(dst, src)
+
+    expected = {"inner": {"x": 10}}
+    assert res == expected
 
 
 @mark.parametrize(


### PR DESCRIPTION
Closes #1087.

This PR addresses an edge-case where `AssertionError` is raised during a
call to `OmegaConf.unsafe_merge`.

This PR is marked as a draft:
- I haven't written tests yet
- I'm not sure if this is the best approach to solving the issue.
