### PR TITLE
Add support for arithmetic operators in number interpolations (fixes #91)

### DIFF
--- a/news/91.feature
+++ b/news/91.feature
@@ -1,0 +1,2 @@
+Support basic arithmetic operators (+, -, *, /) in number interpolations.
+

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -404,7 +404,12 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         if num_children < 3:
             return None
 
-        operator_map = {"+": lambda a, b: a + b, "-": lambda a, b: a - b, "*": lambda a, b: a * b, "/": lambda a, b: a / b}
+        operator_map = {
+            "+": lambda a, b: a + b,
+            "-": lambda a, b: a - b,
+            "*": lambda a, b: a * b,
+            "/": lambda a, b: a / b,
+        }
         i = 0
 
         if not isinstance(children[i], OmegaConfGrammarParser.InterpolationContext):

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -396,7 +396,9 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
 
     def _try_arithmetic_expression(
         self,
-        children: List[Union[TerminalNode, OmegaConfGrammarParser.InterpolationContext]],
+        children: List[
+            Union[TerminalNode, OmegaConfGrammarParser.InterpolationContext]
+        ],
     ) -> Optional[Any]:
         from ._utils import _get_value
 

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -404,7 +404,7 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         if num_children < 3:
             return None
 
-        operator_map = {
+        operator_map: Dict[str, Callable[[float, float], float]] = {
             "+": lambda a, b: a + b,
             "-": lambda a, b: a - b,
             "*": lambda a, b: a * b,
@@ -412,10 +412,11 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         }
         i = 0
 
-        if not isinstance(children[i], OmegaConfGrammarParser.InterpolationContext):
+        child = children[i]
+        if not isinstance(child, OmegaConfGrammarParser.InterpolationContext):
             return None
 
-        resolved = self.visitInterpolation(children[i])
+        resolved = self.visitInterpolation(child)
         value = _get_value(resolved)
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             return None
@@ -455,15 +456,17 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
             if operator == "/":
                 has_division = True
 
-            if not isinstance(children[i], OmegaConfGrammarParser.InterpolationContext):
+            child = children[i]
+            if not isinstance(child, OmegaConfGrammarParser.InterpolationContext):
                 return None
 
-            resolved = self.visitInterpolation(children[i])
+            resolved = self.visitInterpolation(child)
             value = _get_value(resolved)
             if isinstance(value, bool) or not isinstance(value, (int, float)):
                 return None
 
-            result = operator_map[operator](result, value)
+            op_func = operator_map[operator]
+            result = op_func(result, value)
             if not isinstance(value, int):
                 all_int = False
             i += 1

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -417,11 +417,12 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
 
         resolved = self.visitInterpolation(children[i])
         value = _get_value(resolved)
-        if not isinstance(value, (int, float)):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
             return None
 
         result = value
         all_int = isinstance(value, int)
+        has_division = False
         i += 1
 
         while i < num_children:
@@ -451,12 +452,15 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
             if operator is None or i >= num_children:
                 return None
 
+            if operator == "/":
+                has_division = True
+
             if not isinstance(children[i], OmegaConfGrammarParser.InterpolationContext):
                 return None
 
             resolved = self.visitInterpolation(children[i])
             value = _get_value(resolved)
-            if not isinstance(value, (int, float)):
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
                 return None
 
             result = operator_map[operator](result, value)
@@ -464,4 +468,6 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
                 all_int = False
             i += 1
 
+        if has_division:
+            return float(result)
         return int(result) if all_int else float(result)

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -20,14 +20,14 @@ from omegaconf import (
     ValidationError,
 )
 from omegaconf._utils import _ensure_container
+from omegaconf.errors import InterpolationKeyError
+from omegaconf.errors import InterpolationResolutionError
+from omegaconf.errors import InterpolationResolutionError as IRE
 from omegaconf.errors import (
-    InterpolationKeyError,
-    InterpolationResolutionError,
     InterpolationToMissingValueError,
     InterpolationValidationError,
     ReadonlyConfigError,
 )
-from omegaconf.errors import InterpolationResolutionError as IRE
 from omegaconf.nodes import InterpolationResultNode
 from tests import (
     Color,

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -519,3 +519,54 @@ def test_interpolation_like_result_is_not_an_interpolation(
     # Check that the resulting node is read-only.
     with raises(ReadonlyConfigError):
         resolved_node._set_value("foo")
+
+
+def test_arithmetic_addition() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2.0, "d": "${a} + ${b}"})
+    assert cfg.d == 3.0
+    assert isinstance(cfg.d, float)
+
+
+def test_arithmetic_subtraction() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "d": "${a} - ${b}"})
+    assert cfg.d == -1
+    assert isinstance(cfg.d, int)
+
+
+def test_arithmetic_multiplication() -> None:
+    cfg = OmegaConf.create({"a": 2, "b": 3, "d": "${a} * ${b}"})
+    assert cfg.d == 6
+    assert isinstance(cfg.d, int)
+
+
+def test_arithmetic_division() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2.0, "d": "${a} / ${b}"})
+    assert cfg.d == 0.5
+    assert isinstance(cfg.d, float)
+
+
+def test_arithmetic_int_result() -> None:
+    cfg = OmegaConf.create({"a": 2, "b": 3, "d": "${a} * ${b}"})
+    assert isinstance(cfg.d, int)
+    assert cfg.d == 6
+
+
+def test_arithmetic_float_result() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2.0, "d": "${a} + ${b}"})
+    assert isinstance(cfg.d, float)
+    assert cfg.d == 3.0
+
+
+def test_arithmetic_with_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "d": "${a}  +  ${b}"})
+    assert cfg.d == 3
+
+
+def test_arithmetic_non_numeric_fallback() -> None:
+    cfg = OmegaConf.create({"a": "hello", "b": "world", "d": "${a} + ${b}"})
+    assert cfg.d == "hello + world"
+
+
+def test_arithmetic_mixed_types_fallback() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": "world", "d": "${a} + ${b}"})
+    assert cfg.d == "1world"

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -569,4 +569,4 @@ def test_arithmetic_non_numeric_fallback() -> None:
 
 def test_arithmetic_mixed_types_fallback() -> None:
     cfg = OmegaConf.create({"a": 1, "b": "world", "d": "${a} + ${b}"})
