### PR TITLE
fix: remove unused mypy ignore-tag

### DIFF
--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -499,7 +499,7 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
             else:
 
                 def key1(x: Any) -> Any:
-                    return key(x._value())  # type: ignore
+                    return key(x._value())
 
             assert isinstance(self.__dict__["_content"], list)
             self.__dict__["_content"].sort(key=key1, reverse=reverse)


### PR DESCRIPTION
## Proposed changes
* removed a `# type: ignore` comment to satisfy mypy

--- 
### Contributed by  [<img src="https://www.nexenio.com/wp-content/uploads/2021/10/001-nexenio-logo-white-rgb@2x-e1636042495927.png" height="15em" />](https://www.nexenio.com)