### PR TITLE
Fix pytest error due to deprecation warning

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -16,11 +16,7 @@ nox.options.error_on_missing_interpreters = True
 def deps(
     session: Session, editable_install: bool, requirements: str = "requirements/dev.txt"
 ) -> None:
-    session.install(
-        "--upgrade",
-        "setuptools<=66",  # pinned due to DeprecationWarning, see https://github.com/omry/omegaconf/issues/1068
-        "pip",
-    )
+    session.install("--upgrade", "setuptools", "pip")
     extra_flags = ["-e"] if editable_install else []
     session.install("-r", requirements, *extra_flags, ".", silent=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ exclude = '''
 '''
 
 [tool.pytest.ini_options]
-addopts = "--import-mode=append -Werror"
+addopts = "--import-mode=append -Werror -W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning' -W 'ignore:Deprecated call to `pkg_resources:DeprecationWarning'"
 pythonpath = ["."]
 
 [tool.towncrier]


### PR DESCRIPTION
Fixes #1100

The fix is similar to what was done in https://github.com/facebookresearch/hydra/pull/2696, instead of pinning a specific version of setuptools as in #1068

I'll mark this PR as draft since I still need to check if #1069 can be reverted now.
[Update: I double checked and we can indeed revert #1069 now, so adding it to this PR]