### PR TITLE
Use CSafeLoader when possible

### DIFF
--- a/news/1150.feature
+++ b/news/1150.feature
@@ -1,0 +1,1 @@
+Yaml parser will now use `yaml.CSafeLoader` instead of `yaml.SafeLoader` whenever possible to speed up parsing.

--- a/news/1150.feature
+++ b/news/1150.feature
@@ -1,1 +1,1 @@
-Yaml parser will now use `yaml.CSafeLoader` instead of `yaml.SafeLoader` whenever possible to speed up parsing.
+The YAML parser will now use `yaml.CSafeLoader` instead of `yaml.SafeLoader` whenever possible to speed up parsing

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -36,10 +36,9 @@ except ImportError:  # pragma: no cover
 
 try:
     from yaml import CSafeLoader
-    BaseLoader: Type[SafeLoader] = CSafeLoader
+    BaseLoader = CSafeLoader
 except ImportError:  # pragma: no cover
-    from yaml import SafeLoader
-    BaseLoader: Type[SafeLoader] = SafeLoader
+    BaseLoader = yaml.SafeLoader
 
 NoneType: Type[None] = type(None)
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -34,6 +34,12 @@ try:
 except ImportError:  # pragma: no cover
     attr = None  # type: ignore # pragma: no cover
 
+# Check for CSafeLoader availability
+try:
+    from yaml import CSafeLoader as BaseLoader
+except ImportError:
+    from yaml import SafeLoader as BaseLoader
+
 NoneType: Type[None] = type(None)
 
 BUILTIN_VALUE_TYPES: Tuple[Type[Any], ...] = (
@@ -123,7 +129,7 @@ def yaml_is_bool(b: str) -> bool:
 
 
 def get_yaml_loader() -> Any:
-    class OmegaConfLoader(yaml.SafeLoader):  # type: ignore
+    class OmegaConfLoader(BaseLoader):  # type: ignore
         def construct_mapping(self, node: yaml.Node, deep: bool = False) -> Any:
             keys = set()
             for key_node, value_node in node.value:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -36,6 +36,7 @@ except ImportError:  # pragma: no cover
 
 try:
     from yaml import CSafeLoader
+
     BaseLoader = CSafeLoader
 except ImportError:  # pragma: no cover
     BaseLoader = yaml.SafeLoader

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -34,11 +34,12 @@ try:
 except ImportError:  # pragma: no cover
     attr = None  # type: ignore # pragma: no cover
 
-# Check for CSafeLoader availability
 try:
-    from yaml import CSafeLoader as BaseLoader
-except ImportError:
-    from yaml import SafeLoader as BaseLoader
+    from yaml import CSafeLoader
+    BaseLoader: Type[SafeLoader] = CSafeLoader
+except ImportError:  # pragma: no cover
+    from yaml import SafeLoader
+    BaseLoader: Type[SafeLoader] = SafeLoader
 
 NoneType: Type[None] = type(None)
 


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve OmegaConf -->

## Motivation

`yaml.CSafeLoader` is **significantly** faster. However, it is not always available. The proposed change is to use it whenever it is available with a fall back to `yaml.SafeLoader` (current loader).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

No additional tests required, current tests should cover yaml being parsed correctly.

## Fixes

What issue does this PR fix? Use https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue to link this PR to a corresponding issue.

Fixes #1149 

## Related PRs

-
