### PR TITLE
Fix structured config container forward refs on Python 3.10 and older

### DIFF
--- a/news/1174.bugfix
+++ b/news/1174.bugfix
@@ -1,0 +1,2 @@
+Fixed structured config support for forward references inside container
+annotations on Python 3.10 and older.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -311,16 +311,23 @@ def get_yaml_loader() -> Any:
     return loader
 
 
-def _get_class(path: str) -> type:
+def _get_class(module_path: str, class_name: str) -> type:
     from importlib import import_module
 
-    module_path, _, class_name = path.rpartition(".")
-    mod = import_module(module_path)
-    try:
-        klass: type = getattr(mod, class_name)
-    except AttributeError:
-        raise ImportError(f"Class {class_name} is not in module {module_path}")
-    return klass
+    if not module_path or not class_name:
+        raise ValueError(
+            f"Invalid module/class specification: {module_path!r}, {class_name!r}"
+        )
+
+    obj: Any = import_module(module_path)
+    for attr_name in class_name.split("."):
+        try:
+            obj = getattr(obj, attr_name)
+        except AttributeError:
+            raise ImportError(f"Class {attr_name} is not in module {module_path}")
+
+    assert isinstance(obj, type)
+    return obj
 
 
 def is_union_annotation(type_: Any) -> bool:
@@ -371,7 +378,9 @@ def _resolve_forward(type_: Type[Any], module: str) -> Type[Any]:
 
     forward = typing.ForwardRef if hasattr(typing, "ForwardRef") else typing._ForwardRef  # type: ignore
     if type(type_) is forward:
-        return _get_class(f"{module}.{type_.__forward_arg__}")
+        return _get_class(module, type_.__forward_arg__)
+    elif isinstance(type_, str):
+        return _get_class(module, type_)
     else:
         if is_dict_annotation(type_):
             kt, vt = get_dict_key_value_types(type_)

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -46,6 +46,19 @@ def module(request: Any) -> Any:
     return import_module(request.param)
 
 
+@dataclasses.dataclass
+class ForwardRefListTree:
+    value: int = -1
+    children: Optional[list["ForwardRefListTree"]] = None
+
+
+class DottedForwardRefListTree:
+    @dataclasses.dataclass
+    class Node:
+        value: int = -1
+        children: Optional[list["DottedForwardRefListTree.Node"]] = None
+
+
 class EnumConfigAssignments:
     legal = [
         (Color.RED, Color.RED),
@@ -252,6 +265,23 @@ class TestConfigs:
 
         conf2 = OmegaConf.structured(module.ConfigWithList(list1=MISSING))
         assert OmegaConf.is_missing(conf2, "list1")
+
+    def test_structured_forward_ref_in_list(self) -> None:
+        cfg = OmegaConf.structured(
+            ForwardRefListTree(value=1, children=[ForwardRefListTree(value=2)])
+        )
+
+        assert cfg == {"value": 1, "children": [{"value": 2, "children": None}]}
+
+    def test_structured_dotted_forward_ref_in_list(self) -> None:
+        cfg = OmegaConf.structured(
+            DottedForwardRefListTree.Node(
+                value=1,
+                children=[DottedForwardRefListTree.Node(value=2)],
+            )
+        )
+
+        assert cfg == {"value": 1, "children": [{"value": 2, "children": None}]}
 
     def test_assignment_to_nested_structured_config(self, module: Any) -> None:
         conf = OmegaConf.structured(module.NestedConfig)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,6 +55,7 @@ from tests import (
     UnionAnnotations,
     User,
 )
+from tests.structured_conf.data.dataclasses import HasForwardRef
 
 
 class DummyEnum(Enum):
@@ -523,16 +524,26 @@ def test_re_parent() -> None:
 
 
 def test_get_class() -> None:
-    name = "tests.examples.test_dataclass_example.SimpleTypes"
-    assert _utils._get_class(name).__name__ == "SimpleTypes"
+    assert (
+        _utils._get_class(
+            "tests.examples.test_dataclass_example", "SimpleTypes"
+        ).__name__
+        == "SimpleTypes"
+    )
+    assert (
+        _utils._get_class(
+            "tests.structured_conf.data.dataclasses", "HasForwardRef.CA"
+        ).__name__
+        == "CA"
+    )
     with raises(ValueError):
-        _utils._get_class("not_found")
+        _utils._get_class("", "not_found")
 
     with raises(ModuleNotFoundError):
-        _utils._get_class("foo.not_found")
+        _utils._get_class("foo", "not_found")
 
     with raises(ImportError):
-        _utils._get_class("tests.examples.test_dataclass_example.not_found")
+        _utils._get_class("tests.examples.test_dataclass_example", "not_found")
 
 
 @mark.parametrize(
@@ -1491,7 +1502,15 @@ def test_resolve_optional_support_pep_604() -> None:
             List[int],
             id="List[int]_forward",
         ),
+        param(
+            List["HasForwardRef.CA"],  # pyrefly: ignore[not-a-type]
+            List[HasForwardRef.CA],
+            id="List[nested_forward]_forward",
+        ),
     ],
 )
 def test_resolve_forward(type_: Any, expected: Any) -> None:
-    assert _resolve_forward(type_, "builtins") == expected
+    module = "builtins"
+    if expected == List[HasForwardRef.CA]:
+        module = "tests.structured_conf.data.dataclasses"
+    assert _resolve_forward(type_, module) == expected


### PR DESCRIPTION

Python 3.10 and older can represent built-in container forward
references like list["Tree"] differently from newer versions, leaving
string-based element types unresolved inside structured configs. This
caused OmegaConf.structured() to fail with a ValidationError for
forward references inside containers.

Handle string-based forward references in _resolve_forward() and allow
_get_class() to resolve dotted nested class paths such as
"HasForwardRef.CA". Add regression tests for both simple and dotted
container forward references.

Closes #1174
