### PR TITLE
feat: add support for dataclasses._MISSING_TYPE

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -7,6 +7,7 @@ import pathlib
 import sys
 import warnings
 from collections import defaultdict
+from dataclasses import _MISSING_TYPE
 from contextlib import contextmanager, nullcontext
 from enum import Enum
 from textwrap import dedent
@@ -845,6 +846,8 @@ class OmegaConf:
 
             if obj is _DEFAULT_MARKER_:
                 obj = {}
+            if isinstance(obj, _MISSING_TYPE):
+                return OmegaConf.create({}, parent=parent, flags=flags)
             if isinstance(obj, str):
                 obj = yaml.load(obj, Loader=get_yaml_loader())
                 if obj is None:

--- a/tests/test_missing_type.py
+++ b/tests/test_missing_type.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass, field
+from typing import List, Any
+from omegaconf import OmegaConf
+
+
+@dataclass
+class Example:
+    num: int
+
+
+@dataclass
+class TestConfig(Example):
+    common: Example = field(default_factory=Example)
+
+
+for k, field_info in TestConfig.__dataclass_fields__.items():
+    default_value = field_info.default
+    default_factory = field_info.default_factory
+    print(
+        f"Field: {k}, Default Value: {default_value}, Default Factory: {default_factory}"
+    )
+
+    mis = OmegaConf.structured(default_factory)


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve OmegaConf -->

## Motivation

I am using fairseq with Python 3.11, finding that there are some compatibility issues here.
If I want to use newer version, I have to change some code. 

![image](https://github.com/omry/omegaconf/assets/19658300/1f4f539f-ef97-42a4-ba37-e30f79cdd5d6)

The error code as above

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I made a test file to reproduce this error.

## Fixes



Fixes #1136

## Related PRs

Not found
