### PR TITLE
Reframe OmegaConf.resolve limitation around custom resolvers

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -772,13 +772,15 @@ Example:
 
 .. warning::
 
-    ``OmegaConf.resolve()`` performs a single, in-order traversal of the config
-    tree.  Because it mutates the config as it walks, results can depend on key
-    insertion order when interpolations form a graph (i.e. when multiple nodes
-    reference the same target, or when resolvers are stateful).
-    For these cases, prefer accessing values lazily (the default) or use
-    ``OmegaConf.to_container(cfg, resolve=True)`` to get a resolved plain Python
-    container without mutating the config in place.
+    ``OmegaConf.resolve()`` works correctly for configs that use only node
+    interpolations (``${key}``) with no custom resolvers.  When custom resolvers
+    are involved, results may depend on the depth-first, key insertion order
+    traversal, because custom resolvers can do anything — they may be stateful,
+    have side effects, or return different values on each call.  No traversal
+    strategy can account for this, so the limitation is by design.
+    For configs that use custom resolvers, prefer accessing values lazily (the
+    default) or use ``OmegaConf.to_container(cfg, resolve=True)`` to get a
+    resolved plain Python container without mutating the config in place.
 
 OmegaConf.select
 ^^^^^^^^^^^^^^^^

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1023,11 +1023,12 @@ class OmegaConf:
         """
         Resolves all interpolations in the given config object in-place.
 
-        This function performs a single, in-order traversal of the config tree,
-        replacing each interpolation with its resolved value as it is encountered.
-        Because the traversal is a simple single pass, results can depend on key
-        insertion order when interpolations form a graph (i.e. when multiple nodes
-        reference the same target or when resolvers are stateful).
+        This function works correctly for configs that use only node interpolations
+        (``${key}``) with no custom resolvers. When custom resolvers are involved,
+        results may depend on the depth-first, key insertion order traversal, because
+        custom resolvers can do anything — they may be stateful, have side effects, or
+        return different values on each call — and this function has no way to account
+        for that.
 
         :param cfg: An OmegaConf container (DictConfig or ListConfig).
         :raises ValueError: If the input object is not an OmegaConf container.


### PR DESCRIPTION

The previous documentation framed the limitation as a single-pass
traversal issue. The real limitation is that custom resolvers can do
anything (be stateful, have side effects, return different values on
each call), so no traversal strategy can guarantee consistent results.
Update the docstring and usage docs to reflect this.

See #1112
