### PR TITLE
Suggest similar key names when a key is not found

### DIFF
--- a/news/1221.feature
+++ b/news/1221.feature
@@ -1,0 +1,1 @@
+When accessing a missing key, OmegaConf now suggests similar key names if any exist (e.g. "Did you mean: 'missing'?").

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -1,4 +1,5 @@
 import copy
+import difflib
 from enum import Enum
 from typing import (
     Any,
@@ -52,6 +53,17 @@ from .errors import (
     ValidationError,
 )
 from .nodes import EnumNode, ValueNode
+
+
+def _make_key_suggestion(key: Any, available: Iterable) -> str:
+    close = difflib.get_close_matches(
+        str(key), [str(k) for k in available], n=3, cutoff=0.6
+    )
+    if not close:
+        return ""
+    if len(close) == 1:
+        return f". Did you mean: {close[0]!r}?"
+    return f". Did you mean one of: {', '.join(repr(k) for k in close)}?"
 
 
 class DictConfig(BaseContainer, MutableMapping[Any, Any]):
@@ -160,6 +172,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
                     msg = f"Key '{key}' not in '{self._metadata.object_type.__name__}'"
                 else:
                     msg = f"Key '{key}' is not in struct"
+                msg += _make_key_suggestion(key, self.keys())
                 self._format_and_raise(
                     key=key, value=value, cause=ConfigAttributeError(msg)
                 )
@@ -478,7 +491,8 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         value: Optional[Node] = self.__dict__["_content"].get(key)
         if value is None:
             if throw_on_missing_key:
-                raise ConfigKeyError(f"Missing key {key!s}")
+                msg = f"Missing key {key!s}" + _make_key_suggestion(key, self.keys())
+                raise ConfigKeyError(msg)
         elif throw_on_missing_value and value._is_missing():
             raise MissingMandatoryValue("Missing mandatory value: $KEY")
         return value

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -2,6 +2,7 @@
 import copy
 import re
 import tempfile
+from contextlib import nullcontext
 from typing import Any, Dict, List, Optional, Union
 
 from pytest import mark, param, raises
@@ -188,6 +189,86 @@ def test_attribute_error() -> None:
     c = OmegaConf.create()
     with raises(ConfigAttributeError):
         assert c.missing_key
+
+
+@mark.parametrize("struct", [None, False, True])
+@mark.parametrize(
+    "access,exc_type",
+    [
+        ("attr", ConfigAttributeError),
+        ("item", ConfigKeyError),
+    ],
+)
+def test_fuzzy_key_suggestion_single_match(
+    struct: Optional[bool], access: str, exc_type: Any
+) -> None:
+    c = OmegaConf.create({"missing": 1, "another": 2})
+    ctx = flag_override(c, "struct", struct) if struct is not None else nullcontext()
+    with ctx:
+        with raises(exc_type, match="Did you mean: 'missing'"):
+            if access == "attr":
+                c.missng
+            else:
+                c["missng"]
+
+
+@mark.parametrize("struct", [None, False, True])
+@mark.parametrize(
+    "access,exc_type",
+    [
+        ("attr", ConfigAttributeError),
+        ("item", ConfigKeyError),
+    ],
+)
+def test_fuzzy_key_suggestion_multiple_matches(
+    struct: Optional[bool], access: str, exc_type: Any
+) -> None:
+    c = OmegaConf.create({"mission": 1, "missing": 2, "misting": 3})
+    ctx = flag_override(c, "struct", struct) if struct is not None else nullcontext()
+    with ctx:
+        with raises(exc_type, match="Did you mean one of:"):
+            if access == "attr":
+                c.missng
+            else:
+                c["missng"]
+
+
+@mark.parametrize("struct", [None, False, True])
+@mark.parametrize(
+    "access,exc_type",
+    [
+        ("attr", ConfigAttributeError),
+        ("item", ConfigKeyError),
+    ],
+)
+def test_fuzzy_key_suggestion_no_match(
+    struct: Optional[bool], access: str, exc_type: Any
+) -> None:
+    c = OmegaConf.create({"alpha": 1, "beta": 2})
+    ctx = flag_override(c, "struct", struct) if struct is not None else nullcontext()
+    with ctx:
+        with raises(exc_type) as exc_info:
+            if access == "attr":
+                c.gamma
+            else:
+                c["gamma"]
+    assert "Did you mean" not in str(exc_info.value)
+
+
+@mark.parametrize(
+    "access,exc_type",
+    [
+        ("attr", ConfigAttributeError),
+        ("item", ConfigKeyError),
+    ],
+)
+def test_fuzzy_key_suggestion_typed_struct(access: str, exc_type: Any) -> None:
+    c = OmegaConf.structured(User(name="Bond", age=7))
+    with raises(exc_type, match="not in 'User'.*Did you mean: 'name'"):
+        if access == "attr":
+            c.nme
+        else:
+            c["nme"]
 
 
 @mark.parametrize("c", [{}, OmegaConf.create()])


### PR DESCRIPTION

When accessing a missing key on a DictConfig, the error message now
includes a "Did you mean: 'X'?" hint if any existing keys are close
matches (using difflib.get_close_matches). Works for plain dicts,
struct mode, and typed configs, via both attribute and item access.

Closes #1221, #265
