### PR TITLE
bump version -> `v2.4.0.dev1`

### DIFF
--- a/omegaconf/version.py
+++ b/omegaconf/version.py
@@ -1,6 +1,6 @@
 import sys  # pragma: no cover
 
-__version__ = "2.4.0.dev0"
+__version__ = "2.4.0.dev1"
 
 msg = """OmegaConf 2.0 and above is compatible with Python 3.6 and newer.
 You have the following options:


### PR DESCRIPTION
Bumping the OmegaConf dev version following upload of the `v2.4.0.dev0` prerelease to pypi.org:
https://pypi.org/project/omegaconf/2.4.0.dev0/