### PR TITLE
fix: Nested structured config validation

### DIFF
--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -304,7 +304,7 @@ class BaseContainer(Container, ABC):
         list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
     ) -> None:
         """merge src into dest and return a new copy, does not modified input"""
-        from omegaconf import AnyNode, DictConfig, ValueNode
+        from omegaconf import AnyNode, DictConfig, ListConfig, ValueNode
 
         assert isinstance(dest, DictConfig)
         assert isinstance(src, DictConfig)

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -494,7 +494,7 @@ class BaseContainer(Container, ABC):
 
             for item in src._iter_ex(resolve=False):
                 if prototype is not None:
-                    item = OmegaConf.merge(prototype, item)
+                    item = OmegaConf.merge(prototype, item, list_merge_mode=list_merge_mode)
                 temp_target.append(item)
 
             if list_merge_mode == ListMergeMode.EXTEND:

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -384,12 +384,18 @@ class BaseContainer(Container, ABC):
                     dest_node = dest._get_node(key)
 
             is_optional, et = _resolve_optional(dest._metadata.element_type)
-            if dest_node is None and is_structured_config(et) and not src_node_missing:
-                # merging into a new node. Use element_type as a base
-                dest[key] = DictConfig(
-                    et, parent=dest, ref_type=et, is_optional=is_optional
-                )
-                dest_node = dest._get_node(key)
+            if dest_node is None and not src_node_missing:
+                if is_structured_config(et):
+                    # merging into a new node. Use element_type as a base
+                    dest[key] = DictConfig(
+                        et, parent=dest, ref_type=et, is_optional=is_optional
+                    )
+                    dest_node = dest._get_node(key)
+                elif is_dict_annotation(et):
+                    dest[key] = DictConfig({}, parent=dest, ref_type=et, is_optional=is_optional)
+                    dest_node = dest._get_node(key)
+                elif is_list_annotation(et):
+                    dest[key] = ListConfig([], parent=dest, ref_type=et, is_optional=is_optional)
 
             if dest_node is not None:
                 if isinstance(dest_node, BaseContainer):

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -305,6 +305,7 @@ class BaseContainer(Container, ABC):
     ) -> None:
         """merge src into dest and return a new copy, does not modified input"""
         from omegaconf import AnyNode, DictConfig, ListConfig, ValueNode
+
         from ._utils import get_dict_key_value_types, get_list_element_type
 
         assert isinstance(dest, DictConfig)
@@ -389,19 +390,39 @@ class BaseContainer(Container, ABC):
                 # check if merging into a new node
                 if is_structured_config(et):
                     # Use element_type as a base
-                    dest.__setitem__(key, DictConfig(et, parent=dest, ref_type=et, is_optional=is_optional))
+                    dest.__setitem__(
+                        key,
+                        DictConfig(
+                            et, parent=dest, ref_type=et, is_optional=is_optional
+                        ),
+                    )
                     dest_node = dest._get_node(key)
                 elif is_dict_annotation(et):
                     key_type, element_type = get_dict_key_value_types(et)
-                    dest.__setitem__(key, DictConfig(
-                        {}, parent=dest, ref_type=et, key_type=key_type, element_type=element_type, is_optional=is_optional
-                    ))
+                    dest.__setitem__(
+                        key,
+                        DictConfig(
+                            {},
+                            parent=dest,
+                            ref_type=et,
+                            key_type=key_type,
+                            element_type=element_type,
+                            is_optional=is_optional,
+                        ),
+                    )
                     dest_node = dest._get_node(key)
                 elif is_list_annotation(et):
                     element_type = get_list_element_type(et)
-                    dest.__setitem__(key, ListConfig(
-                        [], parent=dest, ref_type=et, element_type=element_type, is_optional=is_optional
-                    ))
+                    dest.__setitem__(
+                        key,
+                        ListConfig(
+                            [],
+                            parent=dest,
+                            ref_type=et,
+                            element_type=element_type,
+                            is_optional=is_optional,
+                        ),
+                    )
                     dest_node = dest._get_node(key)
 
             if dest_node is not None:
