### PR TITLE
Support OrderedDict as input to OmegaConf.create()

### DIFF
--- a/news/1156.bugfix
+++ b/news/1156.bugfix
@@ -1,0 +1,1 @@
+``OmegaConf.create()`` now supports ``collections.OrderedDict`` as both a top-level input and a nested value.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -13,6 +13,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    FrozenSet,
     List,
     Optional,
     Tuple,
@@ -59,6 +60,15 @@ if TYPE_CHECKING:
 
 
 NoneType: Type[None] = type(None)
+
+# (module, qualname) pairs for dict types that are treated as primitive dicts,
+# enabling whitelisting of other dict types without pulling in extra dependencies.
+_PRIMITIVE_DICT_TYPES: FrozenSet[Tuple[str, str]] = frozenset(
+    {
+        ("builtins", "dict"),
+        ("collections", "OrderedDict"),
+    }
+)
 
 BUILTIN_VALUE_TYPES: Tuple[Type[Any], ...] = (
     int,
@@ -775,7 +785,7 @@ def is_primitive_list(obj: Any) -> bool:
 
 def is_primitive_dict(obj: Any) -> bool:
     t = get_type_of(obj)
-    return t is dict
+    return (t.__module__, t.__qualname__) in _PRIMITIVE_DICT_TYPES
 
 
 def is_dict_annotation(type_: Any) -> bool:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -3,6 +3,7 @@
 import platform
 import re
 import sys
+from collections import OrderedDict
 from collections.abc import Sequence
 from pathlib import Path
 from textwrap import dedent
@@ -564,3 +565,24 @@ def test_create_from_str_check_parent(data: str) -> None:
     parent = OmegaConf.create({})
     cfg = OmegaConf.create(data, parent=parent)
     assert cfg._get_parent() is parent
+
+
+@mark.parametrize(
+    "input_, expected",
+    [
+        param(OrderedDict({"a": 1, "b": 2}), {"a": 1, "b": 2}, id="ordered_dict"),
+        param(
+            OrderedDict({"outer": OrderedDict({"inner": 42})}),
+            {"outer": {"inner": 42}},
+            id="nested_ordered_dict",
+        ),
+        param(
+            {"a": OrderedDict({"b": 1})},
+            {"a": {"b": 1}},
+            id="dict_with_ordered_dict_value",
+        ),
+    ],
+)
+def test_create_from_ordered_dict(input_: Any, expected: Any) -> None:
+    cfg = OmegaConf.create(input_)
+    assert OmegaConf.to_container(cfg) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -719,6 +720,8 @@ def test_is_primitive_list(obj: Any, expected: bool) -> None:
     [
         param({}, True, id="dict"),
         param({1: 2}, True, id="dict1"),
+        param(OrderedDict(), True, id="ordered_dict"),
+        param(OrderedDict({"a": 1}), True, id="ordered_dict_populated"),
         param([], False, id="list"),
         param((), False, id="tuple"),
     ],


### PR DESCRIPTION

`is_primitive_dict` previously required an exact `dict` type match, so
`collections.OrderedDict` was rejected with UnsupportedValueType. Now it
checks a string-based whitelist of (module, qualname) pairs, accepting
`dict` and `collections.OrderedDict` as primitive dicts. The whitelist
approach avoids new imports and makes it easy to add other stdlib dict
types in the future without pulling in dependencies.

Fixes #1156
