### PR TITLE
Support List and Dict union members in structured configs

### DIFF
--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -35,7 +35,8 @@ in the input class.
 Currently, type hints supported in OmegaConf’s structured configs include:
  - primitive types (``int``, ``float``, ``bool``, ``str``, ``bytes``, ``Path``) and enum types
    (user-defined subclasses of ``enum.Enum``). See the :ref:`simple_types` section below.
- - unions of primitive/enum types, e.g. ``Union[float, bool, MyEnum]``.
+ - unions of primitive/enum types, e.g. ``Union[float, bool, MyEnum]``, and
+   unions of typed container types, e.g. ``Union[List[int], Dict[str, int]]``.
    See :ref:`union_types` below.
  - structured config fields (i.e. MyConfig.x can have type hint MySubConfig).
    See the :ref:`nesting_structured_configs` section below.
@@ -435,6 +436,79 @@ must precisely match one of the types in the ``Union`` annotation:
         full_key: u
         object_type=StrOrInt
 
+
+Unions of container types
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Union members may also be typed ``List[...]`` or ``Dict[...]`` containers.
+OmegaConf selects the matching branch at assignment time by validating the
+assigned value against each candidate:
+
+.. doctest::
+
+    >>> from dataclasses import field
+    >>> from typing import Dict, List, Union
+    >>>
+    >>> @dataclass
+    ... class HasContainerUnion:
+    ...     value: Union[List[int], Dict[str, int]] = field(default_factory=lambda: [1, 2])
+    ...
+    >>> cfg = OmegaConf.structured(HasContainerUnion)
+    >>> assert cfg.value == [1, 2]        # default selects List[int]
+    >>> cfg.value = {"x": 1}             # selects Dict[str, int]
+    >>> assert cfg.value == {"x": 1}
+    >>> cfg.value = [3, 4]               # back to List[int]
+    >>> assert cfg.value == [3, 4]
+
+Once a branch is selected, the field is fully typed and rejects values that
+violate the selected container's element type:
+
+.. doctest::
+
+    >>> cfg.value = [1, 2]
+    >>> cfg.value.append(1)              # ok — List[int]
+    >>> cfg.value.append("x")           # not ok — str is not int
+    Traceback (most recent call last):
+    ...
+    omegaconf.errors.ValidationError: Value 'x' of type 'str' is incompatible with type hint 'int'
+        full_key: value.[3]
+        reference_type=List[int]
+        object_type=list
+
+**Ambiguous assignments.** When a value is valid for more than one union
+member — most commonly an empty container — OmegaConf raises a
+``ValidationError`` rather than silently picking the first branch:
+
+.. doctest::
+
+    >>> @dataclass
+    ... class ListUnion:
+    ...     value: Union[List[int], List[str]] = field(default_factory=lambda: [1])
+    ...
+    >>> cfg = OmegaConf.structured(ListUnion)
+    >>> cfg.value = []
+    Traceback (most recent call last):
+    ...
+    omegaconf.errors.ValidationError: Ambiguous assignment to Union[List[int], List[str]]. Value '[]' matches multiple union members: List[int], List[str]. Use an explicitly typed container to disambiguate.
+        full_key: value
+        object_type=ListUnion
+
+Use :py:meth:`OmegaConf.typed_list` or :py:meth:`OmegaConf.typed_dict` to
+create an explicitly typed container and resolve the ambiguity:
+
+.. doctest::
+
+    >>> cfg.value = OmegaConf.typed_list([], element_type=str)
+    >>> assert cfg.value == []
+    >>> cfg.value.append("hello")
+    >>> assert cfg.value == ["hello"]
+
+Both methods accept an optional initial content argument:
+
+.. doctest::
+
+    >>> lst = OmegaConf.typed_list([1, 2, 3], element_type=int)
+    >>> d = OmegaConf.typed_dict({"x": 1}, key_type=str, element_type=int)
 
 .. _other_special_features:
 