@@ -461,6 +482,7 @@ class BaseContainer(Container, ABC):
         list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
     ) -> None:
         from omegaconf import DictConfig, ListConfig, OmegaConf
+
         from ._utils import get_dict_key_value_types, get_list_element_type
 
         assert isinstance(dest, ListConfig)
@@ -487,14 +509,24 @@ class BaseContainer(Container, ABC):
                 prototype = DictConfig(et, ref_type=et, is_optional=is_optional)
             elif is_dict_annotation(et):
                 key_type, element_type = get_dict_key_value_types(et)
-                prototype = DictConfig({}, ref_type=et, key_type=key_type, element_type=element_type, is_optional=is_optional)
+                prototype = DictConfig(
+                    {},
+                    ref_type=et,
+                    key_type=key_type,
+                    element_type=element_type,
+                    is_optional=is_optional,
+                )
             elif is_list_annotation(et):
                 element_type = get_list_element_type(et)
-                prototype = ListConfig([], ref_type=et, element_type=element_type, is_optional=is_optional)
+                prototype = ListConfig(
+                    [], ref_type=et, element_type=element_type, is_optional=is_optional
+                )
 
             for item in src._iter_ex(resolve=False):
                 if prototype is not None:
-                    item = OmegaConf.merge(prototype, item, list_merge_mode=list_merge_mode)
+                    item = OmegaConf.merge(
+                        prototype, item, list_merge_mode=list_merge_mode
+                    )
                 temp_target.append(item)
 
             if list_merge_mode == ListMergeMode.EXTEND:

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -396,6 +396,7 @@ class BaseContainer(Container, ABC):
                     dest_node = dest._get_node(key)
                 elif is_list_annotation(et):
                     dest[key] = ListConfig([], parent=dest, ref_type=et, is_optional=is_optional)
+                    dest_node = dest._get_node(key)
 
             if dest_node is not None:
                 if isinstance(dest_node, BaseContainer):

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -262,10 +262,10 @@ class NestedWithAny:
 
 @attr.s(auto_attribs=True)
 class DeeplyNestedUser:
-    dsdsu: Dict[str, Dict[str, User]]
-    dslu: Dict[str, List[User]]
-    ldsu: List[Dict[str, User]]
-    llu: List[List[User]]
+    dsdsdsu: Dict[str, Dict[str, Dict[str, User]]]
+    dsdslu: Dict[str, Dict[str, List[User]]]
+    lldsu: List[List[Dict[str, User]]]
+    lllu: List[List[List[User]]]
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -261,6 +261,14 @@ class NestedWithAny:
 
 
 @attr.s(auto_attribs=True)
+class DeeplyNestedUser:
+    dsdsu: Dict[str, Dict[str, User]]
+    dslu: Dict[str, List[User]]
+    ldsu: List[Dict[str, User]]
+    llu: List[List[User]]
+
+
+@attr.s(auto_attribs=True)
 class NoDefaultValue:
     no_default: Any
 

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -264,6 +264,14 @@ class NestedWithAny:
 
 
 @dataclass
+class DeeplyNestedUser:
+    dsdsu: Dict[str, Dict[str, User]]
+    dslu: Dict[str, List[User]]
+    ldsu: List[Dict[str, User]]
+    llu: List[List[User]]
+
+
+@dataclass
 class NoDefaultValue:
     no_default: Any
 

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -265,10 +265,10 @@ class NestedWithAny:
 
 @dataclass
 class DeeplyNestedUser:
-    dsdsu: Dict[str, Dict[str, User]]
-    dslu: Dict[str, List[User]]
-    ldsu: List[Dict[str, User]]
-    llu: List[List[User]]
+    dsdsdsu: Dict[str, Dict[str, Dict[str, User]]]
+    dsdslu: Dict[str, Dict[str, List[User]]]
+    lldsu: List[List[Dict[str, User]]]
+    lllu: List[List[List[User]]]
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses_pre_311.py
+++ b/tests/structured_conf/data/dataclasses_pre_311.py
@@ -263,10 +263,10 @@ class NestedWithAny:
 
 @dataclass
 class DeeplyNestedUser:
