### PR TITLE
Split the optional pydevd plugin into its own package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,14 +10,12 @@ on:
 # Use separate jobs for building and publishing so that write 
 # permissions are only accessible minimally.
 #
-# Both jobs require are run under the pypi-publish environment,
-# which is configured to require review and approval from authorized
-# maintainers.
+# Only the publish job runs under the protected pypi-publish
+# environment, so artifact builds do not require a separate approval.
 jobs:
   build-artifacts:
     name: Build distribution artifacts
     runs-on: ubuntu-latest
-    environment: pypi-publish 
     steps:
     - uses: actions/checkout@v5
 
@@ -38,11 +36,14 @@ jobs:
         pip install build
 
     - name: Build distribution
-      run: python -m build
+      run: |
+        python -m build
+        python setup_pydevd.py sdist bdist_wheel
 
     - name: Verify build artifacts
       run: |
         ls -lah dist/
+        python build_helpers/check_package_artifacts.py dist
         python -m pip install twine
         twine check dist/*
 

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -11,7 +11,6 @@ jobs:
   build-artifacts:
     name: Build distribution artifacts
     runs-on: ubuntu-latest
-    environment: testpypi-publish
     steps:
     - uses: actions/checkout@v5
 
@@ -32,11 +31,14 @@ jobs:
         pip install build
 
     - name: Build distribution
-      run: python -m build
+      run: |
+        python -m build
+        python setup_pydevd.py sdist bdist_wheel
 
     - name: Verify build artifacts
       run: |
         ls -lah dist/
+        python build_helpers/check_package_artifacts.py dist
         python -m pip install twine
         twine check dist/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 build
 dist
 omegaconf.egg-info
+omegaconf_pydev.egg-info
+omegaconf_pydevd.egg-info
+build_pydev
+build_pydevd
 venv
 .envrc
 .idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ Activate your new conda environment: `conda activate omegaconf38`
 
 Install development dependencies: `pip install -r requirements/dev.txt -e .`
 
+If you are working on the optional debugger integration, also install the
+pydevd plugin package from this checkout: `python setup_pydevd.py develop`
+
 Optionally install commit hooks: `pre-commit install`
 
 pre-commit will verify your code lints cleanly when you commit. You can use `git commit -n` to skip the pre-commit hook for a specific commit.

--- a/MANIFEST-pydevd.in
+++ b/MANIFEST-pydevd.in
@@ -1,0 +1,9 @@
+include LICENSE
+include README-pydevd.md
+include pyproject.toml
+include setup.cfg
+include setup_pydevd.py
+include omegaconf/version.py
+include build_helpers/__init__.py
+include build_helpers/build_helpers.py
+recursive-include pydevd_plugins *.py

--- a/README-pydevd.md
+++ b/README-pydevd.md
@@ -1,0 +1,33 @@
+# OmegaConf pydevd Plugin
+
+`omegaconf-pydevd` provides the optional `pydevd` plugin for OmegaConf objects.
+
+This debugger integration was split out of the main `omegaconf` package so that
+installing OmegaConf no longer adds modules under the global `pydevd_plugins`
+namespace by default.
+
+The plugin improves debugger inspection of OmegaConf objects, including handling
+of interpolations and missing values.
+
+## Installation
+
+```bash
+pip install omegaconf-pydevd
+```
+
+This package depends on the matching `omegaconf` version and installs the
+`pydevd_plugins.extensions.pydevd_plugin_omegaconf` module.
+
+## Development From Source
+
+From a local checkout, install OmegaConf itself in editable mode:
+
+```bash
+pip install -r requirements/dev.txt -e .
+```
+
+Then install the pydevd plugin package from this checkout:
+
+```bash
+python setup_pydevd.py develop
+```

--- a/build_helpers/build_helpers.py
+++ b/build_helpers/build_helpers.py
@@ -7,10 +7,12 @@ import subprocess
 import sys
 from functools import partial
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, cast
 
 from setuptools import Command
 from setuptools.command import build_py, develop, sdist
+from setuptools.command.egg_info import egg_info as egg_info_command
+from setuptools.command.egg_info import manifest_maker
 
 
 class ANTLRCommand(Command):  # type: ignore  # pragma: no cover
@@ -151,6 +153,56 @@ class SDistCommand(sdist.sdist):  # pragma: no cover
             self.run_command("clean")
             run_antlr(self)
         sdist.sdist.run(self)
+
+
+class PydevdSDistCommand(sdist.sdist):  # pragma: no cover
+    def initialize_options(self) -> None:
+        super().initialize_options()
+        self.template = "MANIFEST-pydevd.in"
+        self.use_defaults = False
+
+    def get_file_list(self) -> None:
+        template_exists = os.path.isfile(self.template)
+        if not template_exists:
+            self.warn(f"manifest template '{self.template}' does not exist")
+
+        self.filelist.findall()
+        self.filelist.files = []
+
+        if template_exists:
+            self.read_template()
+
+        if self.prune:
+            self.prune_file_list()
+
+        self.filelist.sort()
+        self.filelist.remove_duplicates()
+        self.write_manifest()
+
+
+class PydevdManifestMaker(manifest_maker):  # pragma: no cover
+    template = "MANIFEST-pydevd.in"
+    ignore_egg_info_dir: bool
+
+    def initialize_options(self) -> None:
+        super().initialize_options()
+        self.ignore_egg_info_dir = False
+
+    def add_defaults(self) -> None:
+        self.filelist.append(self.template)
+        self.filelist.append(self.manifest)
+        ei_cmd = cast(PydevdEggInfoCommand, self.get_finalized_command("egg_info"))
+        self.filelist.graft(ei_cmd.egg_info)  # type: ignore[no-untyped-call]
+
+
+class PydevdEggInfoCommand(egg_info_command):  # pragma: no cover
+    def find_sources(self) -> None:
+        manifest_filename = os.path.join(self.egg_info, "SOURCES.txt")
+        mm = PydevdManifestMaker(self.distribution)
+        mm.ignore_egg_info_dir = self.ignore_egg_info_in_manifest
+        mm.manifest = manifest_filename
+        mm.run()
+        self.filelist = mm.filelist
 
 
 def find(

--- a/build_helpers/check_package_artifacts.py
+++ b/build_helpers/check_package_artifacts.py
@@ -1,0 +1,109 @@
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Iterable, List
+
+PYDEV_PLUGIN = "pydevd_plugins/extensions/pydevd_plugin_omegaconf.py"
+OMEGACONF_PACKAGE = "omegaconf/"
+PYDEVD_ARTIFACT_PREFIX = "omegaconf_pydevd-"
+ALLOWED_PYDEVD_EXACT_MEMBERS = {
+    "LICENSE",
+    "MANIFEST-pydevd.in",
+    "PKG-INFO",
+    "README-pydevd.md",
+    "build_helpers/__init__.py",
+    "build_helpers/build_helpers.py",
+    "omegaconf/version.py",
+    "pyproject.toml",
+    "setup.cfg",
+    "setup_pydevd.py",
+}
+ALLOWED_PYDEVD_PREFIXES = (
+    "pydevd_plugins/",
+    "omegaconf_pydevd.egg-info/",
+)
+
+
+def list_archive_members(path: Path) -> List[str]:
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as zf:
+            return [name for name in zf.namelist() if not name.endswith("/")]
+    if path.suffixes[-2:] == [".tar", ".gz"]:
+        with tarfile.open(path, "r:gz") as tf:
+            return [member.name for member in tf.getmembers() if member.isfile()]
+    raise ValueError(f"Unsupported artifact type: {path}")
+
+
+def contains_plugin(members: Iterable[str]) -> bool:
+    return any(member.endswith(PYDEV_PLUGIN) for member in members)
+
+
+def normalized_members(path: Path) -> List[str]:
+    members = list_archive_members(path)
+    if path.suffixes[-2:] != [".tar", ".gz"]:
+        return members
+
+    normalized = []
+    for member in members:
+        _, _, remainder = member.partition("/")
+        normalized.append(remainder or member)
+    return normalized
+
+
+def is_allowed_pydevd_member(member: str) -> bool:
+    if member in ALLOWED_PYDEVD_EXACT_MEMBERS:
+        return True
+    if any(member.startswith(prefix) for prefix in ALLOWED_PYDEVD_PREFIXES):
+        return True
+    return ".dist-info/" in member
+
+
+def assert_contains_plugin(path: Path) -> None:
+    members = normalized_members(path)
+    if not contains_plugin(members):
+        raise AssertionError(f"{path.name} does not contain {PYDEV_PLUGIN}")
+    unexpected_omegaconf_members = sorted(
+        member
+        for member in members
+        if member.startswith(OMEGACONF_PACKAGE)
+        and member not in ALLOWED_PYDEVD_EXACT_MEMBERS
+    )
+    if unexpected_omegaconf_members:
+        raise AssertionError(f"{path.name} unexpectedly contains {OMEGACONF_PACKAGE}")
+    unexpected_members = sorted(
+        member for member in members if not is_allowed_pydevd_member(member)
+    )
+    if unexpected_members:
+        formatted = ", ".join(unexpected_members[:5])
+        raise AssertionError(f"{path.name} contains unexpected members: {formatted}")
+
+
+def assert_excludes_plugin(path: Path) -> None:
+    members = normalized_members(path)
+    if contains_plugin(members):
+        raise AssertionError(f"{path.name} unexpectedly contains {PYDEV_PLUGIN}")
+
+
+def main() -> int:
+    dist_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("dist")
+    artifacts = sorted(path for path in dist_dir.iterdir() if path.is_file())
+
+    main_artifacts = [p for p in artifacts if p.name.startswith("omegaconf-")]
+    pydev_artifacts = [
+        p for p in artifacts if p.name.startswith(PYDEVD_ARTIFACT_PREFIX)
+    ]
+
+    assert main_artifacts, "No omegaconf artifacts found"
+    assert pydev_artifacts, "No omegaconf-pydevd artifacts found"
+
+    for artifact in main_artifacts:
+        assert_excludes_plugin(artifact)
+    for artifact in pydev_artifacts:
+        assert_contains_plugin(artifact)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -885,8 +885,9 @@ The function raises a `ValueError` on input not representing a config.
 Debugger integration
 --------------------
 
-OmegaConf is packaged with a PyDev.Debugger extension which enables better debugging experience in PyCharm, 
-VSCode and other `PyDev.Debugger <https://github.com/fabioz/PyDev.Debugger>`_ powered IDEs.
+OmegaConf provides an optional ``pydevd`` plugin for better debugging in PyCharm,
+VSCode and other `PyDev.Debugger <https://github.com/fabioz/PyDev.Debugger>`_
+powered IDEs. Install it with ``pip install omegaconf-pydevd``.
 
 The debugger extension enables OmegaConf-aware object inspection:
  - providing information about interpolations.

--- a/news/1178.bugfix
+++ b/news/1178.bugfix
@@ -1,0 +1,1 @@
+OmegaConf no longer installs its optional `pydevd` debugger plugin by default. The plugin is now packaged separately as `omegaconf-pydevd` to avoid debugger conflicts in environments that bundle their own `pydevd`.

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,12 +68,21 @@ def version_string_to_tuple(version: str) -> Tuple[int, ...]:
 def lint(session: Session) -> None:
     # Note: Linting only runs on Python 3.10 to avoid running it on every CI job
     deps(session, editable_install=True)
+    session.run("python", "-c", "import os; os.makedirs('.mypy_cache', exist_ok=True)")
     session.run(
         "mypy", ".", "--strict", "--install-types", "--non-interactive", silent=True
     )
     session.run("isort", ".", "--check", silent=True)
     session.run("black", "--check", ".", silent=True)
     session.run("flake8")
+
+
+@nox.session(python=["3.10"])  # type: ignore
+def packaging(session: Session) -> None:
+    session.install("--upgrade", "setuptools", "pip")
+    session.run("python", "setup.py", "sdist", "bdist_wheel")
+    session.run("python", "setup_pydevd.py", "sdist", "bdist_wheel")
+    session.run("python", "build_helpers/check_package_artifacts.py", "dist")
 
 
 @nox.session(python=PYTHON_VERSIONS)  # type: ignore

--- a/omegaconf/version.py
+++ b/omegaconf/version.py
@@ -1,6 +1,6 @@
 import sys  # pragma: no cover
 
-__version__ = "2.4.0.dev4"
+__version__ = "2.4.0.dev7"
 
 msg = """OmegaConf 2.4 and above is compatible with Python 3.10 and newer.
 You have the following options:

--- a/pydevd_plugins/extensions/pydevd_plugin_omegaconf.py
+++ b/pydevd_plugins/extensions/pydevd_plugin_omegaconf.py
@@ -122,5 +122,5 @@ if resolver != "DISABLE":  # pragma: no cover
         TypeResolveProvider.register(OmegaConfDeveloperResolver)
     else:
         sys.stderr.write(
-            f"OmegaConf pydev plugin: Not installing. Unknown mode {resolver}. Supported one of [USER, DEV, DISABLE]\n"
+            f"OmegaConf pydevd plugin: Not installing. Unknown mode {resolver}. Supported one of [USER, DEV, DISABLE]\n"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ exclude = '''
     | omegaconf/vendor
     | \.nox
     | build
+    | build_pydev
+    | build_pydevd
     | temp
     | vendor
   )
@@ -16,7 +18,7 @@ exclude = '''
 '''
 
 [tool.isort]
-skip_glob = ["temp/*", "omegaconf/vendor/*"]
+skip_glob = ["temp/*", "build_pydev/*", "build_pydevd/*", "omegaconf/vendor/*"]
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=append -Werror"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,12 +4,12 @@ test=pytest
 [mypy]
 python_version = 3.10
 mypy_path=.stubs
-exclude = (build/|temp/|.nox/|omegaconf/vendor/)
+exclude = (build/|build_pydev/|build_pydevd/|temp/|.nox/|omegaconf/vendor/)
 
 [flake8]
 max-line-length = 88
 extend-ignore = E203, E501
-exclude = .git,.eggs,.mypy_cache,.nox,build,temp,vendor,omegaconf/grammar/gen,omegaconf/vendor
+exclude = .git,.eggs,.mypy_cache,.nox,build,build_pydev,build_pydevd,temp,vendor,omegaconf/grammar/gen,omegaconf/vendor
 
 [mypy-antlr4.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,6 @@ with open("README.md", "r") as fh:
             "omegaconf.grammar.gen",
             "omegaconf.resolvers",
             "omegaconf.resolvers.oc",
-            "pydevd_plugins",
-            "pydevd_plugins.extensions",
         ]
         + vendored_packages,
         python_requires=">=3.10",

--- a/setup_pydevd.py
+++ b/setup_pydevd.py
@@ -1,0 +1,53 @@
+# type: ignore
+"""
+OmegaConf pydevd plugin setup.
+
+Build:
+    rm -rf dist/ omegaconf_pydevd.egg-info/
+    python setup_pydevd.py sdist bdist_wheel
+"""
+
+import pathlib
+
+import setuptools
+
+from build_helpers.build_helpers import (
+    PydevdEggInfoCommand,
+    PydevdSDistCommand,
+    find_version,
+)
+
+ROOT = pathlib.Path(__file__).parent
+VERSION = find_version("omegaconf", "version.py")
+
+with (ROOT / "README-pydevd.md").open("r", encoding="utf-8") as fh:
+    LONG_DESC = fh.read()
+
+setuptools.setup(
+    cmdclass={"egg_info": PydevdEggInfoCommand, "sdist": PydevdSDistCommand},
+    name="omegaconf-pydevd",
+    version=VERSION,
+    author="Omry Yadan",
+    author_email="omry@yadan.net",
+    description="pydevd debugger plugin for OmegaConf",
+    long_description=LONG_DESC,
+    long_description_content_type="text/markdown",
+    url="https://github.com/omry/omegaconf",
+    keywords="omegaconf pydevd debugpy debugger",
+    packages=[
+        "pydevd_plugins",
+        "pydevd_plugins.extensions",
+    ],
+    python_requires=">=3.10",
+    classifiers=[
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[f"omegaconf=={VERSION}"],
+    options={"build": {"build_base": "build_pydevd"}},
+)

--- a/tests/test_check_package_artifacts.py
+++ b/tests/test_check_package_artifacts.py
@@ -1,0 +1,199 @@
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from build_helpers.check_package_artifacts import (
+    assert_contains_plugin,
+    assert_excludes_plugin,
+    main,
+    normalized_members,
+)
+
+
+def write_tar_gz(path: Path, members: dict[str, bytes]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(path, "w:gz") as tf:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, fileobj=__import__("io").BytesIO(data))
+
+
+def write_wheel(path: Path, members: dict[str, bytes]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+
+
+def test_normalized_members_strip_sdist_root(tmp_path: Path) -> None:
+    artifact = tmp_path / "omegaconf_pydevd-1.0.0.tar.gz"
+    write_tar_gz(
+        artifact,
+        {
+            "omegaconf_pydevd-1.0.0/README-pydevd.md": b"",
+            "omegaconf_pydevd-1.0.0/pydevd_plugins/__init__.py": b"",
+        },
+    )
+
+    assert normalized_members(artifact) == [
+        "README-pydevd.md",
+        "pydevd_plugins/__init__.py",
+    ]
+
+
+def test_assert_contains_plugin_accepts_expected_pydevd_layout(tmp_path: Path) -> None:
+    artifact = tmp_path / "omegaconf_pydevd-1.0.0.tar.gz"
+    write_tar_gz(
+        artifact,
+        {
+            "omegaconf_pydevd-1.0.0/LICENSE": b"",
+            "omegaconf_pydevd-1.0.0/README-pydevd.md": b"",
+            "omegaconf_pydevd-1.0.0/build_helpers/__init__.py": b"",
+            "omegaconf_pydevd-1.0.0/build_helpers/build_helpers.py": b"",
+            "omegaconf_pydevd-1.0.0/omegaconf/version.py": b"__version__ = '1.0.0'\n",
+            "omegaconf_pydevd-1.0.0/pydevd_plugins/__init__.py": b"",
+            "omegaconf_pydevd-1.0.0/pydevd_plugins/extensions/__init__.py": b"",
+            "omegaconf_pydevd-1.0.0/pydevd_plugins/extensions/pydevd_plugin_omegaconf.py": b"",
+            "omegaconf_pydevd-1.0.0/pyproject.toml": b"",
+            "omegaconf_pydevd-1.0.0/setup.cfg": b"",
+            "omegaconf_pydevd-1.0.0/setup_pydevd.py": b"",
+        },
+    )
+
+    assert_contains_plugin(artifact)
+
+
+def test_assert_contains_plugin_rejects_unexpected_pydevd_members(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "omegaconf_pydevd-1.0.0-py3-none-any.whl"
+    write_wheel(
+        artifact,
+        {
+            "LICENSE": b"",
+            "README-pydevd.md": b"",
+            "pydevd_plugins/__init__.py": b"",
+            "pydevd_plugins/extensions/__init__.py": b"",
+            "pydevd_plugins/extensions/pydevd_plugin_omegaconf.py": b"",
+            "tests/test_pydev_resolver_plugin.py": b"",
+            "omegaconf_pydevd-1.0.0.dist-info/METADATA": b"",
+        },
+    )
+
+    with pytest.raises(AssertionError, match="unexpected members"):
+        assert_contains_plugin(artifact)
+
+
+def test_normalized_members_rejects_unsupported_artifact_type(tmp_path: Path) -> None:
+    artifact = tmp_path / "omegaconf_pydevd-1.0.0.zip"
+    artifact.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="Unsupported artifact type"):
+        normalized_members(artifact)
+
+
+def test_assert_contains_plugin_rejects_missing_plugin(tmp_path: Path) -> None:
+    artifact = tmp_path / "omegaconf_pydevd-1.0.0-py3-none-any.whl"
+    write_wheel(
+        artifact,
+        {
+            "LICENSE": b"",
+            "README-pydevd.md": b"",
+            "omegaconf_pydevd-1.0.0.dist-info/METADATA": b"",
+        },
+    )
+
+    with pytest.raises(AssertionError, match="does not contain"):
+        assert_contains_plugin(artifact)
+
+
+def test_assert_excludes_plugin_accepts_main_package_layout(tmp_path: Path) -> None:
+    artifact = tmp_path / "omegaconf-1.0.0-py3-none-any.whl"
+    write_wheel(
+        artifact,
+        {
+            "omegaconf/__init__.py": b"",
+            "omegaconf/version.py": b"__version__ = '1.0.0'\n",
+            "omegaconf-1.0.0.dist-info/METADATA": b"",
+        },
+    )
+
+    assert_excludes_plugin(artifact)
+
+
+def test_assert_excludes_plugin_rejects_plugin_in_main_package(tmp_path: Path) -> None:
+    artifact = tmp_path / "omegaconf-1.0.0-py3-none-any.whl"
+    write_wheel(
+        artifact,
+        {
+            "omegaconf/__init__.py": b"",
+            "pydevd_plugins/extensions/pydevd_plugin_omegaconf.py": b"",
+            "omegaconf-1.0.0.dist-info/METADATA": b"",
+        },
+    )
+
+    with pytest.raises(AssertionError, match="unexpectedly contains"):
+        assert_excludes_plugin(artifact)
+
+
+def test_main_validates_main_and_pydevd_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_wheel(
+        tmp_path / "omegaconf-1.0.0-py3-none-any.whl",
+        {
+            "omegaconf/__init__.py": b"",
+            "omegaconf/version.py": b"__version__ = '1.0.0'\n",
+            "omegaconf-1.0.0.dist-info/METADATA": b"",
+        },
+    )
+    write_wheel(
+        tmp_path / "omegaconf_pydevd-1.0.0-py3-none-any.whl",
+        {
+            "LICENSE": b"",
+            "README-pydevd.md": b"",
+            "pydevd_plugins/__init__.py": b"",
+            "pydevd_plugins/extensions/__init__.py": b"",
+            "pydevd_plugins/extensions/pydevd_plugin_omegaconf.py": b"",
+            "omegaconf_pydevd-1.0.0.dist-info/METADATA": b"",
+        },
+    )
+    monkeypatch.setattr("sys.argv", ["check_package_artifacts.py", str(tmp_path)])
+
+    assert main() == 0
+
+
+def test_main_requires_main_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_wheel(
+        tmp_path / "omegaconf_pydevd-1.0.0-py3-none-any.whl",
+        {
+            "pydevd_plugins/extensions/pydevd_plugin_omegaconf.py": b"",
+            "omegaconf_pydevd-1.0.0.dist-info/METADATA": b"",
+        },
+    )
+    monkeypatch.setattr("sys.argv", ["check_package_artifacts.py", str(tmp_path)])
+
+    with pytest.raises(AssertionError, match="No omegaconf artifacts found"):
+        main()
+
+
+def test_main_requires_pydevd_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_wheel(
+        tmp_path / "omegaconf-1.0.0-py3-none-any.whl",
+        {
+            "omegaconf/__init__.py": b"",
+            "omegaconf/version.py": b"__version__ = '1.0.0'\n",
+            "omegaconf-1.0.0.dist-info/METADATA": b"",
+        },
+    )
+    monkeypatch.setattr("sys.argv", ["check_package_artifacts.py", str(tmp_path)])
+
+    with pytest.raises(AssertionError, match="No omegaconf-pydevd artifacts found"):
+        main()


### PR DESCRIPTION

Package the OmegaConf pydevd debugger integration as
omegaconf-pydevd instead of shipping it in the main omegaconf
distribution.

Update packaging, publishing, docs, and verification to build and
release both distributions.

#1178