--- a/news/1261.feature
+++ b/news/1261.feature
@@ -1,0 +1,1 @@
+Add support for unions of typed container types (e.g. ``Union[List[int], Dict[str, int]]``) in structured configs. Introduce ``OmegaConf.typed_list()`` and ``OmegaConf.typed_dict()`` for explicit container typing when disambiguating an otherwise ambiguous union assignment.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -798,11 +798,14 @@ def is_tuple_annotation(type_: Any) -> bool:
 
 
 def is_supported_union_annotation(obj: Any) -> bool:
-    """Currently only primitive types are supported in Unions, e.g. Union[int, str]"""
+    """Primitives and typed List/Dict containers are supported in Unions."""
     if not is_union_annotation(obj):
         return False
     args = obj.__args__
-    return all(is_primitive_type_annotation(arg) for arg in args)
+    return all(
+        is_primitive_type_annotation(arg) or is_container_annotation(arg)
+        for arg in args
+    )
 
 
 def is_dict_subclass(type_: Any) -> bool:

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -27,6 +27,8 @@ from ._utils import (
     _is_special,
     format_and_raise,
     get_value_kind,
+    is_dict_annotation,
+    is_list_annotation,
     is_union_annotation,
     is_valid_value_annotation,
     split_key,
@@ -921,6 +923,7 @@ class UnionNode(Box):
     def _set_value_impl(
         self, value: Any, flags: Optional[Dict[str, bool]] = None
     ) -> None:
+        from omegaconf.listconfig import ListConfig
         from omegaconf.omegaconf import _node_wrap
 
         ref_type = self._metadata.ref_type
@@ -935,9 +938,20 @@ class UnionNode(Box):
                         f"Value '$VALUE' is incompatible with type hint '{type_str(type_hint)}'"
                     )
             self.__dict__["_content"] = value
-        elif isinstance(value, Container):
-            raise ValidationError(
-                f"Cannot assign container '$VALUE' of type '$VALUE_TYPE' to {type_str(type_hint)}"
+        elif isinstance(value, (list, tuple, ListConfig)):
+            # Only try List[...] candidates — keeps primitive members out of container
+            # dispatch and makes ambiguity an error instead of silent first-match.
+            self._set_container_value(
+                value=value,
+                candidates=[t for t in ref_type.__args__ if is_list_annotation(t)],
+                type_hint=type_hint,
+            )
+        elif isinstance(value, (dict, Container)):
+            # Same policy for Dict[...] candidates.
+            self._set_container_value(
+                value=value,
+                candidates=[t for t in ref_type.__args__ if is_dict_annotation(t)],
+                type_hint=type_hint,
             )
         else:
             for candidate_ref_type in ref_type.__args__:
@@ -956,6 +970,68 @@ class UnionNode(Box):
                 raise ValidationError(
                     f"Value '$VALUE' of type '$VALUE_TYPE' is incompatible with type hint '{type_str(type_hint)}'"
                 )
+
+    def _set_container_value(
+        self,
+        value: Any,
+        candidates: List[Any],
+        type_hint: Any,
+    ) -> None:
+        from omegaconf.listconfig import ListConfig
+        from omegaconf.omegaconf import _node_wrap
+
+        from ._utils import get_dict_key_value_types, get_list_element_type
+
+        # For an already-typed container (from typed_list/typed_dict or another
+        # structured config), use its element-type metadata to narrow candidates
+        # before falling back to content-based validation. This makes empty
+        # containers unambiguous when the metadata uniquely identifies one branch.
+        if isinstance(value, ListConfig) and value._metadata.element_type is not Any:
+            meta_candidates = [
+                t
+                for t in candidates
+                if get_list_element_type(t) == value._metadata.element_type
+            ]
+            if meta_candidates:
+                candidates = meta_candidates
+        elif isinstance(value, Container) and not isinstance(value, ListConfig):
+            vkey, vval = get_dict_key_value_types(value._metadata.ref_type)
+            if vkey is not Any or vval is not Any:
+                meta_candidates = [
+                    t for t in candidates if get_dict_key_value_types(t) == (vkey, vval)
+                ]
+                if meta_candidates:
+                    candidates = meta_candidates
+
+        matches: List[Node] = []
+        for candidate_ref_type in candidates:
+            try:
+                node = _node_wrap(
+                    value=value,
+                    ref_type=candidate_ref_type,
+                    is_optional=False,
+                    key=None,
+                    parent=self,
+                )
+                matches.append(node)
+                if len(matches) > 1:
+                    break  # ambiguous — stop constructing further candidates
+            except Exception:
+                continue
+
+        if len(matches) == 0:
+            raise ValidationError(
+                f"Value '$VALUE' of type '$VALUE_TYPE' is incompatible with type hint '{type_str(type_hint)}'"
+            )
+        elif len(matches) == 1:
+            self.__dict__["_content"] = matches[0]
+        else:
+            matching_types = ", ".join(type_str(n._metadata.ref_type) for n in matches)
+            raise ValidationError(
+                f"Ambiguous assignment to {type_str(type_hint)}. "
+                f"Value '$VALUE' matches multiple union members: {matching_types}. "
+                f"Use an explicitly typed container to disambiguate."
+            )
 
     def _is_optional(self) -> bool:
         return self.__dict__["_metadata"].optional is True

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -185,6 +185,46 @@ class OmegaConf:
         )
 
     @staticmethod