-    assert cfg.d == "1world"
+    assert cfg.d == "1 + world"

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -823,3 +823,156 @@ def test_arithmetic_primitive_with_whitespace() -> None:
 def test_arithmetic_primitive_no_whitespace() -> None:
     cfg = OmegaConf.create({"a": 1, "b": 2, "value": "${a}+${b}"})
     assert cfg.value == 3
+
+
+def test_arithmetic_multiple_operators_no_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "c": 3, "value": "${a}+${b}+${c}"})
+    assert cfg.value == 6
+
+
+def test_arithmetic_multiple_operators_with_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "c": 3, "value": "${a}  +  ${b}  +  ${c}"})
+    assert cfg.value == 6
+
+
+def test_arithmetic_subtraction_no_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 5, "b": 2, "value": "${a}-${b}"})
+    assert cfg.value == 3
+
+
+def test_arithmetic_multiplication_no_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 2, "b": 3, "value": "${a}*${b}"})
+    assert cfg.value == 6
+
+
+def test_arithmetic_division_no_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 10, "b": 2, "value": "${a}/${b}"})
+    assert cfg.value == 5.0
+
+
+def test_arithmetic_primitive_context_unquoted_char() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "c": 3})
+    cfg.p1 = "${a}+${b}"
+    cfg.p2 = "${a}-${b}"
+    cfg.p3 = "${a}*${b}"
+    cfg.p4 = "${a}/${b}"
+    cfg.p5 = "${a}+${b}+${c}"
+    assert cfg.p1 == 3
+    assert cfg.p2 == -1
+    assert cfg.p3 == 2
+    assert cfg.p4 == 0.5
+    assert cfg.p5 == 6
+
+
+def test_arithmetic_primitive_context_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "c": 3})
+    cfg.p1 = "${a}  +  ${b}"
+    cfg.p2 = "${a}  -  ${b}"
+    cfg.p3 = "${a}  *  ${b}"
+    cfg.p4 = "${a}  /  ${b}"
+    cfg.p5 = "${a}  +  ${b}  +  ${c}"
+    assert cfg.p1 == 3
+    assert cfg.p2 == -1
+    assert cfg.p3 == 2
+    assert cfg.p4 == 0.5
+    assert cfg.p5 == 6
+
+
+def test_arithmetic_coverage_unquoted_char_all_operators() -> None:
+    cfg = OmegaConf.create({"a": 5, "b": 2, "c": 3})
+    cfg.add = "${a}+${b}"
+    cfg.sub = "${a}-${b}"
+    cfg.mul = "${a}*${b}"
+    cfg.div = "${a}/${b}"
+    cfg.chain = "${a}+${b}+${c}"
+    assert cfg.add == 7
+    assert cfg.sub == 3
+    assert cfg.mul == 10
+    assert cfg.div == 2.5
+    assert cfg.chain == 10
+
+
+def test_arithmetic_coverage_whitespace_all_operators() -> None:
+    cfg = OmegaConf.create({"a": 5, "b": 2, "c": 3})
+    cfg.add = "${a}  +  ${b}"
+    cfg.sub = "${a}  -  ${b}"
+    cfg.mul = "${a}  *  ${b}"
+    cfg.div = "${a}  /  ${b}"
+    cfg.chain = "${a}  +  ${b}  +  ${c}"
+    assert cfg.add == 7
+    assert cfg.sub == 3
+    assert cfg.mul == 10
+    assert cfg.div == 2.5
+    assert cfg.chain == 10
+
+
+def test_arithmetic_in_list_items() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "c": 3})
+    cfg.list = ["${a}+${b}", "${a}-${b}", "${a}*${b}", "${a}/${b}", "${a}+${b}+${c}"]
+    assert cfg.list[0] == 3
+    assert cfg.list[1] == -1
+    assert cfg.list[2] == 2
+    assert cfg.list[3] == 0.5
+    assert cfg.list[4] == 6
+
+
+def test_arithmetic_in_dict_values() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "c": 3})
+    cfg.dict = {
+        "add": "${a}+${b}",
+        "sub": "${a}-${b}",
+        "mul": "${a}*${b}",
+        "div": "${a}/${b}",
+        "chain": "${a}+${b}+${c}",
+    }
+    assert cfg.dict.add == 3
+    assert cfg.dict.sub == -1
+    assert cfg.dict.mul == 2
+    assert cfg.dict.div == 0.5
+    assert cfg.dict.chain == 6
+
+
+def test_arithmetic_in_dict_values_with_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "c": 3})
+    cfg.dict = {
+        "add": "${a}  +  ${b}",
+        "sub": "${a}  -  ${b}",
+        "mul": "${a}  *  ${b}",
+        "div": "${a}  /  ${b}",
+        "chain": "${a}  +  ${b}  +  ${c}",
+    }
+    assert cfg.dict.add == 3
+    assert cfg.dict.sub == -1
+    assert cfg.dict.mul == 2
+    assert cfg.dict.div == 0.5
+    assert cfg.dict.chain == 6
+
+
+def test_arithmetic_yaml_list_primitive_context() -> None:
+    import yaml
+
+    yaml_str = """
+a: 1
+b: 2
+c: 3
+list:
+  - ${a}+${b}
+  - ${a}-${b}
+  - ${a}*${b}
+  - ${a}/${b}
+  - ${a}+${b}+${c}
+  - ${a}  +  ${b}
+  - ${a}  -  ${b}
+  - ${a}  *  ${b}
+  - ${a}  /  ${b}
+"""
+    cfg = OmegaConf.create(yaml.safe_load(yaml_str))
+    assert cfg.list[0] == 3
+    assert cfg.list[1] == -1
+    assert cfg.list[2] == 2
+    assert cfg.list[3] == 0.5
+    assert cfg.list[4] == 6
+    assert cfg.list[5] == 3
+    assert cfg.list[6] == -1
+    assert cfg.list[7] == 2
+    assert cfg.list[8] == 0.5

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -857,10 +857,15 @@ def test_arithmetic_primitive_context_unquoted_char() -> None:
     cfg.p3 = "${a}*${b}"
     cfg.p4 = "${a}/${b}"
     cfg.p5 = "${a}+${b}+${c}"
