### PR TITLE
Preserve unresolved interpolations when merging missing structured nodes

### DIFF
--- a/news/1205.bugfix
+++ b/news/1205.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where merging a missing structured config into an unresolved interpolation could replace the interpolation with the structured type's default value instead of preserving the interpolation.

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -358,11 +358,12 @@ class BaseContainer(Container, ABC):
 
             node._set_value(val)
 
-        if (
+        src_was_missing_structured = (
             src._is_missing()
             and not dest._is_missing()
             and is_structured_config(src_ref_type)
-        ):
+        )
+        if src_was_missing_structured:
             # Replace `src` with a prototype of its corresponding structured config
             # whose fields are all missing (to avoid overwriting fields in `dest`).
             assert src_type is None  # src missing, so src's object_type should be None
@@ -371,7 +372,17 @@ class BaseContainer(Container, ABC):
                 ref_type=src_ref_type, object_type=src_type
             )
 
-        if (dest._is_interpolation() or dest._is_missing()) and not src._is_missing():
+        if dest._is_interpolation() and src_was_missing_structured:
+            # Keep unresolved structured interpolations intact when the source
+            # was originally MISSING; the synthesized prototype only exists to
+            # preserve type information during merge.
+            _update_types(node=dest, ref_type=src_ref_type, object_type=src_type)
+            return
+
+        if (
+            (dest._is_interpolation() and not src_was_missing_structured)
+            or dest._is_missing()
+        ) and not src._is_missing():
             expand(dest)
 
         src_items = list(src) if not src._is_missing() else []

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -2,6 +2,7 @@ import copy
 import re
 import sys
 from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
 from textwrap import dedent
 from typing import (
     Any,
@@ -17,6 +18,7 @@ from typing import (
 from pytest import mark, param, raises
 
 from omegaconf import (
+    II,
     MISSING,
     DictConfig,
     FloatNode,
@@ -445,6 +447,33 @@ def test_merge(
     else:
         with expected:
             merge_function(*configs)
+
+
+def test_merge_missing_structured_keeps_interpolation_target() -> None:
+    @dataclass
+    class Defaults:
+        value: int = 0
+
+    @dataclass
+    class Child:
+        ref: Defaults = II("target")
+
+    @dataclass
+    class Parent:
+        target: Defaults = MISSING
+        child: Child = field(default_factory=Child)
+
+    cfg1 = OmegaConf.structured(Parent())
+    cfg2 = OmegaConf.structured(Parent())
+    cfg2.child = MISSING
+
+    merged = OmegaConf.merge(cfg1, cfg2)
+
+    assert OmegaConf.to_container(merged, resolve=False) == {
+        "target": "???",
+        "child": {"ref": "${target}"},
+    }
+    assert OmegaConf.is_interpolation(merged.child, "ref")
 
 
 @mark.parametrize(


### PR DESCRIPTION

When a merge combined a destination node holding an unresolved interpolation
with a source node that was MISSING but typed as a structured config,
OmegaConf synthesized a prototype for the source and then expanded the
destination interpolation. That replaced the interpolation with the
structured type's default value, so the merged config no longer preserved
the original interpolation semantics.

Fix this by tracking when the source started out as a missing structured
node and treating the synthesized prototype as type information only. In
that case, keep the destination interpolation intact, update its type
metadata, and skip the expansion path that would otherwise materialize the
default structured value. Add a regression test covering a structured child
whose interpolation target must remain unresolved after merge.

Closes #1205
