### PR TITLE
bump version -> v2.4.0.dev3

### DIFF
--- a/omegaconf/version.py
+++ b/omegaconf/version.py
@@ -1,6 +1,6 @@
 import sys  # pragma: no cover
 
-__version__ = "2.4.0.dev2"
+__version__ = "2.4.0.dev3"
 
 msg = """OmegaConf 2.4 and above is compatible with Python 3.8 and newer.
 You have the following options:


### PR DESCRIPTION
This PR bumps the dev version of OmegaConf. I'll publish v2.4.0.dev3 to PyPI shortly.