+    assert isinstance(cfg.p1, int)
     assert cfg.p1 == 3
+    assert isinstance(cfg.p2, int)
     assert cfg.p2 == -1
+    assert isinstance(cfg.p3, int)
     assert cfg.p3 == 2
+    assert isinstance(cfg.p4, float)
     assert cfg.p4 == 0.5
+    assert isinstance(cfg.p5, int)
     assert cfg.p5 == 6
 
 
@@ -871,10 +876,15 @@ def test_arithmetic_primitive_context_whitespace() -> None:
     cfg.p3 = "${a}  *  ${b}"
     cfg.p4 = "${a}  /  ${b}"
     cfg.p5 = "${a}  +  ${b}  +  ${c}"
+    assert isinstance(cfg.p1, int)
     assert cfg.p1 == 3
+    assert isinstance(cfg.p2, int)
     assert cfg.p2 == -1
+    assert isinstance(cfg.p3, int)
     assert cfg.p3 == 2
+    assert isinstance(cfg.p4, float)
     assert cfg.p4 == 0.5
+    assert isinstance(cfg.p5, int)
     assert cfg.p5 == 6
 
 
@@ -885,10 +895,15 @@ def test_arithmetic_coverage_unquoted_char_all_operators() -> None:
     cfg.mul = "${a}*${b}"
     cfg.div = "${a}/${b}"
     cfg.chain = "${a}+${b}+${c}"
