### PR TITLE
[Bug Fix] `OmegaConf.missing_keys(cfg)` may fail if contained customi…

### DIFF
--- a/news/1118.bugfix
+++ b/news/1118.bugfix
@@ -1,0 +1,1 @@
+Fix a bug that caused `OmegaConf.missing_keys` to crash if passed a config object containing an interpolation to a missing field.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -823,10 +823,11 @@ class OmegaConf:
                 itr = _cfg
 
             for key in itr:
-                if OmegaConf.is_missing(_cfg, key):
-                    missings.add(_cfg._get_full_key(key))
-                elif OmegaConf.is_config(_cfg[key]):
-                    gather(_cfg[key])
+                if not OmegaConf.is_interpolation(_cfg, key):
+                    if OmegaConf.is_missing(_cfg, key):
+                        missings.add(_cfg._get_full_key(key))
+                    elif OmegaConf.is_config(_cfg[key]):
+                        gather(_cfg[key])
 
         gather(cfg)
         return missings


### PR DESCRIPTION
…zed resolver field that the depends on some missing fields.

`OmegaConf.missing_keys(cfg)` may fail if contained customized resolver field that the depends on some missing fields.