### PR TITLE
support union of dataclasses, Literal, and Sequence.

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -175,7 +175,7 @@ From structured config
 ^^^^^^^^^^^^^^^^^^^^^^
 
 You can create OmegaConf objects from structured config classes or objects. This provides static and runtime type safety.
-See :doc:`structured_config` for more details, or keep reading for a minimal example.
+See :doc:`structured_config` (including :ref:`structured_config_unions`) for more details, or keep reading for a minimal example.
 
 .. doctest::
 

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -279,14 +279,25 @@ def is_union_annotation(type_: Any) -> bool:
 
 
 def is_literal_annotation(type_: Any) -> bool:
+    origin = getattr(type_, "__origin__", None)
+
     try:
-        from typing import Literal
-    except ImportError:
-        try:
-            from typing_extensions import Literal
-        except ImportError:
-            return False
-    return getattr(type_, "__origin__", None) is Literal
+        from typing import Literal as _TypingLiteral
+
+        if origin is _TypingLiteral:
+            return True
+    except ImportError:  # pragma: no cover
+        pass
+
+    try:
+        from typing_extensions import Literal as _ExtLiteral
+
+        if origin is _ExtLiteral:
+            return True  # pragma: no cover
+    except ImportError:  # pragma: no cover
+        pass
+
+    return False
 
 
 def _resolve_optional(type_: Any) -> Tuple[bool, Any]:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -785,6 +785,7 @@ def is_supported_union_annotation(obj: Any) -> bool:
 
     return all(
         is_primitive_type_annotation(arg)
+        or is_literal_annotation(arg)
         or is_structured_config(arg)
         or is_container_annotation(arg)
         or arg in (Any, DictConfig, ListConfig)

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -284,16 +284,14 @@ class Node(ABC):
             memo=memo,
         )
 
-    def _get_root(self) -> "Container":
+    def _get_root(self) -> "Box":
         root: Optional[Box] = self._get_parent()
         if root is None:
-            assert isinstance(self, Container)
-            return self
-        assert root is not None and isinstance(root, Box)
+            return self  # type: ignore
+        assert isinstance(root, Box)
         while root._get_parent() is not None:
             root = root._get_parent()
-            assert root is not None and isinstance(root, Box)
-        assert root is not None and isinstance(root, Container)
+            assert isinstance(root, Box)
         return root
 
     def _is_missing(self) -> bool:
@@ -436,7 +434,7 @@ class Container(Box):
     @abstractmethod
     def __getitem__(self, key_or_index: Any) -> Any: ...
 
-    def _resolve_key_and_root(self, key: str) -> Tuple["Container", str]:
+    def _resolve_key_and_root(self, key: str) -> Tuple["Box", str]:
         orig = key
         if not key.startswith("."):
             return self._get_root(), key
@@ -649,6 +647,9 @@ class Container(Box):
             raise InterpolationKeyError(
                 f"ConfigKeyError while resolving interpolation: {exc}"
             ).with_traceback(sys.exc_info()[2])
+
+        if not isinstance(root_node, Container):
+            raise InterpolationKeyError(f"Interpolation key '{inter_key}' not found")
 
         try:
             parent, last_key, value = root_node._select_impl(

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -1063,6 +1063,7 @@ class UnionNode(Box):
                     )
                     return
 
+        validation_errors = []
         for candidate_ref_type in ref_type.__args__:
             try:
                 # `bool` is a subclass of `int` in Python. For unions that do not
@@ -1081,12 +1082,26 @@ class UnionNode(Box):
                     parent=self,
                 )
                 break
-            except ValidationError:
+            except ValidationError as e:
+                validation_errors.append(e)
                 continue
         else:
