### PR TITLE
Support assignment of string-valued enums by value

### DIFF
--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -179,6 +179,25 @@ Runtime validation and conversion works for all supported types, including Enums
     >>> conf.height = 1
     >>> assert conf.height == Height.TALL
 
+For enums with string values, assignments can use either the enum member name
+or the enum value:
+
+.. doctest::
+
+    >>> class HttpStatus(str, Enum):
+    ...     OK = "ok-status"
+    ...     ERROR = "error-status"
+    ...
+    >>> @dataclass
+    ... class StringEnumConfig:
+    ...     status: HttpStatus = HttpStatus.OK
+    ...
+    >>> conf = OmegaConf.structured(StringEnumConfig)
+    >>> conf.status = "ERROR"
+    >>> assert conf.status == HttpStatus.ERROR
+    >>> conf.status = "error-status"
+    >>> assert conf.status == HttpStatus.ERROR
+
 .. _nesting_structured_configs:
 
 Nesting structured configs

--- a/news/1182.feature
+++ b/news/1182.feature
@@ -1,0 +1,1 @@
+Added support for assigning string-valued enums in structured configs from either the enum member name or the enum value.

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -487,7 +487,10 @@ class EnumNode(ValueNode):  # lgtm [py/missing-equals] : Intentional.
                 prefix = f"{enum_type.__name__}."
                 if value.startswith(prefix):
                     value = value[len(prefix) :]
-                return enum_type[value]
+                try:
+                    return enum_type[value]
+                except KeyError:
+                    return enum_type(value)
 
             assert False
 

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -4,6 +4,7 @@ import pathlib
 import re
 import sys
 from contextlib import AbstractContextManager
+from enum import Enum
 from importlib import import_module
 from pathlib import Path
 from types import LambdaType
@@ -62,6 +63,25 @@ class EnumConfigAssignments:
         (3, Color.BLUE),
     ]
     illegal = ["foo", True, b"RED", False, 4, 1.0, Path("hello.txt")]
+
+
+def test_string_valued_enum_assignment_by_member_name_and_value() -> None:
+    from dataclasses import dataclass
+
+    class Height(str, Enum):
+        SHORT = "short-value"
+        TALL = "very-tall-value"
+
+    @dataclass
+    class HeightConfig:
+        height: Height = Height.SHORT
+
+    cfg = OmegaConf.structured(HeightConfig)
+    cfg.height = "TALL"
+    assert cfg.height == Height.TALL
+
+    cfg.height = "very-tall-value"
+    assert cfg.height == Height.TALL
 
 
 class IntegersConfigAssignments:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -676,6 +676,19 @@ def test_legal_assignment_enum(
                 node_type(enum_type)
 
 
+def test_legal_assignment_string_valued_enum_by_member_name_and_value() -> None:
+    class Height(str, Enum):
+        SHORT = "short-value"
+        TALL = "very-tall-value"
+
+    node = EnumNode(Height)
+    node._set_value("TALL")
+    assert node._value() == Height.TALL
+
+    node._set_value("very-tall-value")
+    assert node._value() == Height.TALL
+
+
 @mark.parametrize(
     "obj",
     [


### PR DESCRIPTION

Allow structured-config enum fields and EnumNode to accept string-valued enums by either member name or enum value, while preserving existing support for qualified enum names and numeric enum values.

Add focused regression tests for both the low-level EnumNode path and the structured-config assignment path, update the structured-config docs with a user-facing example, and include a feature fragment.

Closes #1182.
