### PR TITLE
Document OmegaConf.resolve order-sensitivity limitation

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -750,17 +750,14 @@ structured_config_mode=SCMode.INSTANTIATE)``.
 
 OmegaConf.resolve
 ^^^^^^^^^^^^^^^^^
+
+Normally interpolations are resolved lazily, at access time.
+``OmegaConf.resolve()`` eagerly resolves all interpolations in the given config object in-place.
+
 .. code-block:: python
 
-    def resolve(cfg: Container) -> None:
-        """
-        Resolves all interpolations in the given config object in-place.
-        :param cfg: An OmegaConf container (DictConfig, ListConfig)
-                    Raises a ValueError if the input object is not an OmegaConf container.
-        """
+    OmegaConf.resolve(cfg)
 
-Normally interpolations are resolved lazily, at access time. 
-This function eagerly resolves all interpolations in the given config object in-place.
 Example:
 
 .. doctest::
@@ -772,6 +769,16 @@ Example:
     >>> OmegaConf.resolve(cfg)
     >>> show(cfg)
     type: DictConfig, value: {'a': 10, 'b': 10}
+
+.. warning::
+
+    ``OmegaConf.resolve()`` performs a single, in-order traversal of the config
+    tree.  Because it mutates the config as it walks, results can depend on key
+    insertion order when interpolations form a graph (i.e. when multiple nodes
+    reference the same target, or when resolvers are stateful).
+    For these cases, prefer accessing values lazily (the default) or use
+    ``OmegaConf.to_container(cfg, resolve=True)`` to get a resolved plain Python
+    container without mutating the config in place.
 
 OmegaConf.select
 ^^^^^^^^^^^^^^^^

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1023,8 +1023,14 @@ class OmegaConf:
         """
         Resolves all interpolations in the given config object in-place.
 
-        :param cfg: An OmegaConf container (DictConfig, ListConfig)
-                    Raises a ValueError if the input object is not an OmegaConf container.
+        This function performs a single, in-order traversal of the config tree,
+        replacing each interpolation with its resolved value as it is encountered.
+        Because the traversal is a simple single pass, results can depend on key
+        insertion order when interpolations form a graph (i.e. when multiple nodes
+        reference the same target or when resolvers are stateful).
+
+        :param cfg: An OmegaConf container (DictConfig or ListConfig).
+        :raises ValueError: If the input object is not an OmegaConf container.
         """
         import omegaconf._impl
 


### PR DESCRIPTION
`OmegaConf.resolve()` performs a single in-order traversal and mutates the config as it walks. This makes it order-sensitive when interpolations form a graph (multiple nodes referencing the same target, or stateful resolvers). Document this limitation clearly in both the docstring and the usage docs, with a note pointing to lazy access or `to_container()` as alternatives for complex cases.

## Minimal repro

The same two keys, same values — just different insertion order — yet `b` ends up as `1` or `2`:

```python
from omegaconf import OmegaConf

count = 0
def counter(_root_, _node_):
    global count
    count += 1
    return count

OmegaConf.register_new_resolver("counter", counter, use_cache=False)

# b before a: counter is called once, a reuses b's already-resolved value
count = 0
cfg = OmegaConf.create({
    "b": "${counter:}",
    "a": "${b}",
})
OmegaConf.resolve(cfg)
print(cfg)  # {'b': 1, 'a': 1}

# a before b: resolving a forces b's resolver to fire, then b fires again
count = 0
cfg = OmegaConf.create({
    "a": "${b}",
    "b": "${counter:}",
})
OmegaConf.resolve(cfg)
print(cfg)  # {'a': 1, 'b': 2}
```

There is no traversal order that eliminates this ambiguity in the general case. The behavior is by design and is now documented as such.

See #1112