### PR TITLE
Raise ConfigTypeError when updating through a null structured Optional node

### DIFF
--- a/news/1280.bugfix
+++ b/news/1280.bugfix
@@ -1,0 +1,1 @@
+``OmegaConf.update()`` now raises a ``ConfigTypeError`` with a clear message when navigating through a structured ``Optional`` node that is ``None``, instead of an ``AssertionError``.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -56,6 +56,7 @@ from ._utils import (
 from .base import Box, Container, ListMergeMode, Node, SCMode, UnionNode
 from .basecontainer import BaseContainer
 from .errors import (
+    ConfigTypeError,
     MissingMandatoryValue,
     OmegaConfBaseException,
     UnsupportedInterpolationType,
@@ -726,6 +727,11 @@ class OmegaConf:
             k = split[i]
             # if next_root is a primitive (string, int etc) replace it with an empty map
             next_root, key_ = _select_one(root, k, throw_on_missing=False)
+            if isinstance(next_root, Container) and next_root._is_none():
+                raise ConfigTypeError(
+                    f"Cannot set '{key}' because"
+                    f" '{root._get_full_key(key_)}' is None"
+                )
             if not isinstance(next_root, Container):
                 if force_add:
                     with flag_override(root, "struct", False):

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -4,8 +4,8 @@ from pytest import mark, param, raises
 
 from omegaconf import ListConfig, OmegaConf, ValidationError
 from omegaconf._utils import _ensure_container, is_primitive_container
-from omegaconf.errors import ConfigAttributeError, ConfigKeyError
-from tests import Package, User
+from omegaconf.errors import ConfigAttributeError, ConfigKeyError, ConfigTypeError
+from tests import Group, Package, User
 
 
 @mark.parametrize(
@@ -204,3 +204,38 @@ def test_update_force_add(cfg: Any, key: str, value: Any, expected: Any) -> None
 
     OmegaConf.update(cfg, key, value, force_add=True)
     assert cfg == expected
+
+
+def test_update_through_none_structured_node() -> None:
+    # Group.admin is Optional[User] = None; navigating into it must raise a
+    # clear ConfigTypeError naming the null intermediate key, not an AssertionError.
+    cfg = OmegaConf.structured(Group)
+    with raises(
+        ConfigTypeError, match="Cannot set 'admin.name' because 'admin' is None"
+    ):
+        OmegaConf.update(cfg, "admin.name", "Bond")
+
+
+def test_update_through_none_structured_node_nested() -> None:
+    # Verify _get_full_key includes the full path to the null node when it is
+    # more than one level deep: error should say "a.inner" not just "inner".
+    from dataclasses import dataclass, field
+    from typing import Optional
+
+    @dataclass
+    class Inner:
+        x: int = 0
+
+    @dataclass
+    class Middle:
+        inner: Optional[Inner] = None
+
+    @dataclass
+    class Outer:
+        a: Middle = field(default_factory=Middle)
+
+    cfg = OmegaConf.structured(Outer)
+    with raises(
+        ConfigTypeError, match="Cannot set 'a.inner.x' because 'a.inner' is None"
+    ):
+        OmegaConf.update(cfg, "a.inner.x", 1)


### PR DESCRIPTION

OmegaConf.update() would hit an AssertionError with a confusing message when
the key path traversed a structured Optional field set to None.

The root cause: DictConfig(content=None) is a Container, so the traversal
loop did not replace it with {}, then root[key] dereferenced to Python None,
and the post-loop assert fired with an unhelpful message.

The fix detects a null Container during traversal and raises ConfigTypeError
immediately, naming the offending intermediate key via _get_full_key:

    ConfigTypeError: Cannot set 'a.b' because 'a' is None

The post-loop assert is kept as an internal invariant guard with a simple
message. Untyped None values (AnyNode) are unaffected — they are replaced
with an empty dict as before.

Fixes #1280.
Originally reported in #1214.
