### PR TITLE
fix: `SCMode.INSTANTIATE` for attrs fields with aliases/leading "_"

### DIFF
--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -28,7 +28,7 @@ from ._utils import (
     _valid_dict_key_annotation_type,
     format_and_raise,
     get_structured_config_data,
-    get_structured_config_init_field_names,
+    get_structured_config_init_field_aliases,
     get_type_of,
     get_value_kind,
     is_container_annotation,
@@ -726,7 +726,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
 
         object_type = self._metadata.object_type
         assert is_structured_config(object_type)
-        init_field_names = set(get_structured_config_init_field_names(object_type))
+        init_field_aliases = get_structured_config_init_field_aliases(object_type)
 
         init_field_items: Dict[str, Any] = {}
         non_init_field_items: Dict[str, Any] = {}
@@ -739,7 +739,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             except InterpolationResolutionError as e:
                 self._format_and_raise(key=k, value=None, cause=e)
             if node._is_missing():
-                if k not in init_field_names:
+                if k not in init_field_aliases:
                     continue  # MISSING is ignored for init=False fields
                 self._format_and_raise(
                     key=k,
@@ -753,8 +753,8 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             else:
                 v = node._value()
 
-            if k in init_field_names:
-                init_field_items[k] = v
+            if k in init_field_aliases:
+                init_field_items[init_field_aliases[k]] = v
             else:
                 non_init_field_items[k] = v
 

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -651,6 +651,12 @@ class HasInitFalseFields:
         self.post_initialized = "set_by_post_init"
 
 
+@attr.s(auto_attribs=True)
+class LeadingUnderscoreFields:
+    _foo: str = "x"
+    _bar: str = "y"
+
+
 class NestedContainers:
     @attr.s(auto_attribs=True)
     class ListOfLists:

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -676,6 +676,12 @@ class HasInitFalseFields:
         self.post_initialized = "set_by_post_init"
 
 
+@dataclass
+class LeadingUnderscoreFields:
+    _foo: str = "x"
+    _bar: str = "y"
+
+
 class NestedContainers:
     @dataclass
     class ListOfLists:

--- a/tests/structured_conf/data/dataclasses_pre_311.py
+++ b/tests/structured_conf/data/dataclasses_pre_311.py
@@ -672,6 +672,12 @@ class HasInitFalseFields:
         self.post_initialized = "set_by_post_init"
 
 
+@dataclass
+class LeadingUnderscoreFields:
+    _foo: str = "x"
+    _bar: str = "y"
+
+
 class NestedContainers:
     @dataclass
     class ListOfLists:

--- a/tests/test_to_container.py
+++ b/tests/test_to_container.py
@@ -527,6 +527,14 @@ class TestInstantiateStructuredConfigs:
         data = OmegaConf.to_object(cfg)
         assert data == module.HasIgnoreMetadataWithDefault(1, 4)
 
+    def test_leading_underscore_fields(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.LeadingUnderscoreFields)
+        container = OmegaConf.to_container(
+            cfg, structured_config_mode=SCMode.INSTANTIATE
+        )
+        assert isinstance(container, module.LeadingUnderscoreFields)
+        assert container._foo == "x" and container._bar == "y"
+
 
 class TestEnumToStr:
     """Test the `enum_to_str` argument to the `OmegaConf.to_container function`"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -371,13 +371,15 @@ class TestGetStructuredConfigInfo:
         "test_cls_or_obj",
         [_TestDataclass, _TestDataclass(), _TestAttrsClass, _TestAttrsClass()],
     )
-    def test_get_structured_config_field_names(self, test_cls_or_obj: Any) -> None:
-        field_names = _utils.get_structured_config_init_field_names(test_cls_or_obj)
-        assert field_names == ["x", "s", "b", "p", "d", "f", "e", "list1", "dict1"]
+    def test_get_structured_config_field_aliases(self, test_cls_or_obj: Any) -> None:
+        field_names = _utils.get_structured_config_init_field_aliases(test_cls_or_obj)
+        compare = ["x", "s", "b", "p", "d", "f", "e", "list1", "dict1"]
+        assert list(field_names.keys()) == compare
+        assert list(field_names.values()) == compare
 
-    def test_get_structured_config_field_names_throws_ValueError(self) -> None:
+    def test_get_structured_config_field_aliases_throws_ValueError(self) -> None:
         with raises(ValueError):
-            _utils.get_structured_config_init_field_names("invalid")
+            _utils.get_structured_config_init_field_aliases("invalid")
 
 
 @mark.parametrize(


### PR DESCRIPTION
## Motivation
`attrs` classes automatically alias any fields with a leading underscore to a stripped version in that class's `__init__()`.
So, the class
```python
@attr.s
class Foo():
    _bar: int = attr.ib(default=0)
```
has an `__init__()` that looks like:
```python
def __init__(self, bar):
    self._bar = bar
```
---
This PR changes the structured config instantiation behavior to take aliases into account, when setting up the params for an `__init__()`.

## Test Plan
Test `test_leading_underscore_fields()` added.

## Fixes
Fixes #1063