### PR TITLE
Modify .coveragerc to fix CI coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
-[run]
+[report]
 omit =
     .nox/*
-    *tests*
+    */tests/*
     docs/*
     omegaconf/grammar/gen/*
     omegaconf/vendor/*
@@ -9,7 +9,6 @@ omit =
     omegaconf/typing.py
     .stubs
 
-[report]
 exclude_lines =
     pragma: no cover
     raise AssertionError


### PR DESCRIPTION
## Motivation

code coverage CI is failing.
This PR attempts to fix that.

It seems there were two problems with the .coveragerc file:
- when running `coverage report`, the `run.omit` setting in `.coveragerc` was not being picked up. I moved the contents of `run.omit` to `report.omit`.
- The omission pattern `*tests*` was not excluding the tests folder form coverage. I changed `*tests*` to `*/tests/*``.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

Verify coverage now succeeds on CI, and that coverage is still measured for the desired omegaconf source directory.