### PR TITLE
Support Factory in attrs.

### DIFF
--- a/news/945.bugfix
+++ b/news/945.bugfix
@@ -1,0 +1,1 @@
+Fix handling of `attrs` classes that use a default factory (`attrs.Factory`).

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -479,9 +479,22 @@ def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, A
         if not is_type:
             value = getattr(obj, name)
         else:
-            value = attrib.default
-            if value == attr.NOTHING:
+            default = attrib.default
+            if default == attr.NOTHING:
                 value = MISSING
+            elif isinstance(default, attr.Factory):  # type: ignore[arg-type]
+                assert default is not None
+                if default.takes_self:
+                    e = ConfigValueError(
+                        "'takes_self' in attrs attributes is not supported\n"
+                        + f"{name}: {type_str(type_)}"
+                    )
+                    format_and_raise(
+                        node=None, key=None, value=default, cause=e, msg=str(e)
+                    )
+                value = default.factory()
+            else:
+                value = default
         if is_union_annotation(type_) and not is_supported_union_annotation(type_):
             e = ConfigValueError(
                 f"Unions of containers are not supported:\n{name}: {type_str(type_)}"  # noqa: E231

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ from omegaconf._utils import (  # _normalize_ref_type,
     is_union_annotation,
     split_key,
 )
-from omegaconf.errors import UnsupportedValueType, ValidationError
+from omegaconf.errors import ConfigValueError, UnsupportedValueType, ValidationError
 from omegaconf.nodes import (
     AnyNode,
     BooleanNode,
@@ -298,13 +298,28 @@ class _TestAttrsClass:
     init_false: str = attr.field(init=False, default="foo")
 
 
+@attr.s(auto_attribs=True)
+class _TestAttrsTakesSelf:
+    x: int = 10
+    s: str = "foo"
+    description: str = attr.Factory(lambda self: f"{self.x}, {self.s}", takes_self=True)
+
+
+@attr.s(auto_attribs=True)
+class _TestAttrsFactory:
+    list1: List[int] = attr.Factory(list)
+    dict1: Dict[str, int] = attr.Factory(dict)
+    x: int = attr.Factory(lambda: 10)
+    s: str = attr.Factory(lambda: "foo")
+
+
 @dataclass
 class _TestDataclassIllegalValue:
     x: Any = field(default_factory=IllegalType)
 
 
 @attr.s(auto_attribs=True)
-class _TestAttrllegalValue:
+class _TestAttrIllegalValue:
     x: Any = IllegalType()
 
 
@@ -387,7 +402,7 @@ class TestGetStructuredConfigInfo:
     "test_cls",
     [
         _TestDataclassIllegalValue,
-        _TestAttrllegalValue,
+        _TestAttrIllegalValue,
     ],
 )
 def test_get_structured_config_data_illegal_value(test_cls: Any) -> None:
@@ -399,6 +414,23 @@ def test_get_structured_config_data_illegal_value(test_cls: Any) -> None:
 
     d = _utils.get_structured_config_data(test_cls, allow_objects=True)
     assert d["x"] == IllegalType()
+
+
+def test_get_structured_config_data_attrs_takes_self() -> None:
+    test_cls = _TestAttrsTakesSelf
+    with raises(
+        ConfigValueError, match="'takes_self' in attrs attributes is not supported"
+    ):
+        _utils.get_structured_config_data(test_cls)
+
+
+def test_get_structured_config_data_attrs_factory() -> None:
+    test_cls = _TestAttrsFactory
+    d = _utils.get_structured_config_data(test_cls)
+    assert d["list1"] == []
+    assert d["dict1"] == {}
+    assert d["x"] == 10
+    assert d["s"] == "foo"
 
 
 def test_is_dataclass(mocker: Any) -> None:


### PR DESCRIPTION

* Add support for attr.Factory in structured configs
* Explicitly reject takes_self=True in factories with a ConfigValueError
* Simplify test data and replace duplicated attr_classes_factory.py with targeted tests in test_utils.py
* Restore ErrorListUnsupportedStructuredConfig in dataclass test files
* Improve mypy type inference for attr.Factory
* Add news fragment for release
