### PR TITLE
feat: set flag `readonly` recursively

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -539,9 +539,10 @@ Configuration flags
 -------------------
 
 OmegaConf support several configuration flags.
-Configuration flags can be set on any configuration node (Sequence or Mapping). if a configuration flag is not set
+Configuration flags can be set on any configuration node (Sequence or Mapping). If a configuration flag is not set
 it inherits the value from the parent of the node.
 The default value inherited from the root node is always false.
+To avoid this inhertence and set a flag explicitly to all children nodes, specify the option `recursive=True`.
 
 .. _read-only-flag:
 
@@ -567,6 +568,17 @@ You can temporarily remove the read only flag from a config object:
     >>> OmegaConf.set_readonly(conf, True)
     >>> with read_write(conf):
     ...   conf.a.b = 20
+    >>> conf.a.b
+    20
+
+Example using `recursive=True`:
+
+.. doctest:: loaded
+
+    >>> conf = OmegaConf.create({"a": {"b": 10}})
+    >>> OmegaConf.set_readonly(conf.a, True)
+    >>> OmegaConf.set_readonly(conf, False, recursive = True)
+    >>> conf.a.b = 20
     >>> conf.a.b
     20
 

--- a/news/1124.feature
+++ b/news/1124.feature
@@ -1,0 +1,1 @@
+OmegaConf.set_readonly() and OmegaConf.set_struct() have an option recursive, that explicitly sets the flag to all children nodes

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -529,6 +529,17 @@ class OmegaConf:
         return conf._get_flag("readonly")
 
     @staticmethod
+    def set_readonly_recursively(conf: Node, value: Optional[bool]) -> None:
+        # noinspection PyProtectedMember
+        conf._set_flag("readonly", value)
+        if isinstance(conf, DictConfig):
+            for key in conf.keys():
+                OmegaConf.set_readonly_recursively(conf._get_child(key), value)
+        elif isinstance(conf, ListConfig):
+            for index in conf:
+                OmegaConf.set_readonly_recursively(conf._get_child(index), value)
+
+    @staticmethod
     def set_struct(conf: Container, value: Optional[bool]) -> None:
         # noinspection PyProtectedMember
         conf._set_flag("struct", value)

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -519,9 +519,11 @@ class OmegaConf:
         OmegaConf.set_cache(to_config, OmegaConf.get_cache(from_config))
 
     @staticmethod
-    def set_readonly(conf: Node, value: Optional[bool]) -> None:
+    def set_readonly(
+        conf: Node, value: Optional[bool], recursive: bool = False
+    ) -> None:
         # noinspection PyProtectedMember
-        conf._set_flag("readonly", value)
+        conf._set_flag("readonly", value, recursive=recursive)
 
     @staticmethod
     def is_readonly(conf: Node) -> Optional[bool]:
@@ -529,20 +531,11 @@ class OmegaConf:
         return conf._get_flag("readonly")
 
     @staticmethod
-    def set_readonly_recursively(conf: Node, value: Optional[bool]) -> None:
+    def set_struct(
+        conf: Container, value: Optional[bool], recursive: bool = False
+    ) -> None:
         # noinspection PyProtectedMember
-        conf._set_flag("readonly", value)
-        if isinstance(conf, DictConfig):
-            for key in conf.keys():
-                OmegaConf.set_readonly_recursively(conf._get_child(key), value)
-        elif isinstance(conf, ListConfig):
-            for index in conf:
-                OmegaConf.set_readonly_recursively(conf._get_child(index), value)
-
-    @staticmethod
-    def set_struct(conf: Container, value: Optional[bool]) -> None:
-        # noinspection PyProtectedMember
-        conf._set_flag("struct", value)
+        conf._set_flag("struct", value, recursive=recursive)
 
     @staticmethod
     def is_struct(conf: Container) -> Optional[bool]:

--- a/tests/test_base_config.py
+++ b/tests/test_base_config.py
@@ -183,6 +183,25 @@ def test_set_flags() -> None:
         c._set_flag(["readonly", "struct"], [True, False, False])
 
 
+@mark.parametrize("config", [{"a": {"b": 1}}, {"a": [1, 2, 3]}])
+def test_set_flag_recursively(config: Any) -> None:
+    c = OmegaConf.create(config)
+    assert not c._get_flag("readonly")
+    assert not c._get_flag("struct")
+    c.a._set_flag(["readonly", "struct"], [True, True], recursive=False)
+    assert c.a._get_flag("readonly")
+    assert c.a._get_flag("struct")
+    assert not c._get_flag("readonly")
+    assert not c._get_flag("struct")
+
+    c._set_flag("readonly", False, recursive=True)
+    assert not c.a._get_flag("readonly")
+    assert c.a._get_flag("struct")
+
+    c._set_flag("struct", False, recursive=True)
+    assert not c.a._get_flag("struct")
+
+
 @mark.parametrize("no_deepcopy_set_nodes", [True, False])
 @mark.parametrize("node", [20, {"b": 10}, [1, 2]])
 def test_get_flag_after_dict_assignment(no_deepcopy_set_nodes: bool, node: Any) -> None:


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve OmegaConf -->

## Motivation

I want a function that sets a value for a flag (atm `readonly`, but can be extended for all / generic flags) recursively.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?

Yes.

## Test Plan

Tests will be added if the basic structure is confirmed.

## Fixes

Fixes #1123 
