### PR TITLE
Change deepcopy logic to be constrained on correct type

### DIFF
--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -554,7 +554,7 @@ class BaseContainer(Container, ABC):
 
         if isinstance(value, Node):
             do_deepcopy = not self._get_flag("no_deepcopy_set_nodes")
-            if not do_deepcopy and isinstance(value, Box):
+            if not do_deepcopy and isinstance(value, Container):
                 # if value is from the same config, perform a deepcopy no matter what.
                 if self._get_root() is value._get_root():
                     do_deepcopy = True


### PR DESCRIPTION
The deep copy is always done when it is done with an instance of Box and the roots are the same. Box doesn't contain get_root so this condition fails causes an error.

<!-- Thank you for sending a PR and taking the time to improve OmegaConf -->

## Motivation

Broken Case

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?

Yes/No

## Test Plan

This issue is showing up in an internal Meta codebase

## Fixes

No Issue

## Related PRs

None