### PR TITLE
Add new OmegaConf.all_keys()

### DIFF
--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -798,6 +798,10 @@ class OmegaConf:
         omegaconf._impl._resolve(cfg)
 
     @staticmethod
+    def all_keys(cfg: Any) -> Set[str]:
+        raise NotImplementedError()
+
+    @staticmethod
     def missing_keys(cfg: Any) -> Set[str]:
         """
         Returns a set of missing keys in a dotlist style.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -799,7 +799,34 @@ class OmegaConf:
 
     @staticmethod
     def all_keys(cfg: Any) -> Set[str]:
-        raise NotImplementedError()
+        """
+        Returns a set of all keys in a dotlist style.
+
+        :param cfg: An ``OmegaConf.Container``,
+                    or a convertible object via ``OmegaConf.create`` (dict, list, ...).
+        :return: set of strings of the available keys.
+        :raises ValueError: On input not representing a config.
+        """
+        cfg = _ensure_container(cfg)
+        available_keys: Set[str] = set()
+
+        def gather(_cfg: Container) -> None:
+            itr: Iterable[Any]
+            if isinstance(_cfg, ListConfig):
+                itr = range(len(_cfg))
+            else:
+                itr = _cfg
+
+            for key in itr:
+                if OmegaConf.is_missing(_cfg, key):
+                    available_keys.add(_cfg._get_full_key(key))
+                elif OmegaConf.is_config(_cfg[key]):
+                    gather(_cfg[key])
+                else:
+                    available_keys.add(_cfg._get_full_key(key))
+
+        gather(cfg)
+        return available_keys
 
     @staticmethod
     def missing_keys(cfg: Any) -> Set[str]:

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -553,6 +553,135 @@ def test_resolve_invalid_input() -> None:
     "cfg, expected",
     [
         # dict:
+        ({"a": 10, "b": {"c": "???", "d": "..."}}, {"a", "b.c", "b.d"}),
+        (
+            {
+                "a": "???",
+                "b": {
+                    "foo": "bar",
+                    "bar": "???",
+                    "more": {"missing": "???", "available": "yes"},
+                },
+                Color.GREEN: {"tint": "???", "default": Color.BLUE},
+            },
+            {
+                "a",
+                "b.foo",
+                "b.bar",
+                "b.more.missing",
+                "b.more.available",
+                "GREEN.tint",
+                "GREEN.default",
+            },
+        ),
+        (
+            {"a": "a", "b": {"foo": "bar", "bar": "foo"}},
+            {"a", "b.foo", "b.bar"},
+        ),
+        (
+            {"foo": "bar", "bar": "???", "more": {"foo": "???", "bar": "foo"}},
+            {"foo", "bar", "more.foo", "more.bar"},
+        ),
+        # list:
+        (["???", "foo", "bar", "???", 77], {"[0]", "[1]", "[2]", "[3]", "[4]"}),
+        (["", "foo", "bar"], {"[0]", "[1]", "[2]"}),
+        (["foo", "bar", "???"], {"[0]", "[1]", "[2]"}),
+        (["foo", "???", ["???", "bar"]], {"[0]", "[1]", "[2][0]", "[2][1]"}),
+        # mixing:
+        (
+            [
+                "???",
+                "foo",
+                {
+                    "a": True,
+                    "b": "???",
+                    "c": ["???", None],
+                    "d": {"e": "???", "f": "fff", "g": [True, "???"]},
+                },
+                "???",
+                77,
+            ],
+            {
+                "[0]",
+                "[1]",
+                "[2].a",
+                "[2].b",
+                "[2].c[0]",
+                "[2].c[1]",
+                "[2].d.e",
+                "[2].d.f",
+                "[2].d.g[0]",
+                "[2].d.g[1]",
+                "[3]",
+                "[4]",
+            },
+        ),
+        (
+            {
+                "list": [
+                    0,
+                    DictConfig({"foo": "???", "bar": None}),
+                    "???",
+                    ["???", 3, False],
+                ],
+                "x": "y",
+                "y": "???",
+            },
+            {
+                "list[0]",
+                "list[1].foo",
+                "list[1].bar",
+                "list[2]",
+                "list[3][0]",
+                "list[3][1]",
+                "list[3][2]",
+                "x",
+                "y",
+            },
+        ),
+        ({Color.RED: ["???", {"missing": "???"}]}, {"RED[0]", "RED[1].missing"}),
+        # with DictConfig and ListConfig:
+        (
+            DictConfig(
+                {
+                    "foo": "???",
+                    "list": ["???", 1],
+                    "bar": {"missing": "???", "more": "yes"},
+                }
+            ),
+            {"foo", "list[0]", "list[1]", "bar.missing", "bar.more"},
+        ),
+        (
+            ListConfig(
+                ["???", "yes", "???", [0, 1, "???"], {"missing": "???", "more": ""}],
+            ),
+            {
+                "[0]",
+                "[1]",
+                "[2]",
+                "[3][0]",
+                "[3][1]",
+                "[3][2]",
+                "[4].missing",
+                "[4].more",
+            },
+        ),
+    ],
+)
+def test_all_keys(cfg: Any, expected: Any) -> None:
+    assert OmegaConf.all_keys(cfg) == expected
+
+
+@mark.parametrize("cfg", [float, int])
+def test_all_keys_invalid_input(cfg: Any) -> None:
+    with raises(ValueError):
+        OmegaConf.all_keys(cfg)
+
+
+@mark.parametrize(
+    "cfg, expected",
+    [
+        # dict:
         ({"a": 10, "b": {"c": "???", "d": "..."}}, {"b.c"}),
         (
             {


### PR DESCRIPTION
## Motivation

So far only `OmegaConf.missing_keys()` exists. A set of all available keys can help to provide better output to users or to add validation steps prior to actually parsing the config.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

I have added automated tests.

## Fixes

I could not find a related issue.

## Related PRs

https://github.com/omry/omegaconf/issues/720