-            raise ValidationError(
-                f"Value '$VALUE' of type '$VALUE_TYPE' is incompatible with type hint '{type_str(type_hint)}'"
-            )
+            msg = f"Value '$VALUE' of type '$VALUE_TYPE' is incompatible with type hint '{type_str(type_hint)}'"
+            if validation_errors:
+                import textwrap
+
+                msg += "\nValidation errors of candidate types:"
+                for e in validation_errors:
+                    indented_err = textwrap.indent(str(e), prefix="  - ")
+                    # Replace subsequent lines' prefix so only first line has hyphen
+                    parts = indented_err.split("\n")
+                    if len(parts) > 1:
+                        for i in range(1, len(parts)):
+                            if parts[i].startswith("  - "):
+                                parts[i] = "    " + parts[i][4:]
+                    indented_err = "\n".join(parts)
+                    msg += f"\n{indented_err}"
+            raise ValidationError(msg)
 
     def _dereference_node_impl(
         self,

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -26,6 +26,7 @@ from ._utils import (
     is_list_annotation,
     is_primitive_dict,
     is_primitive_type_annotation,
+    is_sequence_annotation,
     is_structured_config,
     is_tuple_annotation,
     is_union_annotation,
@@ -130,7 +131,7 @@ class BaseContainer(Container, ABC):
         if is_container_annotation(ref_type):
             if is_dict_annotation(ref_type):
                 dict_copy["_metadata"].ref_type = Dict
-            elif is_list_annotation(ref_type):
+            elif is_list_annotation(ref_type) or is_sequence_annotation(ref_type):
                 dict_copy["_metadata"].ref_type = List
             else:
                 assert False
@@ -403,7 +404,11 @@ class BaseContainer(Container, ABC):
             if rt is not Any:
                 if is_dict_annotation(rt):
                     val = {}
-                elif is_list_annotation(rt) or is_tuple_annotation(rt):
+                elif (
+                    is_list_annotation(rt)
+                    or is_tuple_annotation(rt)
+                    or is_sequence_annotation(rt)
+                ):
                     val = []
                 else:
                     val = rt

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -47,7 +47,11 @@ class ValueNode(Node):
 
     def _strict_validate_type(self, value: Any) -> None:
         ref_type = self._metadata.ref_type
-        if isinstance(ref_type, type) and type(value) is not ref_type:
+        if (
+            isinstance(ref_type, type)
+            and ref_type is not Any
+            and type(value) is not ref_type
+        ):
             type_hint = type_str(self._metadata.type_hint)
             raise ValidationError(
                 f"Value '$VALUE' of type '$VALUE_TYPE' is incompatible with type hint '{type_hint}'"

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -530,6 +530,9 @@ class LiteralNode(ValueNode):
             ),
         )
 
+    def _strict_validate_type(self, value: Any) -> None:
+        self._validate_and_convert_impl(value)
+
     def _validate_and_convert_impl(self, value: Any) -> Any:
         if not is_literal_annotation(self._metadata.ref_type):
             raise ValidationError("LiteralNode ref_type must be a Literal")

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -58,6 +58,9 @@ from ._utils import (
 from .base import Box, Container, ListMergeMode, Node, SCMode, UnionNode
 from .basecontainer import BaseContainer
 from .errors import (
+    ConfigAttributeError,
+    ConfigKeyError,
+    ConfigTypeError,
     MissingMandatoryValue,
     OmegaConfBaseException,
     UnsupportedInterpolationType,
@@ -1075,15 +1078,18 @@ def _node_wrap(
         )
     elif is_structured_config(ref_type) or is_structured_config(value):
         key_type, element_type = get_dict_key_value_types(value)
-        node = DictConfig(
-            ref_type=ref_type,
-            is_optional=is_optional,
-            content=value,
-            key=key,
-            parent=parent,
-            key_type=key_type,
-            element_type=element_type,
-        )
+        try:
+            node = DictConfig(
+                ref_type=ref_type,
+                is_optional=is_optional,
+                content=value,
+                key=key,
+                parent=parent,
+                key_type=key_type,
+                element_type=element_type,
+            )
+        except (ConfigAttributeError, ConfigTypeError, ConfigKeyError) as e:
+            raise ValidationError(e)
     elif is_literal_annotation(ref_type):
         node = LiteralNode(
             value=value,

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -44,9 +44,11 @@ from ._utils import (
     is_dict_annotation,
     is_int,
     is_list_annotation,
+    is_literal_annotation,
     is_primitive_container,
     is_primitive_dict,
     is_primitive_list,
+    is_sequence_annotation,
     is_structured_config,
     is_tuple_annotation,
     is_union_annotation,
@@ -68,6 +70,7 @@ from .nodes import (
     EnumNode,
     FloatNode,
     IntegerNode,
+    LiteralNode,
     PathNode,
     StringNode,
     ValueNode,
@@ -1023,9 +1026,11 @@ def _node_wrap(
             key_type=key_type,
             element_type=element_type,
         )
-    elif (is_list_annotation(ref_type) or is_tuple_annotation(ref_type)) or (
-        type(value) in (list, tuple) and ref_type is Any
-    ):
+    elif (
+        is_list_annotation(ref_type)
+        or is_tuple_annotation(ref_type)
+        or is_sequence_annotation(ref_type)
+    ) or (type(value) in (list, tuple) and ref_type is Any):
         element_type = get_list_element_type(ref_type)
         node = ListConfig(
             content=value,
@@ -1053,6 +1058,14 @@ def _node_wrap(
             is_optional=is_optional,
             key=key,
             parent=parent,
+        )
+    elif is_literal_annotation(ref_type):
+        node = LiteralNode(
+            value=value,
+            key=key,
+            parent=parent,
+            is_optional=is_optional,
+            ref_type=ref_type,
         )
     elif ref_type == Any or ref_type is None:
         node = AnyNode(value=value, key=key, parent=parent)

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -616,7 +616,7 @@ class OmegaConf:
     def is_missing(cfg: Any, key: DictKeyType) -> bool:
         assert isinstance(cfg, Container)
         try:
-            node = cfg._get_child(key)
+            node = cfg._get_node(key)
             if node is None:
                 return False
             assert isinstance(node, Node)
@@ -628,7 +628,7 @@ class OmegaConf:
     def is_interpolation(node: Any, key: Optional[Union[int, str]] = None) -> bool:
         if key is not None:
             assert isinstance(node, Container)
-            target = node._get_child(key)
+            target = node._get_node(key)
         else:
             target = node
         if target is not None:
@@ -1064,17 +1064,17 @@ def _node_wrap(
             parent=parent,
             is_optional=is_optional,
         )
-    elif ref_type == int:
+    elif ref_type is int:
         node = IntegerNode(value=value, key=key, parent=parent, is_optional=is_optional)
-    elif ref_type == float:
+    elif ref_type is float:
         node = FloatNode(value=value, key=key, parent=parent, is_optional=is_optional)
-    elif ref_type == bool:
+    elif ref_type is bool:
         node = BooleanNode(value=value, key=key, parent=parent, is_optional=is_optional)
-    elif ref_type == str:
+    elif ref_type is str:
         node = StringNode(value=value, key=key, parent=parent, is_optional=is_optional)
-    elif ref_type == bytes:
+    elif ref_type is bytes:
         node = BytesNode(value=value, key=key, parent=parent, is_optional=is_optional)
-    elif ref_type == pathlib.Path:
+    elif ref_type is pathlib.Path:
         node = PathNode(value=value, key=key, parent=parent, is_optional=is_optional)
     else:
         if parent is not None and parent._get_flag("allow_objects") is True:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -147,8 +147,18 @@ class StructuredWithMissing:
 
 
 @dataclass
-class UnionError:
-    x: Union[int, List[str]] = 10
+class UnionClass:
+    foo: Union[str, int] = 1
+
+
+@dataclass
+class DictUnion:
+    dict: Dict[str, Union[int, float]] = field(default_factory=lambda: {"a": 1})
+
+
+@dataclass
+class ListUnion:
+    list: List[Union[int, float]] = field(default_factory=lambda: [1])
 
 
 @dataclass

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import attr
 from pytest import importorskip
 
-from omegaconf import II, MISSING, SI
+from omegaconf import II, MISSING, SI, DictConfig, ListConfig
 from tests import Color, Enum1
 
 if sys.version_info >= (3, 8):  # pragma: no cover
@@ -575,8 +575,64 @@ class NestedWithNone:
 
 
 @attr.s(auto_attribs=True)
-class UnionError:
-    x: Union[int, List[str]] = 10
+class Book:
+    author: Union[str, List[str]] = "dude"
+
+
+@attr.s(auto_attribs=True)
+class Shelf:
+    content: Union[Book, int] = 1
+
+
+@attr.s(auto_attribs=True)
+class Shelf2:
+    content: Union[Book, List[Book]] = Book()
+
+
+@attr.s(auto_attribs=True)
+class OptionalBook:
+    author: Optional[Union[str, List[str]]] = "author"
+
+
+@attr.s(auto_attribs=True)
+class ListUnion:
+    list: List[Union[float, int]] = [1, 3.14]
+
+
+@attr.s(auto_attribs=True)
+class DictUnion:
+    dict: Dict[str, Union[float, int]] = {"foo": 1}
+
+
+@attr.s(auto_attribs=True)
+class UnionWithContainer:
+    union_dict: Union[DictConfig, int] = DictConfig({"foo": 1})
+    union_list: Union[ListConfig, int] = ListConfig([1, 2])
+
+
+@attr.s(auto_attribs=True)
+class Base:
+    foo: int = 1
+
+
+@attr.s(auto_attribs=True)
+class Subclass1(Base):
+    pass
+
+
+@attr.s(auto_attribs=True)
+class Subclass2(Base):
+    pass
+
+
+@attr.s(auto_attribs=True)
+class UnionWithBaseclass:
+    foo: Union[Base, int] = Base()
+
+
+@attr.s(auto_attribs=True)
+class UnionOfSubclasses:
+    foo: Union[Subclass1, Subclass2] = Subclass1()
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pytest import importorskip
 
-from omegaconf import II, MISSING, SI
+from omegaconf import II, MISSING, SI, DictConfig, ListConfig
 from tests import Color, Enum1
 
 if sys.version_info >= (3, 8):  # pragma: no cover
@@ -600,8 +600,68 @@ class NestedWithNone:
 
 
 @dataclass
-class UnionError:
-    x: Union[int, List[str]] = 10
+class Book:
+    author: Union[str, List[str]] = "dude"
+
+
+@dataclass
+class Shelf:
+    content: Union[Book, int] = 1
+
+
+@dataclass
+class Shelf2:
+    content: Union[Book, List[Book]] = field(default_factory=Book)
+
+
+@dataclass
+class OptionalBook:
+    author: Optional[Union[str, List[str]]] = "foo"
+
+
+@dataclass
+class ListUnion:
+    list: List[Union[float, int]] = field(default_factory=lambda: [1, 3.14])
+
+
+@dataclass
+class DictUnion:
+    dict: Dict[str, Union[float, int]] = field(default_factory=lambda: {"foo": 1})
+
+
+@dataclass
+class UnionWithContainer:
+    union_dict: Union[DictConfig, int] = field(
+        default_factory=lambda: DictConfig({"foo": 1})
+    )
+    union_list: Union[ListConfig, int] = field(
+        default_factory=lambda: ListConfig([1, 2])
+    )
+
+
+@dataclass
+class Base:
+    foo: int = 1
+
+
+@dataclass
+class Subclass1(Base):
+    pass
+
+
+@dataclass
+class Subclass2(Base):
+    pass
+
+
+@dataclass
+class UnionWithBaseclass:
+    foo: Union[Base, int] = field(default_factory=Base)
+
+
+@dataclass
+class UnionOfSubclasses:
+    foo: Union[Subclass1, Subclass2] = field(default_factory=Subclass1)
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses_pre_311.py
+++ b/tests/structured_conf/data/dataclasses_pre_311.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pytest import importorskip
 
-from omegaconf import II, MISSING, SI
+from omegaconf import II, MISSING, SI, DictConfig, ListConfig
 from tests import Color, Enum1
 
 if sys.version_info >= (3, 8):  # pragma: no cover
@@ -596,8 +596,68 @@ class NestedWithNone:
 
 
 @dataclass
-class UnionError:
-    x: Union[int, List[str]] = 10
+class Book:
+    author: Union[str, List[str]] = "dude"
+
+
+@dataclass
+class Shelf:
+    content: Union[Book, int] = 1
+
+
+@dataclass
+class Shelf2:
+    content: Union[Book, List[Book]] = field(default_factory=Book)
+
+
+@dataclass
+class OptionalBook:
+    author: Optional[Union[str, List[str]]] = "foo"
+
+
+@dataclass
+class ListUnion:
+    list: List[Union[float, int]] = field(default_factory=lambda: [1, 3.14])
+
+
+@dataclass
+class DictUnion:
+    dict: Dict[str, Union[float, int]] = field(default_factory=lambda: {"foo": 1})
+
+
+@dataclass
+class UnionWithContainer:
+    union_dict: Union[DictConfig, int] = field(
+        default_factory=lambda: DictConfig({"foo": 1})
+    )
+    union_list: Union[ListConfig, int] = field(
+        default_factory=lambda: ListConfig([1, 2])
+    )
+
+
+@dataclass
+class Base:
+    foo: int = 1
+
+
+@dataclass
+class Subclass1(Base):
+    pass
+
+
+@dataclass
+class Subclass2(Base):
+    pass
+
+
+@dataclass
+class UnionWithBaseclass:
+    foo: Union[Base, int] = field(default_factory=Base)
+
+
+@dataclass
+class UnionOfSubclasses:
+    foo: Union[Subclass1, Subclass2] = field(default_factory=Subclass1)
 
 
 @dataclass

--- a/tests/structured_conf/test_literal.py
+++ b/tests/structured_conf/test_literal.py
@@ -1,0 +1,98 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from pytest import raises
+
+from omegaconf import OmegaConf, ValidationError
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+
+@dataclass
+class LiteralConfig:
+    int_lit: Literal[1, 2, 3] = 1
+    str_lit: Literal["a", "b", "c"] = "a"
+    bool_lit: Literal[True, False] = True
+    mixed_lit: Literal[1, "a", True] = 1
+    optional_lit: Optional[Literal["foo", "bar"]] = None
+
+
+@dataclass
+class NestedLiteralConfig:
+    cfg: LiteralConfig = field(default_factory=LiteralConfig)
+
+
+class TestLiteral:
+    def test_literal_int(self) -> None:
+        cfg = OmegaConf.structured(LiteralConfig)
+        assert cfg.int_lit == 1
+        cfg.int_lit = 2
+        assert cfg.int_lit == 2
+
+        with raises(ValidationError):
+            cfg.int_lit = 4
+
+    def test_literal_str(self) -> None:
+        cfg = OmegaConf.structured(LiteralConfig)
+        assert cfg.str_lit == "a"
+        cfg.str_lit = "b"
+        assert cfg.str_lit == "b"
+
+        with raises(ValidationError):
+            cfg.str_lit = "d"
+
+    def test_literal_bool(self) -> None:
+        cfg = OmegaConf.structured(LiteralConfig)
+        assert cfg.bool_lit is True
+        cfg.bool_lit = False
+        assert cfg.bool_lit is False
+
+        with raises(ValidationError):
+            cfg.bool_lit = 100
+
+    def test_mixed_literal(self) -> None:
+        cfg = OmegaConf.structured(LiteralConfig)
+        cfg.mixed_lit = "a"
+        assert cfg.mixed_lit == "a"
+        cfg.mixed_lit = True
+        assert cfg.mixed_lit is True
+
+        with raises(ValidationError):
+            cfg.mixed_lit = 2.5
+
+    def test_optional_literal(self) -> None:
+        cfg = OmegaConf.structured(LiteralConfig)
+        assert cfg.optional_lit is None
+        cfg.optional_lit = "foo"
+        assert cfg.optional_lit == "foo"
+        cfg.optional_lit = None
+        assert cfg.optional_lit is None
+
+        with raises(ValidationError):
+            cfg.optional_lit = "baz"
+
+    def test_nested_literal(self) -> None:
+        cfg = OmegaConf.structured(NestedLiteralConfig)
+        assert cfg.cfg.int_lit == 1
+        cfg.cfg.int_lit = 3
+        assert cfg.cfg.int_lit == 3
+
+        with raises(ValidationError):
+            cfg.cfg.int_lit = 10
+
+    def test_literal_merge(self) -> None:
+        cfg = OmegaConf.structured(LiteralConfig)
+        merge_cfg = OmegaConf.create({"int_lit": 2})
+        res = OmegaConf.merge(cfg, merge_cfg)
+        assert res.int_lit == 2
+
+        invalid_merge = OmegaConf.create({"int_lit": 10})
+        with raises(ValidationError):
+            OmegaConf.merge(cfg, invalid_merge)
+
+    def test_literal_instantiation_failure(self) -> None:
+        with raises(ValidationError):
+            OmegaConf.structured(LiteralConfig(int_lit=10))  # type: ignore

--- a/tests/structured_conf/test_sequence.py
+++ b/tests/structured_conf/test_sequence.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Sequence
+
+import pytest
+
+from omegaconf import OmegaConf, ValidationError
+
+
+@dataclass
+class SequenceConfig:
+    seq_items: Sequence[int]
+    mixed: Sequence[int] = (1, 2, 3)
+
+
+def test_sequence_creation():
+    cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2, 3]))
+    assert cfg.seq_items == [1, 2, 3]
+    assert cfg.mixed == [1, 2, 3]  # Tuple converted to List in OmegaConf
+
+
+def test_sequence_assignment_valid():
+    cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2]))
+    cfg.seq_items = [3, 4]
+    assert cfg.seq_items == [3, 4]
+
+    cfg.seq_items = (5, 6)
+    assert cfg.seq_items == [5, 6]
+
+
+def test_sequence_assignment_invalid():
+    cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2]))
+    with pytest.raises(ValidationError):
+        cfg.seq_items = ["a", "b"]
+
+
+def test_sequence_merge():
+    cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2]))
+    merge_cfg = OmegaConf.create({"seq_items": [3, 4]})
+    res = OmegaConf.merge(cfg, merge_cfg)
+    assert res.seq_items == [3, 4]
+
+
+def test_sequence_merge_invalid():
+    cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2]))
+    merge_cfg = OmegaConf.create({"seq_items": ["a", "b"]})
+    with pytest.raises(ValidationError):
+        OmegaConf.merge(cfg, merge_cfg)

