### PR TITLE
listconfig: clamp negative slice bounds to 0 (#1086)

### DIFF
--- a/news/1086.bugfix
+++ b/news/1086.bugfix
@@ -1,0 +1,1 @@
+Fix `ValueError` from `itertools.islice` when slicing a `ListConfig` with negative bounds that walk before index 0 (e.g. `cfg.xs[:-1]` on an empty list). Now matches native Python list semantics.

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -225,9 +225,14 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
         stop = index.stop
         step = index.step
         if index.start and index.start < 0:
-            start = self.__len__() + index.start
+            # Clamp to 0 to match Python list slice semantics; otherwise
+            # itertools.islice rejects negative bounds with ValueError when
+            # the slice goes "before" the list (e.g. lst[-1:] on []).
+            start = max(0, self.__len__() + index.start)
         if index.stop and index.stop < 0:
-            stop = self.__len__() + index.stop
+            # Same clamp as start: lst[:-1] on an empty list should yield []
+            # rather than raising. See issue #1086.
+            stop = max(0, self.__len__() + index.stop)
         if index.step and index.step < 0:
             step = abs(step)
             if start and stop:

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -850,6 +850,29 @@ def test_getitem_slice(sli: slice) -> None:
 
 
 @mark.parametrize(
+    "sli",
+    [
+        # Slices that walk "before" the start of the list. Native Python lists
+        # silently return []; ListConfig used to raise ValueError because the
+        # negative computed bound (e.g. len(empty)+(-1) = -1) was passed
+        # straight to itertools.islice. Regression test for issue #1086.
+        slice(None, -1, None),
+        slice(-1, None, None),
+        slice(-5, None, None),
+        slice(None, -5, None),
+        slice(None, None, -1),
+        slice(-1, None, -1),
+    ],
+)
+def test_getitem_slice_empty_list(sli: slice) -> None:
+    """ListConfig slicing on an empty list must match native list behavior."""
+    lst: list = []
+    olst = OmegaConf.create([])
+    expected = lst[sli.start : sli.stop : sli.step]
+    assert olst.__getitem__(sli) == expected
+
+
+@mark.parametrize(
     "constructor",
     [OmegaConf.create, list, lambda lst: OmegaConf.create({"foo": lst}).foo],
 )


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve OmegaConf -->

## Motivation

`ListConfig.__getitem__(slice(...))` raises `ValueError` when a negative slice index walks before the start of the list — most visibly `cfg.xs[:-1]` on an empty list. Native Python lists silently return `[]` in those cases, so the divergence is surprising and breaks code that defensively slices configs.

```python
>>> from omegaconf import OmegaConf
>>> OmegaConf.create({"xs": []}).xs[:-1]
ValueError: Stop argument for islice() must be None or an integer: 0 <= x <= sys.maxsize.
    full_key: xs[None:-1]
```

### Root cause

`ListConfig._correct_index_params` (`omegaconf/listconfig.py`) translates a negative `index.stop` via `stop = self.__len__() + index.stop`. For an empty list and `index.stop = -1` that yields `stop = -1`, which is then passed straight to `itertools.islice(range(0, len(self)), start, stop, step)` — `islice` rejects negative bounds.

### Fix

Clamp the computed `start` and `stop` to `max(0, ...)` so they never go below zero, matching native Python list slicing semantics. The fix is two lines.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?

Yes.

## Test Plan

A new parametrized test `test_getitem_slice_empty_list` in `tests/test_basic_ops_list.py` exercises six slice patterns that previously raised, comparing each against the native-list result. The test fails on `origin/main` and passes on this branch.

```
$ pytest tests/test_basic_ops_list.py
223 passed in 0.54s
```

### Reproduce BEFORE/AFTER yourself (copy-paste)

A reviewer can verify end-to-end by pasting the block below. Only the checked-out ref changes between BEFORE and AFTER.

```bash
# --- one-time setup ---
git clone https://github.com/omry/omegaconf.git /tmp/repro-1086 && cd /tmp/repro-1086
python3 -m venv .venv && source .venv/bin/activate
pip install -e . -q

# --- BEFORE (origin/main) ---
git checkout origin/main
pip install -e . -q
python3 -c "from omegaconf import OmegaConf; print(OmegaConf.create({'xs': []}).xs[:-1])"
# Expected: ValueError: Stop argument for islice() must be ... 0 <= x <= sys.maxsize

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/omegaconf.git feat/1086-fix-empty-list-slice
git checkout FETCH_HEAD
pip install -e . -q
python3 -c "from omegaconf import OmegaConf; print(repr(OmegaConf.create({'xs': []}).xs[:-1]))"
# Expected: []

# --- run regression test ---
pytest tests/test_basic_ops_list.py::test_getitem_slice_empty_list -v
# Expected: 6 passed
```

## Edge cases tested

| # | Slice | List | Expected | Verified by |
|---|-------|------|----------|-------------|
| 1 | `[:-1]` | `[]` | `[]` | new `test_getitem_slice_empty_list[sli0]` |
| 2 | `[-1:]` | `[]` | `[]` | new test `[sli1]` |
| 3 | `[-5:]` | `[]` | `[]` | new test `[sli2]` |
| 4 | `[:-5]` | `[]` | `[]` | new test `[sli3]` |
| 5 | `[::-1]` | `[]` | `[]` (reverse already empty) | new test `[sli4]` |
| 6 | `[-1::-1]` | `[]` | `[]` | new test `[sli5]` |
| 7 | `[:-1]` | `[1,2,3]` | `[1, 2]` (regression check) | existing `test_getitem_slice` |
| 8 | `[-2:]` | `[1,2,3]` | `[2, 3]` | existing `test_getitem_slice` |
| 9 | `[::-1]` | `[1,2,3]` | `[3, 2, 1]` | existing `test_getitem_slice` |

## Risk / blast radius

Surgical: only `_correct_index_params` changes. The negative-bound branch was incorrect for any `index.start + len(self) < 0` or `index.stop + len(self) < 0`; Python lists clamp such bounds to 0 and so do we now. Existing slice tests (`test_getitem_slice`, `test_setitem_slice`) continue to pass.

## Fixes

Fixes #1086

## Related PRs

None.

## Release note

```release-note
Fix `ListConfig` raising `ValueError` from `itertools.islice` when slicing with negative bounds that walk before the start of the list (e.g. `cfg.xs[:-1]` on an empty list).
```

A news fragment is included at `news/1086.bugfix`.

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against the project's source. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*
