### PR TITLE
Return literal None from OmegaConf.create(None)

### DIFF
--- a/news/1196.bugfix
+++ b/news/1196.bugfix
@@ -1,0 +1,1 @@
+Changed `OmegaConf.create(None)` to return literal `None` instead of a `DictConfig(None)` wrapper. This is a breaking change for code that relied on getting a config object back from `create(None)`.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -159,7 +159,15 @@ class OmegaConf:
     @staticmethod
     @overload
     def create(
-        obj: Optional[Dict[Any, Any]] = None,
+        obj: None,
+        parent: Optional[BaseContainer] = None,
+        flags: Optional[Dict[str, bool]] = None,
+    ) -> None: ...
+
+    @staticmethod
+    @overload
+    def create(
+        obj: Dict[Any, Any] = ...,
         parent: Optional[BaseContainer] = None,
         flags: Optional[Dict[str, bool]] = None,
     ) -> DictConfig: ...
@@ -169,7 +177,7 @@ class OmegaConf:
         obj: Any = _DEFAULT_MARKER_,
         parent: Optional[BaseContainer] = None,
         flags: Optional[Dict[str, bool]] = None,
-    ) -> Union[DictConfig, ListConfig]:
+    ) -> Optional[Union[DictConfig, ListConfig]]:
         return OmegaConf._create_impl(
             obj=obj,
             parent=parent,
@@ -831,7 +839,7 @@ class OmegaConf:
         obj: Any = _DEFAULT_MARKER_,
         parent: Optional[BaseContainer] = None,
         flags: Optional[Dict[str, bool]] = None,
-    ) -> Union[DictConfig, ListConfig]:
+    ) -> Optional[Union[DictConfig, ListConfig]]:
         try:
             from ._utils import get_yaml_loader
             from .dictconfig import DictConfig
@@ -839,6 +847,8 @@ class OmegaConf:
 
             if obj is _DEFAULT_MARKER_:
                 obj = {}
+            elif obj is None:
+                return None
             if isinstance(obj, str):
                 obj = yaml.load(obj, Loader=get_yaml_loader())
                 if obj is None:

--- a/tests/test_config_eq.py
+++ b/tests/test_config_eq.py
@@ -120,6 +120,7 @@ def test_missing_container_string_eq(cfg: Any, other: Any) -> None:
         param({}, {"a": 10}, id="empty_dict_neq_dict"),
         param({}, [], id="empty_dict_vs_list"),
         param({}, None, id="dict_neq_none"),
+        param(DictConfig(None), {}, id="none_dictconfig_neq_dict"),
         param({"foo": None}, {"foo": "bar"}, id="dict_none_neq_dict_not_none"),
         param({"a": 12}, {"a": 13}, id="simple_dict_neq"),
         param({"a": 0}, {"b": 0}, id="different_key_same_value"),

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -68,6 +68,10 @@ def test_create_value(input_: Any, expected: Any) -> None:
     assert OmegaConf.create(input_) == expected
 
 
+def test_create_none_returns_literal_none() -> None:
+    assert OmegaConf.create(None) is None
+
+
 @mark.parametrize(
     "input_",
     [


### PR DESCRIPTION

OmegaConf.create(None) currently returns DictConfig(None), which makes
`OmegaConf.create(None) is None` false even though callers passed in the
literal None object. That behavior is surprising, differs from the input
identity, and forces callers to rely on equality checks or OmegaConf-specific
container semantics where a plain None was expected.

Change create() so an explicit None input returns literal None instead of
routing through the DictConfig construction path. Update the overloads to
reflect the new return type and add a regression test covering the identity
check. Document the behavior change in a news fragment because this is a
breaking change for code that relied on receiving DictConfig(None) from
OmegaConf.create(None).

Closes #1196
