### PR TITLE
Fix unsafe_merge crash with Union types (Issue #1087)

### DIFF
--- a/news/1087.bugfix
+++ b/news/1087.bugfix
@@ -1,0 +1,1 @@
+Fixed a crash in `OmegaConf.unsafe_merge` when merging structured configs containing union types.

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -633,7 +633,10 @@ class BaseContainer(Container, ABC):
             do_deepcopy = not self._get_flag("no_deepcopy_set_nodes")
             if not do_deepcopy and isinstance(value, Box):
                 # if value is from the same config, perform a deepcopy no matter what.
-                if self._get_root() is value._get_root():
+                value_root = (
+                    value._get_root() if value._get_parent() is not None else value
+                )
+                if self._get_root() is value_root:
                     do_deepcopy = True
 
             if do_deepcopy:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1590,3 +1590,26 @@ def test_union_operator_ror_list_raises() -> None:
     c1 = OmegaConf.create([1, 2, 3])
     with raises(TypeError):
         [4, 5] | c1
+
+
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+def test_merge_with_nested_structured_config_and_union_type(
+    merge: Any,
+) -> None:
+    from dataclasses import dataclass
+    from typing import Union
+
+    @dataclass
+    class Inner:
+        x: Union[int, str]
+
+    @dataclass
+    class Outer:
+        inner: Inner
+
+    dst = OmegaConf.structured(Outer)
+    src = OmegaConf.create({"inner": {"x": 10}})
+    res = merge(dst, src)
+
+    expected = {"inner": {"x": 10}}
+    assert res == expected


### PR DESCRIPTION

## Description
Fixes #1087
Supercedes #1088

This PR fixes an `AssertionError` crash that occurs when `OmegaConf.unsafe_merge` is used to merge configurations containing union types.

### Root Cause Analysis
During `unsafe_merge`, OmegaConf skips deepcopying of nodes (`no_deepcopy_set_nodes = True`). However, to prevent circular references, it still performs a safety check during `_set_item_impl` to see if the node being inserted belongs to the *same root config*:
```python
if self._get_root() is value._get_root():
    do_deepcopy = True
```

When a structured config is expanded and it contains a Union type, OmegaConf synthesizes a detached `UnionNode(MISSING)` and attempts to set it. Because `UnionNode` inherits from `Box`, `isinstance(value, Box)` is `True`, and the code executes `value._get_root()`.

Inside `Node._get_root()`, if a node has no parent, it asserts that it must be a `Container`:
```python
def _get_root(self) -> "Container":
    root: Optional[Box] = self._get_parent()
    if root is None:
        assert isinstance(self, Container)  # <--- CRASH
```
Because `UnionNode` is a `Box` but *not* a `Container`, the assertion fails and the program crashes. This bug is completely specific to `unsafe_merge` combined with `UnionNode`s, as other nodes are either not `Box`es (like `IntegerNode`) or are actually `Container`s (like `DictConfig`).

### The Fix
We safely bypass calling `value._get_root()` on detached nodes during the same-config check in `_set_item_impl`. By acknowledging that a detached node (where `_get_parent() is None`) is conceptually its own root, we use `value` directly in the identity check, completely avoiding the problematic assertion in `base.py`.

## Verification
- Added a parameterized test `test_merge_with_nested_structured_config_and_union_type` that ensures both `merge` and `unsafe_merge` evaluate correctly without crashing.
- Full test suite passes with 0 regressions.
