### PR TITLE
Fix union validation in nested structured container merges

### DIFF
--- a/news/1166.bugfix
+++ b/news/1166.bugfix
@@ -1,0 +1,1 @@
+Fixed validation for union-typed values nested in structured config containers during merges and interpolation resolution.

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -647,6 +647,24 @@ class Container(Box):
             if type(conv_value) is not type(res_value):
                 must_wrap = True
                 resolved = conv_value
+        elif isinstance(value, UnionNode):
+            res_value = _get_value(resolved)
+            try:
+                UnionNode(
+                    content=res_value,
+                    ref_type=value._metadata.ref_type,
+                    is_optional=value._is_optional(),
+                )
+            except ValidationError as e:
+                if throw_on_resolution_failure:
+                    self._format_and_raise(
+                        key=key,
+                        value=res_value,
+                        cause=e,
+                        msg=f"While dereferencing interpolation '{value}': {e}",
+                        type_override=InterpolationValidationError,
+                    )
+                return None
 
         if must_wrap:
             return InterpolationResultNode(value=resolved, key=key, parent=parent)

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -873,16 +873,30 @@ def _update_types(node: Node, ref_type: Any, object_type: Optional[type]) -> Non
 
 def _deep_update_type_hint(node: Node, type_hint: Any) -> None:
     """Ensure node is compatible with type_hint, mutating if necessary."""
-    from omegaconf import DictConfig, ListConfig
+    from omegaconf import DictConfig, ListConfig, OmegaConf
 
     from ._utils import get_dict_key_value_types, get_list_element_type
 
     if type_hint is Any:
         return
 
+    new_is_optional, new_ref_type = _resolve_optional(type_hint)
+
+    if (
+        is_structured_config(new_ref_type)
+        and isinstance(node, DictConfig)
+        and not _is_special(node)
+        and not is_structured_config(node._metadata.object_type)
+    ):
+        prototype = DictConfig(
+            new_ref_type,
+            ref_type=new_ref_type,
+            is_optional=new_is_optional,
+        )
+        node._set_value(OmegaConf.merge(prototype, node))
+
     _shallow_validate_type_hint(node, type_hint)
 
-    new_is_optional, new_ref_type = _resolve_optional(type_hint)
     node._metadata.ref_type = new_ref_type
     node._metadata.optional = new_is_optional
 
@@ -911,7 +925,13 @@ def _deep_update_subnode(node: BaseContainer, key: Any, value_type_hint: Any) ->
     """Get node[key] and ensure it is compatible with value_type_hint, mutating if necessary."""
     subnode = node._get_node(key)
     assert isinstance(subnode, Node)
-    if _is_special(subnode):
+    if _is_special(subnode) or (
+        is_union_annotation(value_type_hint)
+        and (
+            not isinstance(subnode, UnionNode)
+            or get_type_hint(subnode) != value_type_hint
+        )
+    ):
         # Ensure special values are wrapped in a Node subclass that
         # is compatible with the type hint.
         node._wrap_value_and_set(key, subnode._value(), value_type_hint)
@@ -922,7 +942,7 @@ def _deep_update_subnode(node: BaseContainer, key: Any, value_type_hint: Any) ->
 
 def _shallow_validate_type_hint(node: Node, type_hint: Any) -> None:
     """Error if node's type, content and metadata are not compatible with type_hint."""
-    from omegaconf import DictConfig, ListConfig, ValueNode
+    from omegaconf import DictConfig, ListConfig, UnionNode, ValueNode
 
     is_optional, ref_type = _resolve_optional(type_hint)
 
@@ -946,6 +966,15 @@ def _shallow_validate_type_hint(node: Node, type_hint: Any) -> None:
                     f"Value {value!r} ({type(value).__name__})"
                     + f" is incompatible with type hint '{ref_type.__name__}'"
                 )