+    assert isinstance(cfg.add, int)
     assert cfg.add == 7
+    assert isinstance(cfg.sub, int)
     assert cfg.sub == 3
+    assert isinstance(cfg.mul, int)
     assert cfg.mul == 10
+    assert isinstance(cfg.div, float)
     assert cfg.div == 2.5
+    assert isinstance(cfg.chain, int)
     assert cfg.chain == 10
 
 
@@ -899,10 +914,15 @@ def test_arithmetic_coverage_whitespace_all_operators() -> None:
     cfg.mul = "${a}  *  ${b}"
     cfg.div = "${a}  /  ${b}"
     cfg.chain = "${a}  +  ${b}  +  ${c}"
+    assert isinstance(cfg.add, int)
     assert cfg.add == 7
+    assert isinstance(cfg.sub, int)
     assert cfg.sub == 3
+    assert isinstance(cfg.mul, int)
     assert cfg.mul == 10
+    assert isinstance(cfg.div, float)
     assert cfg.div == 2.5
+    assert isinstance(cfg.chain, int)
     assert cfg.chain == 10
 
 
@@ -925,11 +945,16 @@ def test_arithmetic_in_dict_values() -> None:
         "div": "${a}/${b}",
         "chain": "${a}+${b}+${c}",
     }
-    assert cfg.dict.add == 3
-    assert cfg.dict.sub == -1
-    assert cfg.dict.mul == 2
-    assert cfg.dict.div == 0.5
-    assert cfg.dict.chain == 6
+    assert isinstance(cfg.dict["add"], int)
+    assert cfg.dict["add"] == 3
+    assert isinstance(cfg.dict["sub"], int)
+    assert cfg.dict["sub"] == -1
+    assert isinstance(cfg.dict["mul"], int)
+    assert cfg.dict["mul"] == 2
+    assert isinstance(cfg.dict["div"], float)
+    assert cfg.dict["div"] == 0.5
+    assert isinstance(cfg.dict["chain"], int)
+    assert cfg.dict["chain"] == 6
 
 
 def test_arithmetic_in_dict_values_with_whitespace() -> None:
