### PR TITLE
OmegaConf.resolve: handle custom resolvers returning dict/list

### DIFF
--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -2,8 +2,15 @@ from typing import Any
 
 from omegaconf import MISSING, Container, DictConfig, ListConfig, Node, ValueNode
 from omegaconf.errors import ConfigTypeError, InterpolationToMissingValueError
+from omegaconf.nodes import InterpolationResultNode
 
-from ._utils import _DEFAULT_MARKER_, _get_value
+from ._utils import (
+    _DEFAULT_MARKER_,
+    _ensure_container,
+    _get_value,
+    is_primitive_container,
+    is_structured_config,
+)
 
 
 def _resolve_container_value(cfg: Container, key: Any) -> None:
@@ -17,6 +24,12 @@ def _resolve_container_value(cfg: Container, key: Any) -> None:
         else:
             if isinstance(resolved, Container):
                 _resolve(resolved)
+            if isinstance(resolved, InterpolationResultNode):
+                resolved_value = _get_value(resolved)
+                if is_primitive_container(resolved_value) or is_structured_config(
+                    resolved_value
+                ):
+                    resolved = _ensure_container(resolved_value)
             if isinstance(resolved, Container) and isinstance(node, ValueNode):
                 cfg[key] = resolved
             else:

--- a/tests/interpolation/test_custom_resolvers.py
+++ b/tests/interpolation/test_custom_resolvers.py
@@ -490,8 +490,8 @@ def test_merge_into_resolver_output(
 def test_resolve_resolver_returning_primitive_container(
     restore_resolvers: Any, primitive_container: Any
 ) -> None:
-    OmegaConf.register_new_resolver("returns_dict", lambda: primitive_container)
-    cfg = OmegaConf.create({"foo": "${returns_dict:}"})
+    OmegaConf.register_new_resolver("returns_container", lambda: primitive_container)
+    cfg = OmegaConf.create({"foo": "${returns_container:}"})
     assert cfg.foo == primitive_container
     OmegaConf.resolve(cfg)
     assert cfg.foo == primitive_container

--- a/tests/interpolation/test_custom_resolvers.py
+++ b/tests/interpolation/test_custom_resolvers.py
@@ -6,6 +6,7 @@ from pytest import mark, param, raises, warns
 
 from omegaconf import OmegaConf, Resolver
 from omegaconf.nodes import InterpolationResultNode
+from tests import User
 from tests.interpolation import dereference_node
 
 
@@ -485,6 +486,7 @@ def test_merge_into_resolver_output(
     [
         param({"first": 1, "second": 2}, id="dict"),
         param(["first", "second"], id="list"),
+        param(User(name="Bond", age=7), id="user"),
     ],
 )
 def test_resolve_resolver_returning_primitive_container(

--- a/tests/interpolation/test_custom_resolvers.py
+++ b/tests/interpolation/test_custom_resolvers.py
@@ -478,3 +478,20 @@ def test_merge_into_resolver_output(
 
     cfg = OmegaConf.create({"foo": "${make:}"})
     assert OmegaConf.merge(cfg, cfg2) == expected
+
+
+@mark.parametrize(
+    "primitive_container",
+    [
+        param({"first": 1, "second": 2}, id="dict"),
+        param(["first", "second"], id="list"),
+    ],
+)
+def test_resolve_resolver_returning_primitive_container(
+    restore_resolvers: Any, primitive_container: Any
+) -> None:
+    OmegaConf.register_new_resolver("returns_dict", lambda: primitive_container)
+    cfg = OmegaConf.create({"foo": "${returns_dict:}"})
+    assert cfg.foo == primitive_container
+    OmegaConf.resolve(cfg)
+    assert cfg.foo == primitive_container


### PR DESCRIPTION
The `OmegaConf.resolve` function was erroring when used with a custom resolver that returns a dict or list.

Here's a minimal repro:
```python
# repro.py
from omegaconf import OmegaConf

def my_resolver():
    return {"first": 1, "second": 2}

OmegaConf.register_new_resolver("my_resolver", my_resolver)

yaml = """
test: ${my_resolver:}
"""

config = OmegaConf.create(yaml)
OmegaConf.resolve(config)  # raises omegaconf.errors.UnsupportedValueType
```
```text
$ python repro.py
Traceback (most recent call last):
  File "/home/homestar/dev/omegaconf/repro.py", line 14, in <module>
    OmegaConf.resolve(config)  # raises omegaconf.errors.UnsupportedValueType
  File "/home/homestar/dev/omegaconf/omegaconf/omegaconf.py", line 785, in resolve
    omegaconf._impl._resolve(cfg)
  File "/home/homestar/dev/omegaconf/omegaconf/_impl.py", line 40, in _resolve
    _resolve_container_value(cfg, k)
  File "/home/homestar/dev/omegaconf/omegaconf/_impl.py", line 23, in _resolve_container_value
    node._set_value(_get_value(resolved))
  File "/home/homestar/dev/omegaconf/omegaconf/nodes.py", line 46, in _set_value
    self._val = self.validate_and_convert(value)
  File "/home/homestar/dev/omegaconf/omegaconf/nodes.py", line 76, in validate_and_convert
    return self._validate_and_convert_impl(value)
  File "/home/homestar/dev/omegaconf/omegaconf/nodes.py", line 154, in _validate_and_convert_impl
    raise UnsupportedValueType(
omegaconf.errors.UnsupportedValueType: Value 'dict' is not a supported primitive type
```

Closes #1092.