### PR TITLE
Fix invalid metadata for 2.0 branch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-PyYAML>=5.1.*
+PyYAML>=5.1.0
 # Use dataclasses backport for Python 3.6.
 dataclasses;python_version=='3.6'
 typing-extensions


### PR DESCRIPTION
So this can be used with pip >= 24.1

## Motivation

omegaconf 2.0 `requirements/base.txt` has this line:

```ini
PyYAML>=5.1.*
```

which is considered an invalid metadata for pip >= 24.1, and makes it unable to install.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

If it can be installed with `pip install .` (or `pip install omegaconf>2.0.6` (please change the version number to fit), it should be considered a pass.

## Fixes

By change that line in `requirements/base.txt`  to:

```ini
PyYAML>=5.1.0
```
- This PR will fixes issue #1187
  - By fixing that issue, it will also help fixing https://github.com/facebookresearch/fairseq/issues/5436
  - fairseq 0.12.2 depends on omegaconf<2.1
    hydra-core 1.0.7 depends on omegaconf<2.1 and >=2.0.5
    https://github.com/facebookresearch/fairseq/pull/3722
 
