### PR TITLE
Fix OmegaConf.resolve discrepancy on interpolation to missing

### DIFF
--- a/news/1131.api_change
+++ b/news/1131.api_change
@@ -1,0 +1,1 @@
+``OmegaConf.resolve()`` now raises ``InterpolationToMissingValueError`` when an interpolation dereferences to a missing (``???``) value, instead of silently overwriting the node with ``???``. This restores the invariant that working with a resolved config gives the same results as working with the unresolved config.

--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-from omegaconf import MISSING, Container, DictConfig, ListConfig, Node, ValueNode
-from omegaconf.errors import ConfigTypeError, InterpolationToMissingValueError
+from omegaconf import Container, DictConfig, ListConfig, Node, ValueNode
+from omegaconf.errors import ConfigTypeError
 from omegaconf.nodes import InterpolationResultNode
 
 from ._utils import (
@@ -17,23 +17,19 @@ def _resolve_container_value(cfg: Container, key: Any) -> None:
     node = cfg._get_child(key)
     assert isinstance(node, Node)
     if node._is_interpolation():
-        try:
-            resolved = node._dereference_node()
-        except InterpolationToMissingValueError:
-            node._set_value(MISSING)
+        resolved = node._dereference_node()
+        if isinstance(resolved, Container):
+            _resolve(resolved)
+        if isinstance(resolved, InterpolationResultNode):
+            resolved_value = _get_value(resolved)
+            if is_primitive_container(resolved_value) or is_structured_config(
+                resolved_value
+            ):
+                resolved = _ensure_container(resolved_value)
+        if isinstance(resolved, Container) and isinstance(node, ValueNode):
+            cfg[key] = resolved
         else:
-            if isinstance(resolved, Container):
-                _resolve(resolved)
-            if isinstance(resolved, InterpolationResultNode):
-                resolved_value = _get_value(resolved)
-                if is_primitive_container(resolved_value) or is_structured_config(
-                    resolved_value
-                ):
-                    resolved = _ensure_container(resolved_value)
-            if isinstance(resolved, Container) and isinstance(node, ValueNode):
-                cfg[key] = resolved
-            else:
-                node._set_value(_get_value(resolved))
+            node._set_value(_get_value(resolved))
     else:
         _resolve(node)
 
@@ -41,12 +37,8 @@ def _resolve_container_value(cfg: Container, key: Any) -> None:
 def _resolve(cfg: Node) -> Node:
     assert isinstance(cfg, Node)
     if cfg._is_interpolation():
-        try:
-            resolved = cfg._dereference_node()
-        except InterpolationToMissingValueError:
-            cfg._set_value(MISSING)
-        else:
-            cfg._set_value(resolved._value())
+        resolved = cfg._dereference_node()
+        cfg._set_value(resolved._value())
 
     if isinstance(cfg, DictConfig):
         for k in cfg.keys():

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -463,30 +463,14 @@ def test_is_issubclass() -> None:
         ),
         param(OmegaConf.create({"a": "???"}), {"a": "???"}, id="dict:missing"),
         param(
-            OmegaConf.create({"a": "???", "b": "${a}"}),
-            {"a": "???", "b": "???"},
-            id="dict:missing",
-        ),
-        param(
             OmegaConf.create({"a": 10, "b": "a_${a}"}),
             {"a": 10, "b": "a_10"},
             id="dict:str_inter",
-        ),
-        # This seems like a reasonable resolution for a string interpolation pointing to a missing node:
-        param(
-            OmegaConf.create({"a": "???", "b": "a_${a}"}),
-            {"a": "???", "b": "???"},
-            id="dict:str_inter_missing",
         ),
         param(
             DictConfig("${a}", parent=OmegaConf.create({"a": {"b": 10}})),
             {"b": 10},
             id="inter_dict",
-        ),
-        param(
-            DictConfig("${a}", parent=OmegaConf.create({"a": "???"})),
-            "???",
-            id="inter_dict_to_missing",
         ),
         param(
             OmegaConf.create({"x": "${y}", "y": {"z": "${foo}"}, "foo": 0}),
@@ -500,16 +484,10 @@ def test_is_issubclass() -> None:
         param(OmegaConf.create([]), [], id="list"),
         param(OmegaConf.create([10, "${0}"]), [10, 10], id="list"),
         param(OmegaConf.create(["???"]), ["???"], id="list:missing"),
-        param(OmegaConf.create(["${1}", "???"]), ["???", "???"], id="list:missing"),
         param(
             ListConfig("${a}", parent=OmegaConf.create({"a": [1, 2]})),
             [1, 2],
             id="inter_list",
-        ),
-        param(
-            ListConfig("${a}", parent=OmegaConf.create({"a": "???"})),
-            "???",
-            id="inter_list_to_missing",
         ),
         param(ListConfig(None), None, id="none_list"),
         # comparing to ??? because to_container returns it.
@@ -547,6 +525,45 @@ def test_resolve(cfg: Any, expected: Any) -> None:
 def test_resolve_invalid_input() -> None:
     with raises(ValueError):
         OmegaConf.resolve("aaa")  # type: ignore
+
+
+@mark.parametrize(
+    "cfg",
+    [
+        param(
+            OmegaConf.create({"a": "???", "b": "${a}"}),
+            id="dict:node_inter_to_missing",
+        ),
+        param(
+            OmegaConf.create({"a": "???", "b": "a_${a}"}),
+            id="dict:str_inter_to_missing",
+        ),
+        param(
+            DictConfig("${a}", parent=OmegaConf.create({"a": "???"})),
+            id="inter_dict_to_missing",
+        ),
+        param(
+            OmegaConf.create(["${1}", "???"]),
+            id="list:node_inter_to_missing",
+        ),
+        param(
+            ListConfig("${a}", parent=OmegaConf.create({"a": "???"})),
+            id="inter_list_to_missing",
+        ),
+    ],
+)
+def test_resolve_raises_on_interpolation_to_missing(cfg: Any) -> None:
+    with raises(InterpolationToMissingValueError):
+        OmegaConf.resolve(cfg)
+
+
+def test_resolve_raises_on_resolver_arg_to_missing(restore_resolvers: Any) -> None:
+    """https://github.com/omry/omegaconf/issues/1131"""
+    OmegaConf.register_new_resolver("no_op", lambda x: x)
+    cfg = OmegaConf.create({"a": "${no_op:${b}}", "b": "???"})
+    assert not OmegaConf.is_missing(cfg, "a")
+    with raises(InterpolationToMissingValueError):
+        OmegaConf.resolve(cfg)
 
 
 @mark.parametrize(


### PR DESCRIPTION

OmegaConf.resolve() previously caught InterpolationToMissingValueError
and silently overwrote the node with MISSING. This caused
is_missing(cfg, "a") to flip False -> True across resolve() whenever
"a" was an interpolation pointing at a missing value, breaking the
invariant that resolved and unresolved configs behave the same way.

resolve() now propagates the error, matching direct attribute access.

Fixes #1131

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