--- a/tests/structured_conf/test_sequence.py
+++ b/tests/structured_conf/test_sequence.py
@@ -12,35 +12,35 @@ class SequenceConfig:
     mixed: Sequence[int] = (1, 2, 3)
 
 
-def test_sequence_creation():
+def test_sequence_creation() -> None:
     cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2, 3]))
     assert cfg.seq_items == [1, 2, 3]
     assert cfg.mixed == [1, 2, 3]  # Tuple converted to List in OmegaConf
 
 
-def test_sequence_assignment_valid():
+def test_sequence_assignment_valid() -> None:
     cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2]))
     cfg.seq_items = [3, 4]
-    assert cfg.seq_items == [3, 4]
+    assert list(cfg.seq_items) == [3, 4]
 
     cfg.seq_items = (5, 6)
-    assert cfg.seq_items == [5, 6]
+    assert list(cfg.seq_items) == [5, 6]
 
 
-def test_sequence_assignment_invalid():
+def test_sequence_assignment_invalid() -> None:
     cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2]))
     with pytest.raises(ValidationError):
         cfg.seq_items = ["a", "b"]
 
 
-def test_sequence_merge():
+def test_sequence_merge() -> None:
     cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2]))
     merge_cfg = OmegaConf.create({"seq_items": [3, 4]})
     res = OmegaConf.merge(cfg, merge_cfg)
     assert res.seq_items == [3, 4]
 
 
-def test_sequence_merge_invalid():
+def test_sequence_merge_invalid() -> None:
     cfg = OmegaConf.structured(SequenceConfig(seq_items=[1, 2]))
     merge_cfg = OmegaConf.create({"seq_items": ["a", "b"]})
     with pytest.raises(ValidationError):

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -1199,5 +1199,5 @@ def test_set_invalid_union_value() -> None:
     with raises(ValidationError):
         cfg.dict = {"a": 4, "b": True, "c": "foo"}
     assert cfg == OmegaConf.structured(DictUnion)
-    assert isinstance(cfg.dict._get_node("a"), UnionNode)  # type: ignore
-    assert cfg.dict.a == 1  # type: ignore
+    assert isinstance(cfg.dict._get_node("a"), UnionNode)
+    assert cfg.dict.a == 1

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -1122,5 +1122,5 @@ def test_set_invalid_union_value() -> None:
     with raises(ValidationError):
         cfg.list = [1, True, "foo"]
     assert cfg == OmegaConf.structured(ListUnion)
-    assert isinstance(cfg.list._get_node(0), UnionNode)  # type: ignore
+    assert isinstance(cfg.list._get_node(0), UnionNode)
     assert cfg.list[0] == 1

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -53,7 +53,6 @@ from tests import (
     StructuredWithBadList,
     StructuredWithMissing,
     SubscriptedDict,
-    UnionError,
     User,
     warns_dict_subclass_deprecated,
 )
@@ -854,16 +853,6 @@ params = [
             msg="Unsupported value type: 'tests.IllegalType'",
         ),
         id="structured:create_with_unsupported_element_type",