-    dsdsu: Dict[str, Dict[str, User]]
-    dslu: Dict[str, List[User]]
-    ldsu: List[Dict[str, User]]
-    llu: List[List[User]]
+    dsdsdsu: Dict[str, Dict[str, Dict[str, User]]]
+    dsdslu: Dict[str, Dict[str, List[User]]]
+    lldsu: List[List[Dict[str, User]]]
+    lllu: List[List[List[User]]]
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses_pre_311.py
+++ b/tests/structured_conf/data/dataclasses_pre_311.py
@@ -262,6 +262,14 @@ class NestedWithAny:
 
 
 @dataclass
+class DeeplyNestedUser:
+    dsdsu: Dict[str, Dict[str, User]]
+    dslu: Dict[str, List[User]]
+    ldsu: List[Dict[str, User]]
+    llu: List[List[User]]
+
+
+@dataclass
 class NoDefaultValue:
     no_default: Any
 

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1915,10 +1915,23 @@ class TestNestedContainers:
                 id="dsdsdsu",
             ),
             param(
-                "dsdslu", lambda uv: {"l1": {"l2": [uv]}}, ["l1", "l2", 0], id="dsdslu"
+                "dsdslu",
+                lambda uv: {"l1": {"l2": [uv]}},
+                ["l1", "l2", 0],
+                id="dsdslu",
             ),
-            param("lldsu", lambda uv: [[{"l3": uv}]], [0, 0, "l3"], id="lldsu"),
-            param("lllu", lambda uv: [[[uv]]], [0, 0, 0], id="lllu"),
+            param(
+                "lldsu",
+                lambda uv: [[{"l3": uv}]],
+                [0, 0, "l3"],
+                id="lldsu",
+            ),
+            param(
+                "lllu",
+                lambda uv: [[[uv]]],
+                [0, 0, 0],
+                id="lllu",
+            ),
         ],
     )
     def test_merge_with_deep_nesting(

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1899,38 +1899,38 @@ class TestNestedContainers:
     @mark.parametrize(
         "user_value, expected_error",
         [
-            param({'name': 'Bond', 'age': 7}, None, id='user-good'),
-            param({'cat': 'Bond', 'turnip': 7}, ConfigKeyError, id='user-bad-key'),
-            param({'name': 'Bond', 'age': 'abc'}, ValidationError, id='user-bad-type1'),
-            param([1, 2, 3], ConfigTypeError, id='user-bad-type2'),
+            param({"name": "Bond", "age": 7}, None, id="user-good"),
+            param({"cat": "Bond", "turnip": 7}, ConfigKeyError, id="user-bad-key"),
+            param({"name": "Bond", "age": "abc"}, ValidationError, id="user-bad-type1"),
+            param([1, 2, 3], ConfigTypeError, id="user-bad-type2"),
         ]
     )
     @mark.parametrize(
         "key, make_nested, indices",
         [
             param(
-                'dsdsdsu',
-                lambda uv: {'l1': {'l2': {'l3': uv}}},
-                ['l1', 'l2', 'l3'],
-                id='dsdsdsu'
+                "dsdsdsu",
+                lambda uv: {"l1": {"l2": {"l3": uv}}},
+                ["l1", "l2", "l3"],
+                id="dsdsdsu"
             ),
             param(
-                'dsdslu',
-                lambda uv: {'l1': {'l2': [uv]}},
-                ['l1', 'l2', 0],
-                id='dsdslu'
+                "dsdslu",
+                lambda uv: {"l1": {"l2": [uv]}},
+                ["l1", "l2", 0],
+                id="dsdslu"
             ),
             param(
-                'lldsu',
-                lambda uv: [[{'l3': uv}]],
-                [0, 0, 'l3'],
-                id='lldsu'
+                "lldsu",
+                lambda uv: [[{"l3": uv}]],
+                [0, 0, "l3"],
+                id="lldsu"
             ),
             param(
-                'lllu',
+                "lllu",
                 lambda uv: [[[uv]]],
                 [0, 0, 0],
-                id='lllu'
+                id="lllu"
             ),
         ]
     )

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1903,7 +1903,7 @@ class TestNestedContainers:
             param({"cat": "Bond", "turnip": 7}, ConfigKeyError, id="user-bad-key"),
             param({"name": "Bond", "age": "abc"}, ValidationError, id="user-bad-type1"),
             param([1, 2, 3], ConfigTypeError, id="user-bad-type2"),
-        ]
+        ],
     )
     @mark.parametrize(
         "key, make_nested, indices",
@@ -1912,27 +1912,14 @@ class TestNestedContainers:
                 "dsdsdsu",
                 lambda uv: {"l1": {"l2": {"l3": uv}}},
                 ["l1", "l2", "l3"],
-                id="dsdsdsu"
+                id="dsdsdsu",
             ),
             param(
-                "dsdslu",
-                lambda uv: {"l1": {"l2": [uv]}},
-                ["l1", "l2", 0],
-                id="dsdslu"
+                "dsdslu", lambda uv: {"l1": {"l2": [uv]}}, ["l1", "l2", 0], id="dsdslu"
             ),
