### PR TITLE
handle SCMode.INSTANTIATE with throw_on_missing=False

### DIFF
--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -1,4 +1,12 @@
-from .base import Container, DictKeyType, ListMergeMode, Node, SCMode, UnionNode
+from .base import (
+    MISSING,
+    Container,
+    DictKeyType,
+    ListMergeMode,
+    Node,
+    SCMode,
+    UnionNode,
+)
 from .dictconfig import DictConfig
 from .errors import (
     KeyValidationError,
@@ -19,16 +27,7 @@ from .nodes import (
     StringNode,
     ValueNode,
 )
-from .omegaconf import (
-    II,
-    MISSING,
-    SI,
-    OmegaConf,
-    Resolver,
-    flag_override,
-    open_dict,
-    read_write,
-)
+from .omegaconf import II, SI, OmegaConf, Resolver, flag_override, open_dict, read_write
 from .version import __version__
 
 __all__ = [

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -378,7 +378,8 @@ def get_dataclass_fields(obj: Any) -> List["dataclasses.Field[Any]"]:
 def get_dataclass_data(
     obj: Any, allow_objects: Optional[bool] = None
 ) -> Dict[str, Any]:
-    from omegaconf.omegaconf import MISSING, OmegaConf, _maybe_wrap
+    from omegaconf import MISSING, OmegaConf
+    from omegaconf.omegaconf import _maybe_wrap
 
     flags = {"allow_objects": allow_objects} if allow_objects is not None else {}
     d = {}

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -38,6 +38,8 @@ from .grammar.gen.OmegaConfGrammarParser import OmegaConfGrammarParser
 from .grammar_parser import parse
 from .grammar_visitor import GrammarVisitor
 
+MISSING: Any = "???"
+
 DictKeyType = Union[str, bytes, int, Enum, float, bool]
 
 

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -286,7 +286,7 @@ class BaseContainer(Container, ABC):
             if structured_config_mode == SCMode.INSTANTIATE and is_structured_config(
                 conf._metadata.object_type
             ):
-                return conf._to_object()
+                return conf._to_object(throw_on_missing=throw_on_missing)
 
             retdict: Dict[DictKeyType, Any] = {}
             for key in conf.keys():

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -38,7 +38,7 @@ from ._utils import (
     is_structured_config_frozen,
     type_str,
 )
-from .base import Box, Container, ContainerMetadata, DictKeyType, Node
+from .base import MISSING, Box, Container, ContainerMetadata, DictKeyType, Node
 from .basecontainer import BaseContainer
 from .errors import (
     ConfigAttributeError,
@@ -716,7 +716,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
 
         return True
 
-    def _to_object(self) -> Any:
+    def _to_object(self, throw_on_missing: bool) -> Any:
         """
         Instantiate an instance of `self._metadata.object_type`.
         This requires `self` to be a structured config.
@@ -741,13 +741,16 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             if node._is_missing():
                 if k not in init_field_names:
                     continue  # MISSING is ignored for init=False fields
-                self._format_and_raise(
-                    key=k,
-                    value=None,
-                    cause=MissingMandatoryValue(
-                        "Structured config of type `$OBJECT_TYPE` has missing mandatory value: $KEY"
-                    ),
-                )
+                if throw_on_missing:
+                    self._format_and_raise(
+                        key=k,
+                        value=None,
+                        cause=MissingMandatoryValue(
+                            "Structured config of type `$OBJECT_TYPE` has missing mandatory value: $KEY"
+                        ),
+                    )
+                else:
+                    v = MISSING
             if isinstance(node, Container):
                 v = OmegaConf.to_object(node)
             else:

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -73,8 +73,6 @@ from .nodes import (
     ValueNode,
 )
 
-MISSING: Any = "???"
-
 Resolver = Callable[..., Any]
 
 

--- a/tests/test_to_container.py
+++ b/tests/test_to_container.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional
 from pytest import fixture, mark, param, raises
 
 from omegaconf import (
+    MISSING,
     DictConfig,
     ListConfig,
     MissingMandatoryValue,
@@ -406,6 +407,17 @@ class TestInstantiateStructuredConfigs:
         assert isinstance(container, dict)
         assert container["color"] == "BLUE"
         assert container["obj"].not_optional is Color.BLUE
+
+    def test_to_container_INSTANTIATE_throw_on_missing_False(self, module: Any) -> None:
+        """Test the lower level `to_container` API with SCMode.INSTANTIATE and throw_on_missing=False"""
+        src = module.User("Bond")  # age: MISSING
+        cfg = OmegaConf.create(src)
+        container = OmegaConf.to_container(
+            cfg, throw_on_missing=False, structured_config_mode=SCMode.INSTANTIATE
+        )
+        assert isinstance(container, module.User)
+        assert container.name == "Bond"
+        assert container.age is MISSING
 
     def test_to_object_InterpolationResolutionError(self, module: Any) -> None:
         with raises(InterpolationResolutionError):


### PR DESCRIPTION
This PR enables `OmegaConf.to_container(..., throw_on_missing=False)` to work for structured configs when `structured_config_mode=SCMode.INSTANTIATE`. Closes #1103.

In addition, this PR moves `MISSING` from `omegaconf.py` into `base.py` to avoid a circular import issue.

Here is an example of the behavior enabled by this PR:
```python
# repro.py
from dataclasses import dataclass
from enum import Enum
import omegaconf
from omegaconf import OmegaConf

@dataclass(frozen=True)
class A:
    x: int

a = OmegaConf.create(A)
container = OmegaConf.to_container(
    a,
    throw_on_missing=False,
    structured_config_mode=omegaconf.SCMode.INSTANTIATE,
)

assert isinstance(container, A)
print(container)
```
### BEFORE:
```
$ python repro.py
Traceback (most recent call last):
  File "/home/homestar/dev/omegaconf/repro.py", line 12, in <module>
    cfg = OmegaConf.to_container(
...
omegaconf.errors.MissingMandatoryValue: Structured config of type `A` has missing mandatory value: x
    full_key: x
    object_type=A
```
### AFTER:
```
$ python repro.py
A(x='???')
```