+    def typed_list(
+        content: Optional[List[Any]] = None,
+        element_type: Any = Any,
+    ) -> ListConfig:
+        """Create a ListConfig with an explicit element type.
+
+        Useful for disambiguating assignment to a Union[List[X], List[Y]] field
+        when the value is empty or otherwise matches multiple candidates.
+        """
+        from typing import List as _List
+
+        ref_type = _List[element_type]
+        return ListConfig(
+            content=content if content is not None else [],
+            element_type=element_type,
+            ref_type=ref_type,
+        )
+
+    @staticmethod
+    def typed_dict(
+        content: Optional[Dict[Any, Any]] = None,
+        key_type: Any = Any,
+        element_type: Any = Any,
+    ) -> DictConfig:
+        """Create a DictConfig with explicit key and value types.
+
+        Useful for disambiguating assignment to a Union[Dict[str, X], Dict[str, Y]]
+        field when the value is empty or otherwise matches multiple candidates.
+        """
+        from typing import Dict as _Dict
+
+        ref_type = _Dict[key_type, element_type]
+        return DictConfig(
+            content=content if content is not None else {},
+            key_type=key_type,
+            element_type=element_type,
+            ref_type=ref_type,
+        )
+
+    @staticmethod
     def load(file_: Union[str, pathlib.Path, IO[Any]]) -> Union[DictConfig, ListConfig]:
         from ._utils import get_yaml_loader
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -149,7 +149,7 @@ class StructuredWithMissing:
 
 @dataclass
 class UnionError:
-    x: Union[int, List[str]] = 10
+    x: Union[int, User] = 10
 
 
 @dataclass

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -576,7 +576,12 @@ class NestedWithNone:
 
 @attr.s(auto_attribs=True)
 class UnionError:
-    x: Union[int, List[str]] = 10
+    x: Union[int, Plugin] = 10
+
+
+@attr.s(auto_attribs=True)
+class ContainerUnion:
+    x: Union[List[int], Dict[str, int]] = [1, 2]  # type: ignore
 
 
 @attr.s(auto_attribs=True)

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -601,7 +601,12 @@ class NestedWithNone:
 
 @dataclass
 class UnionError:
-    x: Union[int, List[str]] = 10
+    x: Union[int, Plugin] = 10
+
+
+@dataclass
+class ContainerUnion:
+    x: Union[List[int], Dict[str, int]] = field(default_factory=lambda: [1, 2])
 
 
 @dataclass

--- a/tests/structured_conf/data/dataclasses_pre_311.py
+++ b/tests/structured_conf/data/dataclasses_pre_311.py
@@ -599,7 +599,12 @@ class NestedWithNone:
 
 @dataclass
 class UnionError:
