### PR TITLE
fix: prevent RuntimeError when resolver returns Container during OmegaConf.resolve (Python 3.12+)

### DIFF
--- a/news/1239.bugfix
+++ b/news/1239.bugfix
@@ -1,0 +1,1 @@
+Fix ``RuntimeError: dictionary changed size during iteration`` in ``OmegaConf.resolve()`` on Python 3.12+ when a resolver returns a ``DictConfig``.

--- a/news/1239.bugfix
+++ b/news/1239.bugfix
@@ -1,1 +1,1 @@
-Fix ``RuntimeError: dictionary changed size during iteration`` in ``OmegaConf.resolve()`` on Python 3.12+ when a resolver returns a ``DictConfig``.
+Fix `OmegaConf.resolve()` raising `RuntimeError` on Python 3.12+ when a custom resolver returns a `DictConfig`.

--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -41,7 +41,7 @@ def _resolve(cfg: Node) -> Node:
         cfg._set_value(resolved._value())
 
     if isinstance(cfg, DictConfig):
-        for k in cfg.keys():
+        for k in list(cfg.keys()):
             _resolve_container_value(cfg, k)
 
     elif isinstance(cfg, ListConfig):

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -566,6 +566,28 @@ def test_resolve_raises_on_resolver_arg_to_missing(restore_resolvers: Any) -> No
         OmegaConf.resolve(cfg)
 
 
+def test_resolve_does_not_raise_when_resolver_returns_dict_config(
+    restore_resolvers: Any,
+) -> None:
+    OmegaConf.register_new_resolver(
+        "merge_test",
+        lambda a, b: OmegaConf.merge(a, b),
+        replace=True,
+    )
+    cfg = OmegaConf.create(
+        {
+            "base": {"x": 1, "y": 2},
+            "extra": {"z": 3},
+            "merged": "${merge_test:${base},${extra}}",
+        }
+    )
+
+    OmegaConf.resolve(cfg)
+    result = OmegaConf.to_container(cfg, resolve=False)
+    assert isinstance(result, dict)
+    assert result["merged"] == {"x": 1, "y": 2, "z": 3}
+
+
 @mark.parametrize(
     "cfg, expected",
     [


### PR DESCRIPTION
Fixes #1239

## Problem

`OmegaConf.resolve()` raises `RuntimeError: dictionary changed size during iteration` on Python 3.12+ when a custom resolver returns a `DictConfig` (Container).

`_resolve()` in `omegaconf/_impl.py` iterates over a live `dict_keys` view:

```python
for k in cfg.keys():
    _resolve_container_value(cfg, k)
```

`_resolve_container_value` can assign a new `DictConfig` back into `cfg` via `cfg[key] = resolved`, modifying the dict structure while iteration is in progress. Python 3.12+ raises `RuntimeError` in this case.

The bug is silent on Python ≤ 3.11 but consistently reproducible on 3.12+.

## Fix

Snapshot the keys with `list()` before iterating:

```python
for k in list(cfg.keys()):
    _resolve_container_value(cfg, k)
```

## Changes

- `omegaconf/_impl.py`: one-line fix in `_resolve()`
- `tests/test_omegaconf.py`: regression test `test_resolve_does_not_raise_when_resolver_adds_keys` covering a resolver that returns a `DictConfig`