-            param(
-                "lldsu",
-                lambda uv: [[{"l3": uv}]],
-                [0, 0, "l3"],
-                id="lldsu"
-            ),
-            param(
-                "lllu",
-                lambda uv: [[[uv]]],
-                [0, 0, 0],
-                id="lllu"
-            ),
-        ]
+            param("lldsu", lambda uv: [[{"l3": uv}]], [0, 0, "l3"], id="lldsu"),
+            param("lllu", lambda uv: [[[uv]]], [0, 0, 0], id="lllu"),
+        ],
     )
     def test_merge_with_deep_nesting(
         self, module: Any, key: str, make_nested, indices, user_value, expected_error

--- a/tests/test_nested_containers.py
+++ b/tests/test_nested_containers.py
@@ -1408,7 +1408,7 @@ def test_merge_nested_list_promotion() -> None:
         ),
         param(
             [DictConfig({}, element_type=Dict[str, int]), {"foo": 123}],
-            "Value 123 (int) is incompatible with type hint 'typing.Dict[str, int]'",
+            "Cannot assign int to Dict[str, int]",
             id="merge-int-into-dict",
         ),
         param(


### PR DESCRIPTION
## Motivation
This fixes the case where, in your schema, you have a structured config nested in multiple levels of `Dict` and `List`, such as `Dict[Dict[str, User]]`, and the types don't get propagated correctly. This causes no validation to be done on the inner object. Also, after `to_container(..., SCMode.INSTANTIATE)`, what should have been `User` in the result will show up as a `dict`.

## Further explanation
Looking at the original issue case...
```python
>>> typed.single_nest.level_1._metadata
ContainerMetadata(ref_type=<class '__main__.DeeplyNestedConf'>, object_type=<class '__main__.DeeplyNestedConf'>, optional=False, key='level_1', flags={}, flags_root=False, resolver_cache=defaultdict(<class 'dict'>, {}), key_type=typing.Any, element_type=typing.Any)

>>> typed.double_nest.level_1.nested_level_1._metadata
ContainerMetadata(ref_type=<class '__main__.DeeplyNestedConf'>, object_type=<class 'dict'>, optional=False, key='nested_level_1', flags={}, flags_root=False, resolver_cache=defaultdict(<class 'dict'>, {}), key_type=typing.Any, element_type=typing.Any)
```
The `ref_type` was getting propagated correctly, but the `object_type` was not.

## Test Plan
Added `test_merge_with_deep_nesting()` which checks for the buggy behavior on various deeply-nested containers.

With these changes, there is a bit of coverage missing for [basecontainer.py L982-L986](https://github.com/bzczb/omegaconf/blob/81e826be396bbd06e1a70c4f3e1acf7e83f83421/omegaconf/basecontainer.py#L982-L986). I don't know how to get that last bit of coverage...



## Fixes
Fixes #1019 Nested structured config validation
