### PR TITLE
Python 3.13 support: Add support for new `pathlib._local` locations of Path et. al.

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -189,7 +189,18 @@ def get_yaml_loader() -> Any:
         "tag:yaml.org,2002:python/object/apply:pathlib.WindowsPath",
         lambda loader, node: pathlib.WindowsPath(*loader.construct_sequence(node)),
     )
-
+    loader.add_constructor(
+        "tag:yaml.org,2002:python/object/apply:pathlib._local.Path",
+        lambda loader, node: pathlib.Path(*loader.construct_sequence(node)),
+    )
+    loader.add_constructor(
+        "tag:yaml.org,2002:python/object/apply:pathlib._local.PosixPath",
+        lambda loader, node: pathlib.PosixPath(*loader.construct_sequence(node)),
+    )
+    loader.add_constructor(
+        "tag:yaml.org,2002:python/object/apply:pathlib._local.WindowsPath",
+        lambda loader, node: pathlib.WindowsPath(*loader.construct_sequence(node)),
+    )
     return loader
 
 


### PR DESCRIPTION
Needed for compatibility with python 3.13; the class definitions for `pathlib.Path` and co were moved to `pathlib._local`, changing their serialized representations
