### PR TITLE
readthedocs: use asdf to provide java for building wheel

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+  commands:
+    - asdf plugin add java
+    - asdf install java latest:adoptopenjdk-11
+    - asdf global java latest:adoptopenjdk-11
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
Currently readthedocs is broken due to a missing dependency on java.
Readthedocs supports using the `asdf` tool to isntall utilities such as java (see [here](https://github.com/readthedocs/readthedocs.org/issues/10346#issuecomment-1576570469)).
Closes #1141.