-    ),
-    param(
-        Expected(
-            create=lambda: None,
-            op=lambda cfg: OmegaConf.structured(UnionError),
-            exception_type=ValueError,
-            msg="Unions of containers are not supported:\nx: Union[int, List[str]]",
-            num_lines=3,
-        ),
-        id="structured:create_with_union_error",
     ),
     # assign
     param(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -70,6 +70,23 @@ class NotOptionalA:
 
 
 @dataclass
+class UnionChildA:
+    name: str
+    age: int
+
+
+@dataclass
+class UnionChildB:
+    title: str
+    score: float
+
+
+@dataclass
+class UnionParent:
+    child: Union[UnionChildA, UnionChildB]
+
+
+@dataclass
 class Expected:
     exception_type: Type[Exception]
     msg: str
@@ -831,8 +848,54 @@ params = [
             full_key="foo.bar",
             parent_node=lambda cfg: cfg.foo,
             child_node=lambda cfg: cfg.foo._get_node("bar"),
+            num_lines=5,
         ),
         id="typed_DictConfig:assign_with_invalid_value-string_to_union[bool-float]",
+    ),
+    param(
+        Expected(
+            create=lambda: OmegaConf.structured(UnionParent),
+            op=lambda cfg: cfg.__setattr__("child", {"name": "test", "age": "bad"}),
+            exception_type=ValidationError,
+            msg=re.escape(
+                "Value '{'name': 'test', 'age': 'bad'}' of type 'dict' is incompatible with type hint 'Union["
+            )
+            + r"(tests\.test_errors\.)?UnionChildA, (tests\.test_errors\.)?UnionChildB\]'\n"
+            + re.escape(
+                "Validation errors of candidate types:\n"
+                "  - Value 'bad' of type 'str' is incompatible with type hint 'int'\n"
+                "        full_key: child.age\n"
+            )
+            + r"        reference_type=(tests\.test_errors\.)?UnionChildA\n"
+            + r"        object_type=(tests\.test_errors\.)?UnionChildA\n"
+            + re.escape(
+                "  - Key 'name' not in 'UnionChildB'\n        full_key: child.name\n"
+            )
+            + r"        reference_type=(tests\.test_errors\.)?UnionChildB\n"
+            + r"        object_type=(tests\.test_errors\.)?UnionChildB",
+            msg_is_regex=True,
+            key="child",
+            full_key="child",
+            parent_node=lambda cfg: cfg,
+            child_node=lambda cfg: cfg._get_node("child"),
+            num_lines=11,
+        ),
+        id="structured:union_duck_typing_error_reporting",
+    ),
+    param(
+        Expected(
+            create=lambda: OmegaConf.structured(UnionParent),
+            op=lambda cfg: cfg.__setattr__(
+                "child", {"_type_": "UnionChildA", "name": "test", "age": "bad"}
+            ),
+            exception_type=ValidationError,
+            msg="Value 'bad' of type 'str' is incompatible with type hint 'int'",
+            key="age",
+            ref_type=UnionChildA,
+            object_type=UnionChildA,
+            low_level=True,
+        ),
+        id="structured:union_explicit_choice_error_reporting",
     ),
     param(
         Expected(

--- a/tests/test_union_dataclasses.py
+++ b/tests/test_union_dataclasses.py
@@ -1,0 +1,431 @@
+from dataclasses import dataclass, field
+from typing import Union, Optional, Any
+import pytest
+from omegaconf import OmegaConf, ValidationError, DictConfig
+
+
+@dataclass
+class User:
+    name: str = "???"
+    age: int = "???"
+
+
+@dataclass
+class Admin(User):
+    permissions: str = "all"
+
+
+@dataclass
+class Guest(User):
+    temporary: bool = True
+
+
+@dataclass
+class Config:
+    user: Union[Admin, Guest] = "Guest"
+
+
+def test_union_dataclass_basic():
+    cfg = OmegaConf.structured(Config)
+    cfg.user.name = "GuestUser"
+    assert cfg.user.name == "GuestUser"
+    assert cfg.user.temporary is True
+
+    cfg.user = "Admin"
+    cfg.user.name = "AdminUser"
+    assert cfg.user.permissions == "all"
+    assert cfg.user.name == "AdminUser"
+
+
+def test_union_dataclass_merge():
+    cfg = OmegaConf.structured(Config)
+    cfg.user = "Guest"
+    OmegaConf.set_struct(cfg, False)
+    OmegaConf.update(cfg, "user.name", "John")
+    assert cfg.user.name == "John"
+
+    # Selection switch via update
+    OmegaConf.update(cfg, "user", "Admin")
+    OmegaConf.update(cfg, "user.name", "Jane")
+    assert isinstance(cfg.user, DictConfig)
+    assert cfg.user.permissions == "all"
+    assert cfg.user.name == "Jane"
+
+
+def test_union_dataclass_invalid_selection():
+    cfg = OmegaConf.structured(Config)
+    with pytest.raises(ValidationError):
+        cfg.user = "Invalid"
+
+
+def test_union_with_primitive():
+    @dataclass
+    class Simple:
+        val: Union[int, Admin] = 10
+
+    cfg = OmegaConf.structured(Simple)
+    assert cfg.val == 10
+
+    cfg.val = "Admin"
+    assert cfg.val.permissions == "all"
+
+    cfg.val = 20
+    assert cfg.val == 20
+
+
+def test_optional_union_dataclass():
+    @dataclass
+    class OptionalConfig:
+        user: Optional[Union[Admin, Guest]] = None
+
+    cfg = OmegaConf.structured(OptionalConfig)
+    assert cfg.user is None
+
+    cfg.user = "Admin"
+    assert cfg.user.permissions == "all"
+
+    cfg.user = None
+    assert cfg.user is None
+
+
+def test_nested_union_dataclass():
+    @dataclass
+    class Sub:
+        x: int = 1
+
+    @dataclass
+    class Parent:
+        child: Union[Sub, int] = "Sub"
+
+    @dataclass
+    class Root:
+        node: Parent = field(default_factory=Parent)
+
+    cfg = OmegaConf.structured(Root)
+    assert cfg.node.child.x == 1
+
+    cfg.node.child = 10
+    assert cfg.node.child == 10
+
+    cfg.node.child = "Sub"
+    assert cfg.node.child.x == 1
+
+
+def test_union_dataclass_from_dict():
+    cfg = OmegaConf.structured(Config)
+    # This should work if it matches Admin uniquely (duck typing still works if not selecting via string?)
+    cfg.user = {"permissions": "some", "name": "AdminUser"}
+    assert cfg.user.permissions == "some"
+    assert cfg.user.name == "AdminUser"
+
+
+def test_union_dataclass_duck_typing_ambiguity():
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class B:
+        x: int = 2
+
+    @dataclass
+    class C:
+        val: Union[A, B] = "A"
+
+    cfg = OmegaConf.structured(C)
+    assert cfg.val.x == 1
+
+    # Matching x uniquely. If both have x, the first one (A) might be picked by duck typing
+    cfg.val = {"x": 10}
+    # Current OmegaConf duck typing picks the first candidate that works.
+    assert cfg.val.x == 10
+
+    # Explicit switch
+    cfg.val = "B"
+    assert cfg.val.x == 2
+
+
+def test_hierarchical_union_dataclass():
+    @dataclass
+    class InnerA:
+        a: int = 1
+
+    @dataclass
+    class InnerB:
+        b: int = 2
+
+    @dataclass
+    class OuterA:
+        inner: Union[InnerA, InnerB] = "InnerA"
+
+    @dataclass
+    class OuterB:
+        val: int = 10
+
+    @dataclass
+    class Root:
+        outer: Union[OuterA, OuterB] = "OuterA"
+
+    cfg = OmegaConf.structured(Root)
+    assert cfg.outer.inner.a == 1
+
+    # Switch inner
+    cfg.outer.inner = "InnerB"
+    assert cfg.outer.inner.b == 2
+
+    # Switch outer
+    cfg.outer = "OuterB"
+    assert cfg.outer.val == 10
+
+    # Switch outer back to A
+    cfg.outer = "OuterA"
+    assert cfg.outer.inner.a == 1
+
+
+def test_union_with_any():
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class ConfigWithAny:
+        val: Union[A, Any] = 10
+
+    cfg = OmegaConf.structured(ConfigWithAny)
+    assert cfg.val == 10
+
+    cfg.val = "A"
+    assert cfg.val.x == 1
+
+    cfg.val = {"x": 20}
+    assert cfg.val.x == 20
+
+    cfg.val = "hello"
+    assert cfg.val == "hello"
+
+
+def test_union_mandatory_missing():
+    @dataclass
+    class A:
+        x: int = "???"
+
+    @dataclass
+    class B:
+        y: int = 2
+
+    @dataclass
+    class Config:
+        val: Union[A, B] = "A"
+
+    cfg = OmegaConf.structured(Config)
+    from omegaconf.errors import MissingMandatoryValue
+
+    with pytest.raises(MissingMandatoryValue):
+        _ = cfg.val.x
+
+    cfg.val.x = 10
+    assert cfg.val.x == 10
+
+
+def test_union_readonly():
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class B:
+        y: int = 2
+
+    @dataclass
+    class Config:
+        val: Union[A, B] = "A"
+
+    cfg = OmegaConf.structured(Config)
+    OmegaConf.set_readonly(cfg, True)
+
+    from omegaconf.errors import ReadonlyConfigError
+
+    with pytest.raises(ReadonlyConfigError):
+        cfg.val = "B"
+
+    with pytest.raises(ReadonlyConfigError):
+        cfg.val.x = 10
+
+
+def test_union_interpolation():
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class B:
+        y: int = 2
+
+    @dataclass
+    class Config:
+        val: Union[A, B] = "A"
+        target: str = "B"
+        proxy: Union[A, B] = "${val}"
+
+    cfg = OmegaConf.structured(Config)
+    assert cfg.proxy.x == 1
+
+    cfg.val = "B"
+    assert cfg.proxy.y == 2
+
+    # Interpolation to selection string
+    cfg.val = "${target}"
+    assert cfg.val.y == 2
+    assert cfg.proxy.y == 2
+
+
+def test_union_none_handling():
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class Config:
+        val: Optional[Union[A, int]] = "A"
+
+    cfg = OmegaConf.structured(Config)
+    assert cfg.val.x == 1
+
+    cfg.val = None
+    assert cfg.val is None
+
+    cfg.val = 10
+    assert cfg.val == 10
+
+    cfg.val = "A"
+    assert cfg.val.x == 1
+
+
+def test_union_dataclass_complex_merge():
+    @dataclass
+    class Inner1:
+        v1: int = 1
+
+    @dataclass
+    class Inner2:
+        v2: int = 2
+
+    @dataclass
+    class Middle:
+        inner: Union[Inner1, Inner2] = "Inner1"
+        m: int = 0
+
+    @dataclass
+    class Root:
+        middle: Middle = field(default_factory=Middle)
+
+    cfg = OmegaConf.structured(Root)
+    assert cfg.middle.inner.v1 == 1
+
+    # Merge a dict that changes middle.m and middle.inner.v1
+    cfg.merge_with({"middle": {"m": 10, "inner": {"v1": 100}}})
+    assert cfg.middle.m == 10
+    assert cfg.middle.inner.v1 == 100
+
+    # Merge a dict that switches middle.inner to Inner2 and sets v2
+    # This tests if UnionNode handles nested updates that include a selection string
+    cfg.merge_with({"middle": {"inner": "Inner2"}})
+    assert cfg.middle.inner.v2 == 2
+
+    # Merge and switch simultaneously
+    cfg.merge_with({"middle": {"inner": {"v2": 200}}})  # Duck typing should keep Inner2
+    assert cfg.middle.inner.v2 == 200
+
+    # Test merging two structured configs
+    over = {"middle": {"inner": "Inner1", "m": 50}}
+    cfg.merge_with(over)
+    assert cfg.middle.inner.v1 == 1
+    assert cfg.middle.m == 50
+
+
+def test_union_merge_into_missing():
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class B:
+        y: int = 2
+
+    @dataclass
+    class Config:
+        val: Union[A, B] = "???"
+
+    cfg = OmegaConf.structured(Config)
+
+    # Merging "selection string" into missing
+    cfg.merge_with({"val": "A"})
+    assert cfg.val.x == 1
+
+    # Merging dict (duck typing) into missing
+    cfg = OmegaConf.structured(Config)
+    cfg.merge_with({"val": {"y": 10}})
+    assert cfg.val.y == 10
+
+
+def test_union_or_operator_syntax():
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class B:
+        y: int = 2
+
+    @dataclass
+    class Config:
+        # Use | syntax (PEP 604)
+        val: A | B = field(default_factory=A)
+
+    cfg = OmegaConf.structured(Config)
+    assert cfg.val.x == 1
+
+
+def test_union_merge_string_selection():
+    @dataclass
+    class RSNNConfig:
+        foo: int = 1
+
+    @dataclass
+    class TCNConfig:
+        bar: int = 2
+
+    @dataclass
+    class Config:
+        backbone: Union[RSNNConfig, TCNConfig] = field(default_factory=RSNNConfig)
+
+    cfg = OmegaConf.structured(Config)
+
+    # Test merging string matching the current type (no-op effectively, but ensures validity)
+    cfg.merge_with({"backbone": "RSNNConfig"})
+    assert cfg.backbone.foo == 1
+    assert isinstance(cfg.backbone, DictConfig)
+
+    # Test switching type via merge with string
+    cfg.merge_with({"backbone": "TCNConfig"})
+    assert cfg.backbone.bar == 2
+    assert "foo" not in cfg.backbone
+
+
+def test_union_with_str_skip_selection():
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class Config:
+        val: Union[str, A] = field(default_factory=A)
+
+    cfg = OmegaConf.structured(Config)
+
+    # "A" matches class name A. But str is in Union.
+    # So it should NOT be converted to A().
+    # It should result in Unsupported value type (because DictConfig can't be str)
+    # or validated as a string if OmegaConf supports that transition (it currently errors).
+    with pytest.raises(ValidationError, match="Unsupported value type"):
+        cfg.val = "A"

--- a/tests/test_union_dataclasses.py
+++ b/tests/test_union_dataclasses.py
@@ -1,15 +1,16 @@
+import sys
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import pytest
 
-from omegaconf import DictConfig, OmegaConf, ValidationError
+from omegaconf import MISSING, DictConfig, OmegaConf, ValidationError
 
 
 @dataclass
 class User:
-    name: str = "???"
-    age: int = "???"
+    name: str = MISSING
+    age: int = MISSING
 
 
 @dataclass
@@ -24,104 +25,135 @@ class Guest(User):
 
 @dataclass
 class Config:
-    user: Union[Admin, Guest] = "Guest"
+    user: Union[Admin, Guest] = field(default_factory=Guest)
 
 
-def test_union_dataclass_basic():
-    cfg = OmegaConf.structured(Config)
+def test_union_dataclass_basic() -> None:
+    cfg: Any = OmegaConf.structured(Config)
     cfg.user.name = "GuestUser"
     assert cfg.user.name == "GuestUser"
     assert cfg.user.temporary is True
 
     cfg.user = "Admin"
-    cfg.user.name = "AdminUser"
-    assert cfg.user.permissions == "all"
-    assert cfg.user.name == "AdminUser"
+    user_cfg: Any = cfg.user
+    user_cfg.name = "AdminUser"
+    assert user_cfg.permissions == "all"
+    assert user_cfg.name == "AdminUser"
 
 
-def test_union_dataclass_merge():
-    cfg = OmegaConf.structured(Config)
+def test_union_dataclass_merge() -> None:
+    cfg: Any = OmegaConf.structured(Config)
     cfg.user = "Guest"
     OmegaConf.set_struct(cfg, False)
     OmegaConf.update(cfg, "user.name", "John")
-    assert cfg.user.name == "John"
+    user_cfg: Any = cast(Any, cfg.user)
+    assert user_cfg.name == "John"
 
     # Selection switch via update
     OmegaConf.update(cfg, "user", "Admin")
     OmegaConf.update(cfg, "user.name", "Jane")
     assert isinstance(cfg.user, DictConfig)
-    assert cfg.user.permissions == "all"
-    assert cfg.user.name == "Jane"
+    user_cfg = cfg.user
+    assert user_cfg.permissions == "all"
+    assert user_cfg.name == "Jane"
 
 
-def test_union_dataclass_invalid_selection():
-    cfg = OmegaConf.structured(Config)
+def test_union_dataclass_invalid_selection() -> None:
+    cfg: Any = OmegaConf.structured(Config)
     with pytest.raises(ValidationError):
         cfg.user = "Invalid"
 
 
-def test_union_with_primitive():
+def test_union_dataclass_merge_uses_type_discriminator() -> None:
+    cfg: Any = OmegaConf.structured(Config)
+    merged = OmegaConf.merge(
+        cfg,
+        {
+            "user": {
+                "_type_": f"{Admin.__module__}.Admin",
+                "name": "Bob",
+            }
+        },
+    )
+    assert isinstance(merged.user, DictConfig)
+    user_cfg: Any = merged.user
+    assert user_cfg.permissions == "all"
+    assert user_cfg.name == "Bob"
+    assert "_type_" not in user_cfg
+
+
+def test_union_dataclass_merge_unknown_type_discriminator_raises() -> None:
+    cfg: Any = OmegaConf.structured(Config)
+    with pytest.raises(ValidationError):
+        OmegaConf.merge(cfg, {"user": {"_type_": "Unknown", "name": "Bob"}})
+
+
+def test_union_with_primitive() -> None:
     @dataclass
     class Simple:
         val: Union[int, Admin] = 10
 
-    cfg = OmegaConf.structured(Simple)
+    cfg: Any = OmegaConf.structured(Simple)
     assert cfg.val == 10
 
     cfg.val = "Admin"
-    assert cfg.val.permissions == "all"
+    val_cfg: Any = cfg.val
+    assert val_cfg.permissions == "all"
 
     cfg.val = 20
     assert cfg.val == 20
 
 
-def test_optional_union_dataclass():
+def test_optional_union_dataclass() -> None:
     @dataclass
     class OptionalConfig:
         user: Optional[Union[Admin, Guest]] = None
 
-    cfg = OmegaConf.structured(OptionalConfig)
+    cfg: Any = OmegaConf.structured(OptionalConfig)
     assert cfg.user is None
 
     cfg.user = "Admin"
-    assert cfg.user.permissions == "all"
+    user_cfg: Any = cfg.user
+    assert user_cfg.permissions == "all"
 
     cfg.user = None
     assert cfg.user is None
 
 
-def test_nested_union_dataclass():
+def test_nested_union_dataclass() -> None:
     @dataclass
     class Sub:
         x: int = 1
 
     @dataclass
     class Parent:
-        child: Union[Sub, int] = "Sub"
+        child: Union[Sub, int] = field(default_factory=Sub)
 
     @dataclass
     class Root:
         node: Parent = field(default_factory=Parent)
 
-    cfg = OmegaConf.structured(Root)
+    cfg: Any = OmegaConf.structured(Root)
     assert cfg.node.child.x == 1
 
     cfg.node.child = 10
     assert cfg.node.child == 10
 
     cfg.node.child = "Sub"
-    assert cfg.node.child.x == 1
+    child_cfg: Any = cfg.node.child
+    assert child_cfg.x == 1
 
 
-def test_union_dataclass_from_dict():
-    cfg = OmegaConf.structured(Config)
+def test_union_dataclass_from_dict() -> None:
+    cfg: Any = OmegaConf.structured(Config)
     # This should work if it matches Admin uniquely (duck typing still works if not selecting via string?)
     cfg.user = {"permissions": "some", "name": "AdminUser"}
-    assert cfg.user.permissions == "some"
-    assert cfg.user.name == "AdminUser"
+    user_cfg: Any = cfg.user
+    assert user_cfg.permissions == "some"
+    assert user_cfg.name == "AdminUser"
 
 
-def test_union_dataclass_duck_typing_ambiguity():
+def test_union_dataclass_duck_typing_ambiguity() -> None:
     @dataclass
     class A:
         x: int = 1
@@ -132,22 +164,24 @@ def test_union_dataclass_duck_typing_ambiguity():
 
     @dataclass
     class C:
-        val: Union[A, B] = "A"
+        val: Union[A, B] = field(default_factory=A)
 
-    cfg = OmegaConf.structured(C)
+    cfg: Any = OmegaConf.structured(C)
     assert cfg.val.x == 1
 
     # Matching x uniquely. If both have x, the first one (A) might be picked by duck typing
     cfg.val = {"x": 10}
     # Current OmegaConf duck typing picks the first candidate that works.
-    assert cfg.val.x == 10
+    val_cfg: Any = cfg.val
+    assert val_cfg.x == 10
 
     # Explicit switch
     cfg.val = "B"
-    assert cfg.val.x == 2
+    val_cfg = cfg.val
+    assert val_cfg.x == 2
 
 
-def test_hierarchical_union_dataclass():
+def test_hierarchical_union_dataclass() -> None:
     @dataclass
     class InnerA:
         a: int = 1
@@ -158,7 +192,7 @@ def test_hierarchical_union_dataclass():
 
     @dataclass
     class OuterA:
-        inner: Union[InnerA, InnerB] = "InnerA"
+        inner: Union[InnerA, InnerB] = field(default_factory=InnerA)
 
     @dataclass
     class OuterB:
@@ -166,25 +200,28 @@ def test_hierarchical_union_dataclass():
 
     @dataclass
     class Root:
-        outer: Union[OuterA, OuterB] = "OuterA"
+        outer: Union[OuterA, OuterB] = field(default_factory=OuterA)
 
-    cfg = OmegaConf.structured(Root)
+    cfg: Any = OmegaConf.structured(Root)
     assert cfg.outer.inner.a == 1
 
     # Switch inner
     cfg.outer.inner = "InnerB"
-    assert cfg.outer.inner.b == 2
+    inner_cfg: Any = cfg.outer.inner
+    assert inner_cfg.b == 2
 
     # Switch outer
     cfg.outer = "OuterB"
-    assert cfg.outer.val == 10
+    outer_cfg: Any = cfg.outer
+    assert outer_cfg.val == 10
 
     # Switch outer back to A
     cfg.outer = "OuterA"
-    assert cfg.outer.inner.a == 1
+    outer_cfg = cfg.outer
+    assert outer_cfg.inner.a == 1
 
 
-def test_union_with_any():
+def test_union_with_any() -> None:
     @dataclass
     class A:
         x: int = 1
@@ -193,23 +230,25 @@ def test_union_with_any():
     class ConfigWithAny:
         val: Union[A, Any] = 10
 
-    cfg = OmegaConf.structured(ConfigWithAny)
+    cfg: Any = OmegaConf.structured(ConfigWithAny)
     assert cfg.val == 10
 
     cfg.val = "A"
-    assert cfg.val.x == 1
+    val_cfg: Any = cfg.val
+    assert val_cfg.x == 1
 
     cfg.val = {"x": 20}
-    assert cfg.val.x == 20
+    val_cfg = cfg.val
+    assert val_cfg.x == 20
 
     cfg.val = "hello"
     assert cfg.val == "hello"
 
 
-def test_union_mandatory_missing():
+def test_union_mandatory_missing() -> None:
     @dataclass
     class A:
-        x: int = "???"
+        x: int = MISSING
 
     @dataclass
     class B:
@@ -217,9 +256,9 @@ def test_union_mandatory_missing():
 
     @dataclass
     class Config:
-        val: Union[A, B] = "A"
+        val: Union[A, B] = field(default_factory=A)
 
-    cfg = OmegaConf.structured(Config)
+    cfg: Any = OmegaConf.structured(Config)
     from omegaconf.errors import MissingMandatoryValue
 
     with pytest.raises(MissingMandatoryValue):
@@ -229,7 +268,7 @@ def test_union_mandatory_missing():
     assert cfg.val.x == 10
 
 
-def test_union_readonly():
+def test_union_readonly() -> None:
     @dataclass
     class A:
         x: int = 1
@@ -240,9 +279,9 @@ def test_union_readonly():
 
     @dataclass
     class Config:
-        val: Union[A, B] = "A"
+        val: Union[A, B] = field(default_factory=A)
 
-    cfg = OmegaConf.structured(Config)
+    cfg: Any = OmegaConf.structured(Config)
     OmegaConf.set_readonly(cfg, True)
 
     from omegaconf.errors import ReadonlyConfigError
@@ -254,7 +293,7 @@ def test_union_readonly():
         cfg.val.x = 10
 
 
-def test_union_interpolation():
+def test_union_interpolation() -> None:
     @dataclass
     class A:
         x: int = 1
@@ -265,32 +304,35 @@ def test_union_interpolation():
 
     @dataclass
     class Config:
-        val: Union[A, B] = "A"
+        val: Union[A, B] = field(default_factory=A)
         target: str = "B"
-        proxy: Union[A, B] = "${val}"
+        proxy: Union[A, B] = cast(Union[A, B], "${val}")
 
-    cfg = OmegaConf.structured(Config)
+    cfg: Any = OmegaConf.structured(Config)
     assert cfg.proxy.x == 1
 
     cfg.val = "B"
-    assert cfg.proxy.y == 2
+    proxy_cfg: Any = cfg.proxy
+    assert proxy_cfg.y == 2
 
     # Interpolation to selection string
     cfg.val = "${target}"
-    assert cfg.val.y == 2
-    assert cfg.proxy.y == 2
+    val_cfg: Any = cfg.val
+    assert val_cfg.y == 2
+    proxy_cfg = cfg.proxy
+    assert proxy_cfg.y == 2
 
 
-def test_union_none_handling():
+def test_union_none_handling() -> None:
     @dataclass
     class A:
         x: int = 1
 
     @dataclass
     class Config:
-        val: Optional[Union[A, int]] = "A"
+        val: Optional[Union[A, int]] = field(default_factory=A)
 
-    cfg = OmegaConf.structured(Config)
+    cfg: Any = OmegaConf.structured(Config)
     assert cfg.val.x == 1
 
     cfg.val = None
@@ -300,10 +342,11 @@ def test_union_none_handling():
     assert cfg.val == 10
 
     cfg.val = "A"
-    assert cfg.val.x == 1
+    val_cfg: Any = cfg.val
+    assert val_cfg.x == 1
 
 
-def test_union_dataclass_complex_merge():
+def test_union_dataclass_complex_merge() -> None:
     @dataclass
     class Inner1:
         v1: int = 1
@@ -314,14 +357,14 @@ def test_union_dataclass_complex_merge():
 
     @dataclass
     class Middle:
-        inner: Union[Inner1, Inner2] = "Inner1"
+        inner: Union[Inner1, Inner2] = field(default_factory=Inner1)
         m: int = 0
 
     @dataclass
     class Root:
         middle: Middle = field(default_factory=Middle)
 
-    cfg = OmegaConf.structured(Root)
+    cfg: Any = OmegaConf.structured(Root)
     assert cfg.middle.inner.v1 == 1
 
     # Merge a dict that changes middle.m and middle.inner.v1
@@ -332,11 +375,13 @@ def test_union_dataclass_complex_merge():
     # Merge a dict that switches middle.inner to Inner2 and sets v2
     # This tests if UnionNode handles nested updates that include a selection string
     cfg.merge_with({"middle": {"inner": "Inner2"}})
-    assert cfg.middle.inner.v2 == 2
+    inner_cfg: Any = cfg.middle.inner
+    assert inner_cfg.v2 == 2
 
     # Merge and switch simultaneously
     cfg.merge_with({"middle": {"inner": {"v2": 200}}})  # Duck typing should keep Inner2
-    assert cfg.middle.inner.v2 == 200
+    inner_cfg = cfg.middle.inner
+    assert inner_cfg.v2 == 200
 
     # Test merging two structured configs
     over = {"middle": {"inner": "Inner1", "m": 50}}
@@ -345,7 +390,7 @@ def test_union_dataclass_complex_merge():
     assert cfg.middle.m == 50
 
 
-def test_union_merge_into_missing():
+def test_union_merge_into_missing() -> None:
     @dataclass
     class A:
         x: int = 1
@@ -356,21 +401,23 @@ def test_union_merge_into_missing():
 
     @dataclass
     class Config:
-        val: Union[A, B] = "???"
+        val: Union[A, B] = MISSING
 
-    cfg = OmegaConf.structured(Config)
+    cfg: Any = OmegaConf.structured(Config)
 
     # Merging "selection string" into missing
     cfg.merge_with({"val": "A"})
-    assert cfg.val.x == 1
+    val_cfg: Any = cfg.val
+    assert val_cfg.x == 1
 
     # Merging dict (duck typing) into missing
     cfg = OmegaConf.structured(Config)
     cfg.merge_with({"val": {"y": 10}})
-    assert cfg.val.y == 10
+    val_cfg = cfg.val
+    assert val_cfg.y == 10
 
 
-def test_union_or_operator_syntax():
+def test_union_or_operator_syntax() -> None:
     @dataclass
     class A:
         x: int = 1
@@ -379,16 +426,25 @@ def test_union_or_operator_syntax():
     class B:
         y: int = 2
 
-    @dataclass
-    class Config:
-        # Use | syntax (PEP 604)
-        val: A | B = field(default_factory=A)
+    if sys.version_info >= (3, 10):
+        ns: dict[str, Any] = {"A": A, "B": B, "dataclass": dataclass, "field": field}
+        exec(
+            """
+@dataclass
+class Config:
+    val: A | B = field(default_factory=A)
+""",
+            ns,
+            ns,
+        )
+        cfg: Any = OmegaConf.structured(ns["Config"])
+        assert cfg.val.x == 1
+    else:
+        with pytest.raises(TypeError):
+            exec("A | B", {"A": A, "B": B})
 
-    cfg = OmegaConf.structured(Config)
-    assert cfg.val.x == 1
 
-
-def test_union_merge_string_selection():
+def test_union_merge_string_selection() -> None:
     @dataclass
     class RSNNConfig:
         foo: int = 1
@@ -401,7 +457,7 @@ def test_union_merge_string_selection():
     class Config:
         backbone: Union[RSNNConfig, TCNConfig] = field(default_factory=RSNNConfig)
 
-    cfg = OmegaConf.structured(Config)
+    cfg: Any = OmegaConf.structured(Config)
 
     # Test merging string matching the current type (no-op effectively, but ensures validity)
     cfg.merge_with({"backbone": "RSNNConfig"})
@@ -414,7 +470,7 @@ def test_union_merge_string_selection():
     assert "foo" not in cfg.backbone
 
 
-def test_union_with_str_skip_selection():
+def test_union_with_str_skip_selection() -> None:
     @dataclass
     class A:
         x: int = 1
@@ -423,9 +479,114 @@ def test_union_with_str_skip_selection():
     class Config:
         val: Union[str, A] = field(default_factory=A)
 
-    cfg = OmegaConf.structured(Config)
+    cfg: Any = OmegaConf.structured(Config)
 
     # "A" matches class name A. But str is in Union.
     # So it should NOT be converted to A(). It should be treated as a plain string.
     cfg.val = "A"
     assert cfg.val == "A"
+
+
+def test_union_dataclass_to_object() -> None:
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class B:
+        y: int = 2
+
+    @dataclass
+    class Config:
+        val: Union[A, B] = field(default_factory=A)
+
+    cfg: Any = OmegaConf.structured(Config)
+
+    # Default is A
+    obj = OmegaConf.to_object(cfg)
+    assert isinstance(obj, Config)
+    assert isinstance(obj.val, A)
+    assert obj.val.x == 1
+
+    # Switch to B
+    cfg.val = "B"
+    obj = OmegaConf.to_object(cfg)
+    assert isinstance(obj, Config)
+    assert isinstance(obj.val, B)
+    assert obj.val.y == 2
+
+
+def test_union_dataclass_from_cli_to_object() -> None:
+    @dataclass
+    class A:
+        x: int = 1
+
+    @dataclass
+    class B:
+        y: int = 2
+
+    @dataclass
+    class Config:
+        val: Union[A, B] = field(default_factory=A)
+
+    base = OmegaConf.structured(Config)
+    # Simulate CLI arguments to switch to B and set value
+    cli_conf = OmegaConf.from_cli(["val._type_=B", "val.y=3"])
+    merged = OmegaConf.merge(base, cli_conf)
+
+    obj = OmegaConf.to_object(merged)
+    assert isinstance(obj, Config)
+    assert isinstance(obj.val, B)
+    assert obj.val.y == 3
+
+
+def test_union_dataclass_deep_nested_to_object() -> None:
+    @dataclass
+    class LeafA:
+        name: str = "A"
+
+    @dataclass
+    class LeafB:
+        count: int = 0
+
+    @dataclass
+    class Level2:
+        # List of Unions
+        items: list[Union[LeafA, LeafB]] = field(default_factory=list)
+        # Dict of Unions
+        mapping: dict[str, Union[LeafA, LeafB]] = field(default_factory=dict)
+
+    @dataclass
+    class Root:
+        lvl2: Level2 = field(default_factory=Level2)
+
+    cfg: Any = OmegaConf.structured(Root)
+
+    # Populate with mixed types
+    cfg.lvl2.items = [
+        {"_type_": "LeafA", "name": "a1"},
+        {"_type_": "LeafB", "count": 1},
+    ]
+    cfg.lvl2.mapping = {
+        "first": {"_type_": "LeafA", "name": "a2"},
+        "second": {"_type_": "LeafB", "count": 2},
+    }
+
+    obj = OmegaConf.to_object(cfg)
+
+    assert isinstance(obj, Root)
+    assert isinstance(obj.lvl2, Level2)
+
+    # Check List
+    assert len(obj.lvl2.items) == 2
+    assert isinstance(obj.lvl2.items[0], LeafA)
+    assert obj.lvl2.items[0].name == "a1"
+    assert isinstance(obj.lvl2.items[1], LeafB)
+    assert obj.lvl2.items[1].count == 1
+
+    # Check Dict
+    assert len(obj.lvl2.mapping) == 2
+    assert isinstance(obj.lvl2.mapping["first"], LeafA)
+    assert obj.lvl2.mapping["first"].name == "a2"
+    assert isinstance(obj.lvl2.mapping["second"], LeafB)
+    assert obj.lvl2.mapping["second"].count == 2

--- a/tests/test_union_dataclasses.py
+++ b/tests/test_union_dataclasses.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass, field
-from typing import Union, Optional, Any
+from typing import Any, Optional, Union
+
 import pytest
-from omegaconf import OmegaConf, ValidationError, DictConfig
+
+from omegaconf import DictConfig, OmegaConf, ValidationError
 
 
 @dataclass
@@ -424,8 +426,6 @@ def test_union_with_str_skip_selection():
     cfg = OmegaConf.structured(Config)
 
     # "A" matches class name A. But str is in Union.
-    # So it should NOT be converted to A().
-    # It should result in Unsupported value type (because DictConfig can't be str)
-    # or validated as a string if OmegaConf supports that transition (it currently errors).
-    with pytest.raises(ValidationError, match="Unsupported value type"):
-        cfg.val = "A"
+    # So it should NOT be converted to A(). It should be treated as a plain string.
+    cfg.val = "A"
+    assert cfg.val == "A"

--- a/tests/test_union_dataclasses.py
+++ b/tests/test_union_dataclasses.py
@@ -1,6 +1,6 @@
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union, cast
+from typing import Any, Literal, Optional, Union, cast
 
 import pytest
 
@@ -622,3 +622,21 @@ def test_union_dataclass_deep_nested_to_object() -> None:
     assert obj.lvl2.mapping["first"].name == "a2"
     assert isinstance(obj.lvl2.mapping["second"], LeafB)
     assert obj.lvl2.mapping["second"].count == 2
+
+
+def test_union_literals() -> None:
+    @dataclass
+    class MyConfig:
+        strategy: Union[
+            Literal["ee_inverse_pool", "ee_ie_inverse_pool"],
+            Literal["e_inverse_pool", "e_i_inverse_pool"],
+        ] = "ee_inverse_pool"
+
+    cfg = OmegaConf.structured(MyConfig)
+    assert cfg.strategy == "ee_inverse_pool"
+
+    cfg.strategy = "e_inverse_pool"
+    assert cfg.strategy == "e_inverse_pool"
+
+    with pytest.raises(ValidationError):
+        cfg.strategy = "invalid_strategy"

--- a/tests/test_union_dataclasses.py
+++ b/tests/test_union_dataclasses.py
@@ -64,6 +64,38 @@ def test_union_dataclass_invalid_selection() -> None:
         cfg.user = "Invalid"
 
 
+def test_union_dataclass_error_reporting() -> None:
+    @dataclass
+    class ChildA:
+        name: str
+        age: int
+
+    @dataclass
+    class ChildB:
+        title: str
+        score: float
+
+    @dataclass
+    class Parent:
+        child: Union[ChildA, ChildB]
+
+    cfg: Any = OmegaConf.structured(Parent)
+    with pytest.raises(ValidationError) as excinfo:
+        cfg.child = {"name": "test", "age": "invalid_int"}
+
+    msg = str(excinfo.value)
+    assert (
+        "Value '{'name': 'test', 'age': 'invalid_int'}' of type 'dict' is "
+        "incompatible with type hint 'Union[ChildA, ChildB]'"
+    ) in msg
+    assert "Validation errors of candidate types:" in msg
+    assert (
+        "- Value 'invalid_int' of type 'str' is incompatible with type hint 'int'"
+        in msg
+    )
+    assert "- Key 'name' not in 'ChildB'" in msg
+
+
 def test_union_dataclass_merge_uses_type_discriminator() -> None:
     cfg: Any = OmegaConf.structured(Config)
     merged = OmegaConf.merge(

--- a/tests/test_union_explicit_type.py
+++ b/tests/test_union_explicit_type.py
@@ -1,0 +1,183 @@
+from dataclasses import dataclass, field
+from typing import Union
+
+from omegaconf import MISSING, DictConfig, OmegaConf
+
+
+def test_union_explicit_type_serialization():
+    """
+    Test that explicit type information (_type_) is serialized for Union fields,
+    and used during deserialization to restore the correct type.
+    """
+
+    @dataclass
+    class RSNNConfig:
+        base_current: float = 0.0
+
+    @dataclass
+    class TCNConfig:
+        input_weight_scaling: float = 1.0
+
+    @dataclass
+    class Config:
+        backbone: Union[RSNNConfig, TCNConfig] = field(default_factory=RSNNConfig)
+
+    cfg = OmegaConf.structured(Config)
+
+    # 1. Switch to TCNConfig
+    cfg.backbone = TCNConfig(input_weight_scaling=5.0)
+
+    # 2. Serialize to YAML
+    yaml_dump = OmegaConf.to_yaml(cfg)
+
+    # Verify _type_ is present
+    # We expect _type_: tests.test_union_explicit_type.TCNConfig (or similar)
+    assert "_type_" in yaml_dump
+    assert "TCNConfig" in yaml_dump
+
+    # 3. Deserialize
+    cfg_new = OmegaConf.structured(Config)
+    loaded = OmegaConf.create(yaml_dump)
+
+    # Merge loaded yaml (which has _type_) into new config
+    cfg_new.merge_with(loaded)
+
+    # Verify type switch
+    assert isinstance(cfg_new.backbone, DictConfig)
+    # Check if content matches TCNConfig schema
+    assert "input_weight_scaling" in cfg_new.backbone
+    assert cfg_new.backbone.input_weight_scaling == 5.0
+
+    # Verify _type_ key is NOT present in the final object (it should be consumed/skipped)
+    # Actually, structured config doesn't allow extra keys, so it MUST be absent.
+    assert "_type_" not in cfg_new.backbone
+
+
+def test_union_explicit_type_conflict():
+    """
+    Test that if a Dataclass explicitly defines a '_type_' field,
+    OmegaConf respects it as a data field and does NOT use it for
+    Union type switching magic (deserialization).
+    Also ensures serializer doesn't overwrite it.
+    """
+
+    @dataclass
+    class TypeHaver:
+        _type_: str = "original"
+        data: int = 0
+
+    @dataclass
+    class Other:
+        data: int = 1
+
+    @dataclass
+    class Config:
+        item: Union[TypeHaver, Other] = field(default_factory=TypeHaver)
+
+    cfg = OmegaConf.structured(Config)
+
+    # 1. Merge that looks like a type switch but hits a valid field
+    # "Other" matches the class name of the matching Union candidate.
+    # But TypeHaver has a field _type_.
+    # Expectation: "bail out" -> Do NOT switch to Other class. Set _type_ field value to "Other".
+    cfg.merge_with({"item": {"_type_": "Other"}})
+
+    # Verify it stayed as TypeHaver
+    assert isinstance(cfg.item, DictConfig)
+    # OmegaConf stores object type metadata for structured configs
+    assert cfg.item._metadata.object_type == TypeHaver
+
+    # Verify the field was updated
+    assert cfg.item._type_ == "Other"
+
+    # 2. Serialization check
+    # If TypeHaver has _type_="special", serializer should NOT overwrite it with "tests.test_...TypeHaver"
+    cfg.item._type_ = "special"
+    dump = OmegaConf.to_yaml(cfg)
+
+    assert "_type_: special" in dump
+    # We should NOT see the auto-generated type info for TypeHaver here because it's overridden/conflicted
+    assert (
+        "TypeHaver" not in dump
+    )  # Class name shouldn't appear in _type_ value if we set "special"
+
+
+@dataclass
+class UnionTypeA:
+    x: int = 10
+    kind: str = "A"
+
+
+@dataclass
+class UnionTypeB:
+    b: int = 20
+    kind: str = "B"
+
+
+@dataclass
+class UnionTypeConfig:
+    u: Union[UnionTypeA, UnionTypeB] = MISSING
+
+
+def test_union_merge_with_type_field():
+    """
+    Test that we can use the `_type_` field to tell OmegaConf which Union subclass
+    to use when merging a dict.
+    """
+    cfg = OmegaConf.structured(UnionTypeConfig)
+
+    # 1. Merge B using fully qualified name in _type_
+    # Note: For this to work with `_type_` pointing to a class, the class needs to be importable.
+    # We will use the full name of B here.
+    # Since these classes are now at module level, they should be importable.
+    # Note: qualname might still need to include the module prefix if we construct it manually,
+    # but for simple module level classes, __module__ + . + __qualname__ works.
+
+    full_name_B = f"{UnionTypeB.__module__}.{UnionTypeB.__qualname__}"
+
+    # Test with _type_ (explicit selection)
+    data = {"u": {"_type_": full_name_B, "b": 100}}
+
+    merged = OmegaConf.merge(cfg, data)
+
+    assert isinstance(merged.u, DictConfig)
+    # Check if we successfully switched to B (by checking field 'b')
+    assert merged.u.b == 100
+
+    # If duck typing works, object_type should be UnionTypeB.
+    # If _type_ works, object_type should be UnionTypeB.
+    # If _type_ causes fallback to dict, that's the bug/behavior we see.
+
+    # If this fails, we know it's not promoting to B.
+    # We'll assert object type matches B
+    assert merged.u._metadata.object_type == UnionTypeB
+
+    assert merged.u.kind == "B"
+    # Verify the underlying type metadata
+    assert merged.u._metadata.object_type == UnionTypeB
+
+    # 2. Verify we can switch back to A via merge
+    full_name_A = f"{UnionTypeA.__module__}.{UnionTypeA.__qualname__}"
+    data_a = {"u": {"_type_": full_name_A, "x": 999}}
+    merged_a = OmegaConf.merge(merged, data_a)
+
+    assert merged_a.u.x == 999
+    assert merged_a.u.kind == "A"
+    assert merged_a.u._metadata.object_type == UnionTypeA
+
+
+def test_union_merge_bad_list():
+    """
+    Regression test for: KeyValidationError: ListConfig indices must be integers or slices, not str
+    When merging a list into a UnionNode, it should raise ValidationError (incompatible type),
+    NOT KeyValidationError (crash when checking _type_).
+    """
+    cfg = OmegaConf.structured(UnionTypeConfig)
+    data = {"u": [123]}
+
+    import pytest
+
+    from omegaconf.errors import ValidationError
+
+    with pytest.raises(ValidationError):
+        OmegaConf.merge(cfg, data)

--- a/tests/test_union_explicit_type.py
+++ b/tests/test_union_explicit_type.py
@@ -38,7 +38,7 @@ class _NestedContainerUnionCfg:
     lst: List[Dict[str, Union[_AmbigA, _AmbigB]]] = field(default_factory=list)
 
 
-def test_union_explicit_type_in_list_roundtrip():
+def test_union_explicit_type_in_list_roundtrip() -> None:
     cfg = OmegaConf.structured(_ListOfUnionCfg)
 
     full_name_b = f"{_AmbigB.__module__}.{_AmbigB.__qualname__}"
@@ -61,7 +61,7 @@ def test_union_explicit_type_in_list_roundtrip():
     assert "_type_" not in cfg2.lst[0]
 
 
-def test_union_explicit_type_in_dict_roundtrip():
+def test_union_explicit_type_in_dict_roundtrip() -> None:
     cfg = OmegaConf.structured(_DictOfUnionCfg)
 
     full_name_b = f"{_AmbigB.__module__}.{_AmbigB.__qualname__}"
@@ -171,7 +171,7 @@ def test_union_in_container_type_field_conflict_is_data() -> None:
     assert "_type_: Other" in dump
 
 
-def test_union_explicit_type_serialization():
+def test_union_explicit_type_serialization() -> None:
     """
     Test that explicit type information (_type_) is serialized for Union fields,
     and used during deserialization to restore the correct type.
@@ -220,7 +220,7 @@ def test_union_explicit_type_serialization():
     assert "_type_" not in cfg_new.backbone
 
 
-def test_union_explicit_type_conflict():
+def test_union_explicit_type_conflict() -> None:
     """
     Test that if a Dataclass explicitly defines a '_type_' field,
     OmegaConf respects it as a data field and does NOT use it for
@@ -286,7 +286,7 @@ class UnionTypeConfig:
     u: Union[UnionTypeA, UnionTypeB] = MISSING
 
 
-def test_union_merge_with_type_field():
+def test_union_merge_with_type_field() -> None:
     """
     Test that we can use the `_type_` field to tell OmegaConf which Union subclass
     to use when merging a dict.
@@ -333,7 +333,7 @@ def test_union_merge_with_type_field():
     assert merged_a.u._metadata.object_type == UnionTypeA
 
 
-def test_union_merge_bad_list():
+def test_union_merge_bad_list() -> None:
     """
     Regression test for: KeyValidationError: ListConfig indices must be integers or slices, not str
     When merging a list into a UnionNode, it should raise ValidationError (incompatible type),

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -93,8 +93,24 @@ def test_get_parent_container() -> None:
 
     unode = cfg._get_node("foo")
     nested_node = unode._value()  # type: ignore
-    any_node = cfg._get_node("bar")
-
     assert unode._get_parent_container() is cfg  # type: ignore
     assert nested_node._get_parent_container() is cfg
-    assert any_node._get_parent_container() is cfg  # type: ignore
+    assert cfg._get_node("bar")._get_parent_container() is cfg  # type: ignore
+
+
+def test_union_node_get_root_standalone() -> None:
+    from tests import User
+
+    # Destination config. We set 'no_deepcopy_set_nodes' flag to True, as this is
+    # the internal flag used by OmegaConf.unsafe_merge to speed up operations.
+    dest = OmegaConf.create({"val": UnionNode(123, Union[User, int])})
+    dest._set_flag("no_deepcopy_set_nodes", True)
+
+    # Source: a standalone UnionNode containing a structured DictConfig
+    user = OmegaConf.structured(User)
+    src_union = UnionNode(content=user, ref_type=Union[User, int])
+
+    # Assignment triggers the _get_root() check in BaseContainer._set_item_impl
+    # This used to raise AssertionError because UnionNode is not a Container.
+    dest.val = src_union
+    assert dest.val == user

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ from omegaconf._utils import (  # _normalize_ref_type,
     is_union_annotation,
     split_key,
 )
-from omegaconf.errors import UnsupportedValueType, ValidationError
+from omegaconf.errors import ConfigKeyError, UnsupportedValueType, ValidationError
 from omegaconf.nodes import (
     AnyNode,
     BooleanNode,
@@ -208,7 +208,12 @@ def test_node_wrap(
             DictConfig(content={"foo": "bar"}),
             id="dict_to_any",
         ),
-        param(Plugin, {"foo": "bar"}, ValidationError, id="dict_to_plugin"),
+        param(
+            Plugin,
+            {"foo": "bar"},
+            (ValidationError, ConfigKeyError),
+            id="dict_to_plugin",
+        ),
         # Structured Config
         param(Plugin, Plugin(), DictConfig(content=Plugin()), id="DictConfig[Plugin]"),
         param(Any, Plugin(), DictConfig(content=Plugin()), id="plugin_to_any"),
@@ -335,8 +340,8 @@ class _TestUserClass:
         (Union[int, List[str]], False),
         (Union[int, Dict[int, str]], False),
         (Union[int, _TestEnum], True),
-        (Union[int, _TestAttrsClass], False),
-        (Union[int, _TestDataclass], False),
+        (Union[int, _TestAttrsClass], True),
+        (Union[int, _TestDataclass], True),
         (Union[int, _TestUserClass], False),
     ],
 )
@@ -846,7 +851,7 @@ def test_is_union_annotation_PEP604() -> None:
         (Union[int, str], True),
         (Union[int, List[str]], False),
         (Union[int, Dict[str, int]], False),
-        (Union[int, User], False),
+        (Union[int, User], True),
         (Optional[Union[int, str]], True),
         (Union[int, None], True),
         (Optional[int], True),


### PR DESCRIPTION
support union of dataclasses, Literal, and Sequence. It reads the annotation to parse all dataclasses and user can choose the concrete dataclass by config.union=classA. Dumping it to yaml will save the choice into a  `_type_` field.

This is primarily vibe coded up. It needs more tests to cover the edge cases. I am currently verifying it by using it myself in my project. 

Fixes #144 