+        elif is_union_annotation(ref_type) and isinstance(node, UnionNode):
+            # Validate the boxed value against the new union hint. The temporary
+            # UnionNode constructor raises ValidationError if it is incompatible.
+            UnionNode(
+                content=_get_value(node),
+                ref_type=ref_type,
+                is_optional=is_optional,
+            )
+            return
         elif is_structured_config(ref_type) and isinstance(node, DictConfig):
             return
         elif is_dict_annotation(ref_type) and isinstance(node, DictConfig):

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -1945,6 +1945,65 @@ class TestNestedContainers:
 
 class TestUnionsOfPrimitiveTypes:
     @mark.parametrize(
+        "container_type, default_factory, merge_value, expected, type_hint_checks",
+        [
+            param(
+                Dict[str, Dict[str, Union[str, int]]],
+                lambda: {"a": {"b": 1}},
+                {"c": {"b": 1}},
+                {"z": {"a": {"b": 1}, "c": {"b": 1}}},
+                [(lambda merged: merged.z.c, "b", Union[str, int])],
+                id="dict-dict",
+            ),
+            param(
+                List[List[Union[str, int]]],
+                lambda: [[1, 2]],
+                [[1, 2], [3]],
+                {"z": [[1, 2], [3]]},
+                [(lambda merged: merged.z, 1, List[Union[str, int]])],
+                id="list-list",
+            ),
+            param(
+                List[Dict[str, Union[str, int]]],
+                lambda: [{"a": 1}],
+                [{"a": 1}, {"b": 2}],
+                {"z": [{"a": 1}, {"b": 2}]},
+                [
+                    (lambda merged: merged.z, 1, Dict[str, Union[str, int]]),
+                    (lambda merged: merged.z[1], "b", Union[str, int]),
+                ],
+                id="list-dict",
+            ),
+            param(
+                Dict[str, List[Union[str, int]]],
+                lambda: {"a": [1, 2]},
+                {"c": [1]},
+                {"z": {"a": [1, 2], "c": [1]}},
+                [(lambda merged: merged.z, "c", List[Union[str, int]])],
+                id="dict-list",
+            ),
+        ],
+    )
+    def test_merge_nested_containers_with_union_types(
+        self,
+        container_type: Any,
+        default_factory: Callable[[], Any],
+        merge_value: Any,
+        expected: Any,
+        type_hint_checks: List[Tuple[Callable[[Any], Any], Any, Any]],
+    ) -> None:
+        HasUnion = dataclasses.make_dataclass(
+            "HasUnion",
+            [("z", container_type, dataclasses.field(default_factory=default_factory))],
+        )
+
+        merged = OmegaConf.merge(OmegaConf.structured(HasUnion), {"z": merge_value})
+
+        assert merged == expected
+        for node_getter, key, expected_type_hint in type_hint_checks:
+            assert _utils.get_type_hint(node_getter(merged), key) == expected_type_hint
+
+    @mark.parametrize(
         "class_name, key, expected_type_hint, expected_val",
         [
             param("Simple", "uis", Union[int, str], MISSING, id="simple-uis"),
@@ -2345,14 +2404,12 @@ class TestUnionsOfPrimitiveTypes:
                 "${none}",
                 raises(ValidationError),
                 id="interp-to-none-err",
-                marks=mark.xfail(reason="interpolations from unions are not validated"),
             ),
             param(
                 "ubi",
                 "${a_string}",
                 raises(ValidationError),
                 id="interp-to-str-err",
-                marks=mark.xfail(reason="interpolations from unions are not validated"),
             ),
             param(
                 "ubi",
@@ -2399,6 +2456,15 @@ class TestUnionsOfPrimitiveTypes:
         with raises(ValidationError):
             OmegaConf.resolve(cfg)
 
+    def test_select_union_interpolation_error_without_throwing(
+        self, module: Any
+    ) -> None:
+        class_ = module.UnionsOfPrimitveTypes.InterpolationFromUnion
+        cfg = OmegaConf.structured(class_)
+        cfg.ubi = "${a_string}"
+
+        assert OmegaConf.select(cfg, "ubi", throw_on_resolution_failure=False) is None
+
     @mark.parametrize(
         "key, expected",
         [
@@ -2443,3 +2509,25 @@ class TestUnionsOfPrimitiveTypes:
         cfg.null_default = Path("hello.txt")
         assert isinstance(cfg.null_default, str)
         assert cfg.null_default == "hello.txt"
+
+
+class TestStructuredConfigValidationInNewNestedContainers:
+    def test_merge_new_nested_list_item_of_structured_config_rejects_unknown_key(
+        self,
+    ) -> None:
+        @dataclasses.dataclass
+        class Foo:
+            exist1: int
+            exist2: str
+
+        @dataclasses.dataclass
+        class BaseStructure:
+            z: Dict[str, List[Foo]] = dataclasses.field(
+                default_factory=lambda: {"a": [Foo(1, "lol")]}
+            )
+
+        with raises(ConfigKeyError):
+            OmegaConf.merge(
+                OmegaConf.structured(BaseStructure),
+                {"z": {"c": [{"exist1": 1, "dontexist2": "lol"}]}},
+            )

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -35,6 +35,7 @@ from omegaconf._utils import (
     is_structured_config,
 )
 from omegaconf.base import ListMergeMode, Node
+from omegaconf.basecontainer import _deep_update_type_hint
 from omegaconf.errors import ConfigKeyError, UnsupportedValueType
 from omegaconf.nodes import IntegerNode
 from tests import (
@@ -1009,6 +1010,16 @@ def test_union_merge(inputs: Any, expected: Any, type_hint: Any) -> None:
         node = merged._get_node("foo")
         assert isinstance(node, Node)
         assert get_type_hint(node) == type_hint
+
+
+def test_deep_update_type_hint_rejects_incompatible_union_node() -> None:
+    node = UnionNode("abc", Union[int, str])
+
+    with raises(ValidationError):
+        _deep_update_type_hint(node, Union[bool, float])
+
+    assert node == "abc"
+    assert node._metadata.ref_type == Union[int, str]
 
 
 @mark.parametrize(


### PR DESCRIPTION

- validate union-typed values when retyping nested dict nodes during merge
- validate interpolation results against union hints when dereferencing union nodes
- convert the remaining regression tests and add a news fragment for #1166

Closes #1166
