### PR TITLE
Preserve structured interpolations when merging missing nodes

### DIFF
--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -358,11 +358,12 @@ class BaseContainer(Container, ABC):
 
             node._set_value(val)
 
-        if (
+        src_was_missing_structured = (
             src._is_missing()
             and not dest._is_missing()
             and is_structured_config(src_ref_type)
-        ):
+        )
+        if src_was_missing_structured:
             # Replace `src` with a prototype of its corresponding structured config
             # whose fields are all missing (to avoid overwriting fields in `dest`).
             assert src_type is None  # src missing, so src's object_type should be None
@@ -371,7 +372,17 @@ class BaseContainer(Container, ABC):
                 ref_type=src_ref_type, object_type=src_type
             )
 
-        if (dest._is_interpolation() or dest._is_missing()) and not src._is_missing():
+        if dest._is_interpolation() and src_was_missing_structured:
+            # Keep unresolved structured interpolations intact when the source
+            # was originally MISSING; the synthesized prototype only exists to
+            # preserve type information during merge.
+            _update_types(node=dest, ref_type=src_ref_type, object_type=src_type)
+            return
+
+        if (
+            (dest._is_interpolation() and not src_was_missing_structured)
+            or dest._is_missing()
+        ) and not src._is_missing():
             expand(dest)
 
         src_items = list(src) if not src._is_missing() else []

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -467,7 +467,10 @@ def test_merge_missing_structured_keeps_interpolation_target() -> None:
 
     merged = OmegaConf.merge(cfg1, cfg2)
 
-    assert merged == {"target": "???", "child": {"ref": "${target}"}}
+    assert OmegaConf.to_container(merged, resolve=False) == {
+        "target": "???",
+        "child": {"ref": "${target}"},
+    }
     assert merged._get_node("child")._get_node("ref")._is_interpolation()
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -2,6 +2,7 @@ import copy
 import re
 import sys
 from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
 from textwrap import dedent
 from typing import (
     Any,
@@ -445,6 +446,29 @@ def test_merge(
     else:
         with expected:
             merge_function(*configs)
+
+
+def test_merge_missing_structured_keeps_interpolation_target() -> None:
+    @dataclass
+    class Defaults:
+        value: int = 0
+
+    @dataclass
+    class Child:
+        ref: Defaults = "${target}"
+
+    @dataclass
+    class Parent:
+        target: str = "???"
+        child: Child = field(default_factory=Child)
+
+    cfg1 = OmegaConf.structured(Parent())
+    cfg2 = OmegaConf.structured(Parent(child="???"))
+
+    merged = OmegaConf.merge(cfg1, cfg2)
+
+    assert merged == {"target": "???", "child": {"ref": "${target}"}}
+    assert merged._get_node("child")._get_node("ref")._is_interpolation()
 
 
 @mark.parametrize(


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/omry/omegaconf/pull/1247).
* __->__ #1247
* #1246