### PR TITLE
Fix missing_keys handling of missing interpolations

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -998,6 +998,11 @@ OmegaConf.missing_keys
 Each missing key is represented as a ``str``, using a dotlist style.
 This utility function can be used after creating a config object, after merging sources and so on,
 to check for missing mandatory fields and aid in creating a proper error message.
+Node interpolations that dereference missing values are reported as missing keys,
+whether they are the full value or part of a string. By default, custom resolver
+interpolations are skipped when collecting missing keys. Pass
+``resolve_custom_resolvers=True`` to resolve custom resolvers and report them as
+missing if they dereference a missing value.
 
 .. doctest::
 

--- a/news/1118.bugfix
+++ b/news/1118.bugfix
@@ -1,0 +1,1 @@
+Fix `OmegaConf.missing_keys()` raising when an interpolation dereferences a missing value, and add a `resolve_custom_resolvers` flag to opt into custom resolver evaluation.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -5,6 +5,7 @@ import inspect
 import io
 import os
 import pathlib
+import re
 import sys
 import warnings
 from collections import defaultdict
@@ -58,6 +59,8 @@ from .base import Box, Container, ListMergeMode, Node, SCMode, UnionNode
 from .basecontainer import BaseContainer
 from .errors import (
     ConfigTypeError,
+    InterpolationResolutionError,
+    InterpolationToMissingValueError,
     MissingMandatoryValue,
     OmegaConfBaseException,
     UnsupportedInterpolationType,
@@ -79,6 +82,7 @@ from .nodes import (
 MISSING: Any = "???"
 
 Resolver = Callable[..., Any]
+_CUSTOM_RESOLVER_INTERPOLATION_PATTERN = re.compile(r"\${[^}]*:")
 
 
 def II(interpolation: str) -> Any:
@@ -1044,17 +1048,60 @@ class OmegaConf:
         omegaconf._impl._resolve(cfg)
 
     @staticmethod
-    def missing_keys(cfg: Any) -> Set[str]:
+    def missing_keys(cfg: Any, *, resolve_custom_resolvers: bool = False) -> Set[str]:
         """
         Returns a set of missing keys in a dotlist style.
 
+        Node interpolations that dereference missing values are reported as missing
+        keys, whether they are the full value or part of a string.
+
         :param cfg: An ``OmegaConf.Container``,
                     or a convertible object via ``OmegaConf.create`` (dict, list, ...).
+        :param resolve_custom_resolvers: If ``True``, custom resolver
+                    interpolations are resolved and reported as missing when they
+                    dereference missing values. If ``False`` (the default),
+                    custom resolver interpolations are not resolved and are not
+                    reported as missing keys.
         :return: set of strings of the missing keys.
         :raises ValueError: On input not representing a config.
         """
         cfg = _ensure_container(cfg)
         missings: Set[str] = set()
+
+        def contains_custom_resolver_interpolation(node: Node) -> bool:
+            value = node._value()
+            assert isinstance(value, str)
+            if _CUSTOM_RESOLVER_INTERPOLATION_PATTERN.search(value) is None:
+                return False
+
+            from .grammar_parser import OmegaConfGrammarParser, parse
+
+            def has_resolver_interpolation(ctx: Any) -> bool:
+                if isinstance(ctx, OmegaConfGrammarParser.InterpolationResolverContext):
+                    return True
+                get_children = getattr(ctx, "getChildren", None)
+                if get_children is None:
+                    return False
+                return any(
+                    has_resolver_interpolation(child) for child in get_children()
+                )
+
+            return has_resolver_interpolation(parse(value))
+
+        def is_missing_value_error(exc: BaseException) -> bool:
+            current: Optional[BaseException] = exc
+            while current is not None:
+                if isinstance(
+                    current,
+                    (InterpolationToMissingValueError, MissingMandatoryValue),
+                ):
+                    return True
+                current = (
+                    current.__cause__
+                    if current.__cause__ is not None
+                    else current.__context__
+                )
+            return False
 
         def gather(_cfg: Container) -> None:
             itr: Iterable[Any]
@@ -1064,10 +1111,27 @@ class OmegaConf:
                 itr = _cfg
 
             for key in itr:
-                if OmegaConf.is_missing(_cfg, key):
+                node = _cfg._get_child(key)
+                assert isinstance(node, Node)
+                if node._is_missing():
                     missings.add(_cfg._get_full_key(key))
-                elif OmegaConf.is_config(_cfg[key]):
-                    gather(_cfg[key])
+                elif (
+                    not resolve_custom_resolvers
+                    and node._is_interpolation()
+                    and contains_custom_resolver_interpolation(node)
+                ):
+                    continue
+                else:
+                    try:
+                        value = _cfg[key]
+                    except InterpolationResolutionError as exc:
+                        if is_missing_value_error(exc):
+                            missings.add(_cfg._get_full_key(key))
+                        else:
+                            raise
+                    else:
+                        if OmegaConf.is_config(value):
+                            gather(value)
 
         gather(cfg)
         return missings

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -25,6 +25,7 @@ from omegaconf._utils import _is_none
 from omegaconf.errors import (
     ConfigKeyError,
     InterpolationKeyError,
+    InterpolationResolutionError,
     InterpolationToMissingValueError,
     UnsupportedInterpolationType,
 )
@@ -669,6 +670,78 @@ def test_resolve_does_not_raise_when_resolver_returns_dict_config(
 )
 def test_missing_keys(cfg: Any, expected: Any) -> None:
     assert OmegaConf.missing_keys(cfg) == expected
+
+
+@mark.parametrize(
+    ("cfg", "expected"),
+    [
+        param({"a": "???", "b": "${.a}"}, {"a", "b"}, id="node-interpolation"),
+        param(
+            {"a": "???", "b": "prefix_${.a}"},
+            {"a", "b"},
+            id="string-node-interpolation",
+        ),
+        param(
+            ["???", "${0}"],
+            {"[0]", "[1]"},
+            id="list-node-interpolation",
+        ),
+        param(
+            ["???", "prefix_${0}"],
+            {"[0]", "[1]"},
+            id="list-string-node-interpolation",
+        ),
+    ],
+)
+def test_missing_keys_interpolation_to_missing(cfg: Any, expected: Any) -> None:
+    assert OmegaConf.missing_keys(cfg) == expected
+    assert OmegaConf.missing_keys(cfg, resolve_custom_resolvers=False) == expected
+
+
+def test_missing_keys_custom_resolver_interpolation_to_missing(
+    restore_resolvers: Any,
+) -> None:
+    OmegaConf.register_new_resolver("add", lambda a, b: a + b)
+    cfg = OmegaConf.create(
+        {
+            "a": "???",
+            "b": "???",
+            "c": "${add:${a},${b}}",
+            "d": "prefix_${add:${a},${b}}",
+        }
+    )
+    assert OmegaConf.missing_keys(cfg) == {"a", "b"}
+    assert OmegaConf.missing_keys(cfg, resolve_custom_resolvers=True) == {
+        "a",
+        "b",
+        "c",
+        "d",
+    }
+    assert OmegaConf.missing_keys(cfg, resolve_custom_resolvers=False) == {"a", "b"}
+
+
+def test_missing_keys_custom_resolver_body_dereferences_missing(
+    restore_resolvers: Any,
+) -> None:
+    OmegaConf.register_new_resolver("read", lambda *, _root_: _root_.a)
+    cfg = OmegaConf.create({"a": "???", "b": "${read:}"})
+    assert OmegaConf.missing_keys(cfg) == {"a"}
+    assert OmegaConf.missing_keys(cfg, resolve_custom_resolvers=True) == {"a", "b"}
+    assert OmegaConf.missing_keys(cfg, resolve_custom_resolvers=False) == {"a"}
+
+
+def test_missing_keys_custom_resolver_non_missing_error(
+    restore_resolvers: Any,
+) -> None:
+    def boom() -> None:
+        raise ValueError("boom")
+
+    OmegaConf.register_new_resolver("boom", boom)
+    cfg = OmegaConf.create({"missing": "???", "err": "${boom:}"})
+    assert OmegaConf.missing_keys(cfg) == {"missing"}
+    assert OmegaConf.missing_keys(cfg, resolve_custom_resolvers=False) == {"missing"}
+    with raises(InterpolationResolutionError, match="ValueError raised"):
+        OmegaConf.missing_keys(cfg, resolve_custom_resolvers=True)
 
 
 @mark.parametrize("cfg", [float, int])


### PR DESCRIPTION
## Summary
- report keys whose node interpolations dereference missing values, including embedded string interpolations
- add `resolve_custom_resolvers` to opt into evaluating custom resolver interpolations
- document node-vs-resolver interpolation behavior and add a news fragment

Closes #1118.
Closes #1117 (supersedes the stale PR).

## Validation
- `/home/omry/miniconda3/envs/omegaconf+hydra/bin/python -m pytest tests/test_omegaconf.py -k missing_keys`
- `/home/omry/miniconda3/envs/omegaconf+hydra/bin/python -m pytest tests/test_omegaconf.py`
- `/home/omry/miniconda3/envs/omegaconf+hydra/bin/python -m pytest`
- `/home/omry/miniconda3/envs/omegaconf+hydra/bin/nox -s lint`
- `/home/omry/miniconda3/envs/omegaconf+hydra/bin/nox -s coverage`