-    x: Union[int, List[str]] = 10
+    x: Union[int, Plugin] = 10
+
+
+@dataclass
+class ContainerUnion:
+    x: Union[List[int], Dict[str, int]] = field(default_factory=lambda: [1, 2])
 
 
 @dataclass

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -265,6 +265,16 @@ class TestConfigs:
         with raises(ValueError):
             OmegaConf.structured(module.UnionError)
 
+    def test_container_union(self, module: Any) -> None:
+        cfg = OmegaConf.structured(module.ContainerUnion)
+        assert cfg.x == [1, 2]
+        cfg.x = {"a": 1}
+        assert cfg.x == {"a": 1}
+        cfg.x = [3, 4]
+        assert cfg.x == [3, 4]
+        with raises(ValidationError):
+            cfg.x = [1, "bad"]  # invalid for List[int]
+
     def test_config_with_list(self, module: Any) -> None:
         def validate(cfg: DictConfig) -> None:
             assert cfg == {"list1": [1, 2, 3], "list2": [1, 2, 3], "missing": MISSING}

--- a/tests/test_container_unions.py
+++ b/tests/test_container_unions.py
@@ -1,0 +1,478 @@
+"""
+Tests for Union[List[...], Dict[...], ...] support (issue #1261).
+"""
+
+import copy
+import pickle
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+from pytest import mark, param, raises
+
+from omegaconf import ListMergeMode, OmegaConf, ValidationError
+from omegaconf._utils import is_supported_union_annotation
+
+# ---------------------------------------------------------------------------
+# Dataclasses for structured-config tests
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CfgIntOrListStr:
+    value: Union[int, List[str]] = 0
+
+
+@dataclass
+class CfgIntOrDictStrInt:
+    value: Union[int, Dict[str, int]] = 0
+
+
+@dataclass
+class CfgListIntOrListStr:
+    value: Union[List[int], List[str]] = field(default_factory=lambda: [1, 2])
+
+
+@dataclass
+class CfgDictStrIntOrDictStrStr:
+    value: Union[Dict[str, int], Dict[str, str]] = field(
+        default_factory=lambda: {"x": 1}
+    )
+
+
+@dataclass
+class CfgDictOrList:
+    value: Union[Dict[str, int], List[int]] = field(default_factory=lambda: [1])
+
+
+@dataclass
+class CfgMissing:
+    value: Union[List[int], List[str]] = field(default_factory=lambda: [1])
+
+
+# ---------------------------------------------------------------------------
+# is_supported_union_annotation
+# ---------------------------------------------------------------------------
+
+
+class TestIsSupportedUnionAnnotation:
+    @mark.parametrize(
+        "annotation, expected",
+        [
+            param(Union[int, List[str]], True, id="int_list_str"),
+            param(Union[int, Dict[str, int]], True, id="int_dict_str_int"),
+            param(Union[List[int], List[str]], True, id="list_int_list_str"),
+            param(
+                Union[Dict[str, int], Dict[str, str]],
+                True,
+                id="dict_str_int_dict_str_str",
+            ),
+            param(Union[Dict[str, int], List[int]], True, id="dict_str_int_list_int"),
+            param(Optional[Union[int, List[str]]], True, id="optional_int_list_str"),
+            # These should still be unsupported (structured configs in unions)
+            param(Union[int, str], True, id="int_str_still_ok"),
+        ],
+    )
+    def test_is_supported(self, annotation: Any, expected: bool) -> None:
+        assert is_supported_union_annotation(annotation) == expected
+
+
+# ---------------------------------------------------------------------------
+# Structured config creation
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredConfigCreation:
+    @mark.parametrize(
+        "cls, expected",
+        [
+            param(CfgIntOrListStr, 0, id="int_or_list_str"),
+            param(CfgIntOrDictStrInt, 0, id="int_or_dict_str_int"),
+            param(CfgListIntOrListStr, [1, 2], id="list_int_or_list_str"),
+            param(
+                CfgDictStrIntOrDictStrStr,
+                {"x": 1},
+                id="dict_str_int_or_dict_str_str",
+            ),
+            param(CfgDictOrList, [1], id="dict_or_list"),
+        ],
+    )
+    def test_create(self, cls: Any, expected: Any) -> None:
+        cfg = OmegaConf.structured(cls)
+        assert cfg.value == expected
+
+
+# ---------------------------------------------------------------------------
+# Branch selection
+# ---------------------------------------------------------------------------
+
+
+class TestBranchSelection:
+    """Assignment should pick the right union branch based on value content."""
+
+    @mark.parametrize(
+        "cls, value, expected",
+        [
+            param(CfgIntOrListStr, ["a", "b"], ["a", "b"], id="int_or_list_list"),
+            param(CfgIntOrListStr, 42, 42, id="int_or_list_int"),
+            param(CfgIntOrDictStrInt, {"x": 1}, {"x": 1}, id="int_or_dict_dict"),
+            param(CfgListIntOrListStr, [1, 2, 3], [1, 2, 3], id="list_int"),
+            param(CfgListIntOrListStr, ["a", "b"], ["a", "b"], id="list_str"),
+            param(CfgDictStrIntOrDictStrStr, {"x": 1}, {"x": 1}, id="dict_int"),
+            param(
+                CfgDictStrIntOrDictStrStr,
+                {"x": "hello"},
+                {"x": "hello"},
+                id="dict_str",
+            ),
+            param(CfgDictOrList, [10, 20], [10, 20], id="dict_or_list_list"),
+            param(CfgDictOrList, {"a": 1}, {"a": 1}, id="dict_or_list_dict"),
+        ],
+    )
+    def test_value_selects_branch(self, cls: Any, value: Any, expected: Any) -> None:
+        cfg = OmegaConf.structured(cls)
+        cfg.value = value
+        assert cfg.value == expected
+
+    def test_mismatched_list_raises(self) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        with raises(ValidationError):
+            cfg.value = [1, "a"]  # mixed — matches neither List[int] nor List[str]
+
+    def test_wrong_type_raises(self) -> None:
+        cfg = OmegaConf.structured(CfgIntOrListStr)
+        with raises(ValidationError):
+            cfg.value = {"x": 1}  # dict when only int or List[str] allowed
+
+
+# ---------------------------------------------------------------------------
+# Ambiguity errors for empty containers
+# ---------------------------------------------------------------------------
+
+
+class TestAmbiguity:
+    @mark.parametrize(
+        "cls, value",
+        [
+            param(CfgListIntOrListStr, [], id="empty_list"),
+            param(CfgDictStrIntOrDictStrStr, {}, id="empty_dict"),
+            param(CfgListIntOrListStr, (), id="empty_tuple"),
+        ],
+    )
+    def test_empty_container_is_ambiguous(self, cls: Any, value: Any) -> None:
+        cfg = OmegaConf.structured(cls)
+        with raises(ValidationError, match="[Aa]mbig"):
+            cfg.value = value
+
+    @mark.parametrize(
+        "cls, value, expected",
+        [
+            param(CfgIntOrDictStrInt, {}, {}, id="single_dict_branch"),
+            param(CfgIntOrListStr, [], [], id="single_list_branch"),
+        ],
+    )
+    def test_empty_container_with_one_branch_is_not_ambiguous(
+        self, cls: Any, value: Any, expected: Any
+    ) -> None:
+        cfg = OmegaConf.structured(cls)
+        cfg.value = value
+        assert cfg.value == expected
+
+    def test_nonempty_tuple_selects_list_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgIntOrListStr)
+        cfg.value = ("a", "b")
+        assert cfg.value == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# OmegaConf.typed_list / typed_dict — explicit disambiguation
+# ---------------------------------------------------------------------------
+
+
+class TestTypedContainers:
+    def test_typed_list_str_disambiguates(self) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        typed = OmegaConf.typed_list([], element_type=str)
+        cfg.value = typed
+        assert cfg.value == []
+        cfg.value.append("hello")
+        assert cfg.value == ["hello"]
+
+    def test_typed_list_int_disambiguates(self) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        typed = OmegaConf.typed_list([], element_type=int)
+        cfg.value = typed
+        assert cfg.value == []
+        cfg.value.append(42)
+        assert cfg.value == [42]
+
+    def test_typed_dict_int_disambiguates(self) -> None:
+        cfg = OmegaConf.structured(CfgDictStrIntOrDictStrStr)
+        typed = OmegaConf.typed_dict({}, key_type=str, element_type=int)
+        cfg.value = typed
+        assert cfg.value == {}
+        cfg.value["x"] = 10
+        assert cfg.value == {"x": 10}
+
+    def test_typed_dict_str_disambiguates(self) -> None:
+        cfg = OmegaConf.structured(CfgDictStrIntOrDictStrStr)
+        typed = OmegaConf.typed_dict({}, key_type=str, element_type=str)
+        cfg.value = typed
+        assert cfg.value == {}
+        cfg.value["x"] = "hello"
+        assert cfg.value == {"x": "hello"}
+
+    def test_typed_list_standalone(self) -> None:
+        lst = OmegaConf.typed_list([1, 2, 3], element_type=int)
+        assert list(lst) == [1, 2, 3]
+
+    def test_typed_dict_standalone(self) -> None:
+        d = OmegaConf.typed_dict({"a": 1}, key_type=str, element_type=int)
+        assert dict(d) == {"a": 1}
+
+    def test_typed_list_wrong_element_raises(self) -> None:
+        lst = OmegaConf.typed_list(element_type=int)
+        lst.append(1)
+        with raises(ValidationError):
+            lst.append("bad")
+
+    def test_typed_dict_wrong_value_raises(self) -> None:
+        d = OmegaConf.typed_dict(key_type=str, element_type=int)
+        d["x"] = 1
+        with raises(ValidationError):
+            d["y"] = "bad"
+
+
+# ---------------------------------------------------------------------------
+# Validation after branch selection
+# ---------------------------------------------------------------------------
+
+
+class TestValidationAfterSelection:
+    def test_list_int_rejects_str_append(self) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        cfg.value = [1, 2]
+        with raises(ValidationError):
+            cfg.value.append("x")  # type: ignore
+
+    def test_list_str_rejects_int_append(self) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        cfg.value = ["a", "b"]
+        with raises(ValidationError):
+            cfg.value.append(99)  # type: ignore
+
+    def test_dict_str_int_rejects_str_value(self) -> None:
+        cfg = OmegaConf.structured(CfgDictStrIntOrDictStrStr)
+        cfg.value = {"x": 1}
+        with raises(ValidationError):
+            cfg.value["y"] = "bad"  # type: ignore
+
+    def test_dict_str_str_rejects_int_value(self) -> None:
+        cfg = OmegaConf.structured(CfgDictStrIntOrDictStrStr)
+        cfg.value = {"x": "hello"}
+        with raises(ValidationError):
+            cfg.value["y"] = 999  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# to_container / to_object
+# ---------------------------------------------------------------------------
+
+
+class TestToContainer:
+    def test_to_container_list_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgIntOrListStr)
+        cfg.value = ["a", "b"]
+        plain = OmegaConf.to_container(cfg)
+        assert plain == {"value": ["a", "b"]}
+
+    def test_to_container_dict_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgIntOrDictStrInt)
+        cfg.value = {"x": 1}
+        plain = OmegaConf.to_container(cfg)
+        assert plain == {"value": {"x": 1}}
+
+    def test_to_object_list_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgIntOrListStr)
+        cfg.value = ["a", "b"]
+        obj = OmegaConf.to_object(cfg)
+        assert obj.value == ["a", "b"]  # type: ignore
+        assert type(obj.value) is list  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Deepcopy and pickle
+# ---------------------------------------------------------------------------
+
+
+class TestDeepCopyAndPickle:
+    def test_deepcopy_list_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        cfg.value = [1, 2, 3]
+        cfg2 = copy.deepcopy(cfg)
+        assert cfg2.value == [1, 2, 3]
+        cfg2.value.append(4)
+        assert cfg.value == [1, 2, 3]  # original unchanged
+
+    def test_deepcopy_dict_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgDictStrIntOrDictStrStr)
+        cfg.value = {"x": 1}
+        cfg2 = copy.deepcopy(cfg)
+        assert cfg2.value == {"x": 1}
+
+    def test_pickle_list_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        cfg.value = [1, 2, 3]
+        data = pickle.dumps(cfg)
+        cfg2 = pickle.loads(data)
+        assert cfg2.value == [1, 2, 3]
+
+    def test_pickle_dict_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgDictStrIntOrDictStrStr)
+        cfg.value = {"x": "hello"}
+        data = pickle.dumps(cfg)
+        cfg2 = pickle.loads(data)
+        assert cfg2.value == {"x": "hello"}
+
+
+# ---------------------------------------------------------------------------
+# Merge behavior
+# ---------------------------------------------------------------------------
+
+
+class TestMerge:
+    def test_merge_list_branch(self) -> None:
+        cfg1 = OmegaConf.structured(CfgListIntOrListStr)
+        cfg1.value = [1, 2]
+        cfg2 = OmegaConf.structured(CfgListIntOrListStr)
+        cfg2.value = [3, 4]
+        merged = OmegaConf.merge(cfg1, cfg2)
+        assert merged.value == [3, 4]
+
+    def test_merge_structured_config_changes_branch(self) -> None:
+        cfg1 = OmegaConf.structured(CfgListIntOrListStr)
+        cfg1.value = [1, 2]
+        cfg2 = OmegaConf.structured(CfgListIntOrListStr)
+        cfg2.value = ["a", "b"]
+        merged = OmegaConf.merge(cfg1, cfg2)
+        assert merged.value == ["a", "b"]
+
+    def test_merge_into_int_or_list_selects_list_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgIntOrListStr)
+        merged = OmegaConf.merge(cfg, {"value": ["x", "y"]})
+        assert merged.value == ["x", "y"]
+
+    def test_merge_into_int_or_dict_selects_dict_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgIntOrDictStrInt)
+        merged = OmegaConf.merge(cfg, {"value": {"a": 1}})
+        assert merged.value == {"a": 1}
+
+    @mark.parametrize(
+        "merge",
+        [
+            param(OmegaConf.merge, id="merge"),
+            param(OmegaConf.unsafe_merge, id="unsafe_merge"),
+        ],
+    )
+    def test_merge_plain_list_selects_branch(self, merge: Any) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        merged = merge(cfg, {"value": ["a", "b"]})
+        assert merged.value == ["a", "b"]
+
+    @mark.parametrize(
+        "merge",
+        [
+            param(OmegaConf.merge, id="merge"),
+            param(OmegaConf.unsafe_merge, id="unsafe_merge"),
+        ],
+    )
+    def test_merge_plain_dict_selects_dict_branch(self, merge: Any) -> None:
+        cfg = OmegaConf.structured(CfgDictOrList)
+        merged = merge(cfg, {"value": {"a": 1}})
+        assert merged.value == {"a": 1}
+
+    def test_merge_with_plain_dict_selects_dict_branch(self) -> None:
+        cfg = OmegaConf.structured(CfgDictOrList)
+        cfg.merge_with({"value": {"a": 1}})
+        assert cfg.value == {"a": 1}
+
+    @mark.parametrize(
+        "merge",
+        [
+            param(OmegaConf.merge, id="merge"),
+            param(OmegaConf.unsafe_merge, id="unsafe_merge"),
+        ],
+    )
+    def test_merge_empty_list_is_ambiguous(self, merge: Any) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        with raises(ValidationError, match="[Aa]mbig"):
+            merge(cfg, {"value": []})
+
+    def test_merge_with_empty_list_is_ambiguous(self) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        with raises(ValidationError, match="[Aa]mbig"):
+            cfg.merge_with({"value": []})
+
+    @mark.parametrize(
+        "merge",
+        [
+            param(OmegaConf.merge, id="merge"),
+            param(OmegaConf.unsafe_merge, id="unsafe_merge"),
+        ],
+    )
+    def test_merge_empty_dict_is_ambiguous(self, merge: Any) -> None:
+        cfg = OmegaConf.structured(CfgDictStrIntOrDictStrStr)
+        with raises(ValidationError, match="[Aa]mbig"):
+            merge(cfg, {"value": {}})
+
+    def test_merge_with_empty_dict_is_ambiguous(self) -> None:
+        cfg = OmegaConf.structured(CfgDictStrIntOrDictStrStr)
+        with raises(ValidationError, match="[Aa]mbig"):
+            cfg.merge_with({"value": {}})
+
+    @mark.parametrize(
+        "list_merge_mode",
+        [
+            param(ListMergeMode.REPLACE, id="replace"),
+            param(ListMergeMode.EXTEND, id="extend"),
+            param(ListMergeMode.EXTEND_UNIQUE, id="extend_unique"),
+        ],
+    )
+    def test_list_merge_mode_replaces_union_branch(
+        self, list_merge_mode: ListMergeMode
+    ) -> None:
+        cfg = OmegaConf.structured(CfgListIntOrListStr)
+        merged = OmegaConf.merge(
+            cfg,
+            {"value": [2, 3]},
+            list_merge_mode=list_merge_mode,
+        )
+        assert merged.value == [2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Interpolation into container union
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolation:
+    def test_interpolation_resolves_to_list(self) -> None:
+        @dataclass
+        class Cfg:
+            items: List[int] = field(default_factory=lambda: [1, 2, 3])
+            value: Union[int, List[int]] = 0
+
+        cfg = OmegaConf.structured(Cfg)
+        cfg.value = "${items}"
+        assert cfg.value == [1, 2, 3]
+
+    def test_missing_is_accepted(self) -> None:
+        @dataclass
+        class Cfg:
+            value: Union[List[int], List[str]] = field(default_factory=lambda: [1])
+
+        cfg = OmegaConf.structured(Cfg)
+        cfg.value = "???"
+        from omegaconf import MissingMandatoryValue
+
+        with raises(MissingMandatoryValue):
+            _ = cfg.value

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -860,7 +860,7 @@ params = [
             create=lambda: None,
             op=lambda cfg: OmegaConf.structured(UnionError),
             exception_type=ValueError,
-            msg="Unions of containers are not supported:\nx: Union[int, List[str]]",
+            msg="Unions of containers are not supported:\nx: Union[int, User]",
             num_lines=3,
         ),
         id="structured:create_with_union_error",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -333,8 +333,8 @@ class _TestUserClass:
         # optional and union
         (Optional[int], True),
         (Union[int, str], True),
-        (Union[int, List[str]], False),
-        (Union[int, Dict[int, str]], False),
+        (Union[int, List[str]], True),
+        (Union[int, Dict[int, str]], True),
         (Union[int, _TestEnum], True),
         (Union[int, _TestAttrsClass], False),
         (Union[int, _TestDataclass], False),
@@ -852,8 +852,8 @@ def test_is_union_annotation_PEP604() -> None:
     "input_, expected",
     [
         (Union[int, str], True),
-        (Union[int, List[str]], False),
-        (Union[int, Dict[str, int]], False),
+        (Union[int, List[str]], True),
+        (Union[int, Dict[str, int]], True),
         (Union[int, User], False),
         (Optional[Union[int, str]], True),
         (Union[int, None], True),


### PR DESCRIPTION
Add support for `List[...]` and `Dict[...]` as union members in structured config type annotations, e.g. `Union[int, List[str]]` or `Union[List[int], List[str]]`. This is distinct from unions of structured configs (dataclasses/attr classes), which are tracked separately in #1275.

Assignments to a list/dict union field select an unambiguous matching branch, preserve typed validation after selection, and reject ambiguous assignments (e.g. an empty list that matches multiple candidates) unless the value carries explicit type metadata.

Introduce `OmegaConf.typed_list()` and `OmegaConf.typed_dict()` helpers for disambiguating empty or otherwise ambiguous container assignments. Document the new behavior, add a news fragment, and cover assignment, merge, interpolation, serialization, deepcopy, docs, and typed-container validation paths.

Closes #1261