### PR TITLE
Fix bug preserving identity on config self-assignment

### DIFF
--- a/news/1177.bugfix
+++ b/news/1177.bugfix
@@ -1,0 +1,1 @@
+Preserve container identity when assigning a config node to itself.

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -576,6 +576,14 @@ class BaseContainer(Container, ABC):
         from .nodes import AnyNode, ValueNode
 
         if isinstance(value, Node):
+            target_node_ref = self._get_node(key, validate_access=False)
+            if target_node_ref is value:
+                if self._get_flag("readonly"):
+                    raise ReadonlyConfigError(
+                        "Cannot change read-only config container"
+                    )
+                return
+
             do_deepcopy = not self._get_flag("no_deepcopy_set_nodes")
             if not do_deepcopy and isinstance(value, Box):
                 # if value is from the same config, perform a deepcopy no matter what.

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -12,7 +12,7 @@ import yaml
 from pytest import mark, param, raises
 
 from omegaconf import DictConfig, ListConfig, OmegaConf
-from omegaconf.errors import UnsupportedValueType, ValidationError
+from omegaconf.errors import ReadonlyConfigError, UnsupportedValueType, ValidationError
 from tests import (
     ConcretePlugin,
     DictOfAny,
@@ -314,6 +314,42 @@ def test_list_assignment_deepcopy_semantics(node: Any) -> None:
     cfg.foo = node
     node[1] = 10
     assert cfg.foo[1] == 2
+
+
+@mark.parametrize(
+    "cfg,key,mutate",
+    [
+        param(
+            OmegaConf.create({"foo": {"bar": "before"}}),
+            "foo",
+            lambda node: setattr(node, "bar", "after"),
+            id="dict",
+        ),
+        param(
+            OmegaConf.create([[1]]),
+            0,
+            lambda node: node.append(2),
+            id="list",
+        ),
+    ],
+)
+def test_self_assignment_preserves_container_identity(
+    cfg: Any, key: Any, mutate: Any
+) -> None:
+    node = cfg[key]
+    cfg[key] = cfg[key]
+    assert cfg[key] is node
+
+    mutate(node)
+    assert cfg[key] == node
+
+
+def test_self_assignment_checks_readonly() -> None:
+    cfg = OmegaConf.create({"foo": {"bar": "before"}})
+    OmegaConf.set_readonly(cfg, True)
+
+    with raises(ReadonlyConfigError):
+        cfg.foo = cfg.foo
 
 
 @mark.parametrize("d", [{"a": {"b": 10}}, {"a": {"b": {"c": 10}}}])


### PR DESCRIPTION

Assigning an OmegaConf container node to itself used to flow through the normal Node assignment path. That path deep-copies incoming nodes before storing them, so code like cfg.foo = cfg.foo or cfg[0] = cfg[0] could replace the stored child container and leave existing references detached from the config.

Fix the bug by detecting exact self-assignment before the deepcopy/reparent step and returning early after preserving readonly enforcement. This keeps normal cross-config and cross-key node assignment deepcopy semantics unchanged while making true no-op self-assignment preserve container identity.

Add coverage for DictConfig child self-assignment, nested ListConfig element self-assignment through public API, and readonly self-assignment. Add a bugfix news fragment for issue 1177.

Fixes #1177 
