### PR TITLE
add required `build.os` key to .readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,9 +14,13 @@ sphinx:
 formats:
   - pdf
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Work in progress to fix issues with readthedocs build.

Context:
![image](https://github.com/omry/omegaconf/assets/8935917/c6858a41-6ef6-4640-86b9-2a044ca7db19)

