### PR TITLE
Support TypeAliasType in structured configs

### DIFF
--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -339,6 +339,11 @@ def is_union_annotation(type_: Any) -> bool:
 
 def _resolve_optional(type_: Any) -> Tuple[bool, Any]:
     """Check whether `type_` is equivalent to `typing.Optional[T]` for some T."""
+    if sys.version_info >= (3, 12):  # pragma: no cover
+        import typing  # lgtm [py/import-and-import-from]
+
+        if isinstance(type_, typing.TypeAliasType):
+            type_ = type_.__value__
     if is_union_annotation(type_):
         args = type_.__args__
         if NoneType in args:

--- a/tests/structured_conf/test_structured_basic.py
+++ b/tests/structured_conf/test_structured_basic.py
@@ -334,3 +334,25 @@ class TestStructured:
             with flag_override(cfg, "allow_objects", True):
                 cfg.plugin = pwo
                 assert cfg.plugin == pwo
+
+
+@mark.skipif(
+    sys.version_info < (3, 12),
+    reason="PEP 695 type alias syntax requires Python 3.12+",
+)
+class TestTypeAliases:
+    def test_type_alias(self) -> None:
+        from dataclasses import dataclass
+        from typing import TypeAliasType  # type: ignore[attr-defined]
+
+        # TypeAliasType is the runtime equivalent of `type MyInt = int` (PEP 695).
+        # Using the constructor avoids a SyntaxError on Python < 3.12.
+        # TODO: once Python 3.11 support is dropped, replace with `type MyInt = int`
+        MyInt = TypeAliasType("MyInt", int)
+
+        @dataclass
+        class C:
+            x: MyInt = 0
+
+        cfg = OmegaConf.structured(C)
+        assert cfg.x == 0


### PR DESCRIPTION

Unwrap typing.TypeAliasType in _resolve_optional so both the PEP 695
`type X = ...` syntax and explicit TypeAliasType() construction work
in structured config field annotations (Python 3.12+).

Fixes #1163