@@ -941,11 +966,16 @@ def test_arithmetic_in_dict_values_with_whitespace() -> None:
         "div": "${a}  /  ${b}",
         "chain": "${a}  +  ${b}  +  ${c}",
     }
-    assert cfg.dict.add == 3
-    assert cfg.dict.sub == -1
-    assert cfg.dict.mul == 2
-    assert cfg.dict.div == 0.5
-    assert cfg.dict.chain == 6
+    assert isinstance(cfg.dict["add"], int)
+    assert cfg.dict["add"] == 3
+    assert isinstance(cfg.dict["sub"], int)
+    assert cfg.dict["sub"] == -1
+    assert isinstance(cfg.dict["mul"], int)
+    assert cfg.dict["mul"] == 2
+    assert isinstance(cfg.dict["div"], float)
+    assert cfg.dict["div"] == 0.5
+    assert isinstance(cfg.dict["chain"], int)
+    assert cfg.dict["chain"] == 6
 
 
 def test_arithmetic_yaml_list_primitive_context() -> None:

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -775,3 +775,35 @@ def test_arithmetic_four_operands() -> None:
     )
     assert cfg.d == 10
     assert isinstance(cfg.d, int)
+
+
+def test_arithmetic_single_interpolation_no_operator() -> None:
+    cfg = OmegaConf.create({"a": 1, "d": "${a}"})
+    assert cfg.d == 1
+    assert not isinstance(cfg.d, str)
+
+
+def test_arithmetic_operator_followed_by_text() -> None:
+    cfg = OmegaConf.create({"a": 1, "d": "${a} + text"})
+    assert cfg.d == "1 + text"
+
+
+def test_arithmetic_no_operator_between_interpolations() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "d": "${a} ${b}"})
+    assert cfg.d == "1 2"
+
+
+def test_arithmetic_unquoted_char_operator_no_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "d": "${a}+${b}"})
+    assert cfg.d == 3
+    assert isinstance(cfg.d, int)
+
+
+def test_arithmetic_invalid_operator_char() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "d": "${a} % ${b}"})
+    assert cfg.d == "1 % 2"
+
+
+def test_arithmetic_operator_with_invalid_token() -> None:
+    cfg = OmegaConf.create({"a": 1, "d": "${a} +"})
+    assert cfg.d == "1 +"

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -807,3 +807,19 @@ def test_arithmetic_invalid_operator_char() -> None:
 def test_arithmetic_operator_with_invalid_token() -> None:
     cfg = OmegaConf.create({"a": 1, "d": "${a} +"})
     assert cfg.d == "1 +"
+
+
+def test_arithmetic_primitive_context() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "value": "${a} + ${b}"})
+    assert cfg.value == 3
+    assert isinstance(cfg.value, int)
+
+
+def test_arithmetic_primitive_with_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "value": "${a}  +  ${b}"})
+    assert cfg.value == 3
+
+
+def test_arithmetic_primitive_no_whitespace() -> None:
+    cfg = OmegaConf.create({"a": 1, "b": 2, "value": "${a}+${b}"})
+    assert cfg.value == 3


### PR DESCRIPTION
This PR implements support for basic arithmetic operators (+, -, *, /) in number interpolations as requested in issue #91.

## Changes
- Implement arithmetic operations for numeric interpolations in `grammar_visitor.py`
- Return int when both operands are int, float otherwise
- Fall back to string concatenation for non-numeric operands (backward compatible)
- Add comprehensive tests for all operations and edge cases
- Optimize implementation for performance with single-pass processing

## Example Usage
```python
cfg = OmegaConf.create({'a': 1, 'b': 2.0})
cfg.d = '${a} + ${b}'  # Results in 3.0 (float)
cfg.e = '${a} - ${b}'  # Results in -1 (int if both int)
```

## Testing
All tests pass, including:
- Addition, subtraction, multiplication, division
- Type checking (int vs float results)
- Whitespace handling
- Fallback to string concatenation for non-numeric operands