### PR TITLE
readthedocs: install java via post_system_dependencies hook

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,10 +18,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
-  commands:
-    - asdf plugin add java
-    - asdf install java latest:adoptopenjdk-11
-    - asdf global java latest:adoptopenjdk-11
+  jobs:
+    post_system_dependencies:
+      - asdf plugin add java
+      - asdf install java latest:adoptopenjdk-11
+      - asdf global java latest:adoptopenjdk-11
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
This is a follow-up to PR #1142 that changes the `.readthedocs` config file.
Rather than using the `build.commands` key to install java, we use `build.jobs.post_system_dependencies`.
The problem with the previous approach is that `build.command` overrides all other build steps performed by readthedocs, which we do not want.

![image](https://github.com/omry/omegaconf/assets/8935917/f89da043-12cf-42dd-b635-be71efd1a7ed)
