### PR TITLE
Break exception reference cycle

### DIFF
--- a/news/1295.bugfix
+++ b/news/1295.bugfix
@@ -1,0 +1,1 @@
+Fix OmegaConf exceptions retaining traceback frame locals through reference cycles.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -966,8 +966,13 @@ def _raise(ex: Exception, cause: Exception) -> None:
     env_var = os.environ["OC_CAUSE"] if "OC_CAUSE" in os.environ else None
     debugging = sys.gettrace() is not None
     full_backtrace = (debugging and not env_var == "0") or (env_var == "1")
-    if full_backtrace and cause is not ex:
-        ex.__cause__ = cause
+    if full_backtrace:
+        # In the alias case (`cause is ex`), assigning `ex.__cause__ = cause`
+        # would create a self-reference cycle that pins `ex` (and transitively
+        # its traceback frames and locals) until cyclic GC runs. Use a shallow
+        # clone so `__cause__` is non-None for the OC_CAUSE=1 contract while
+        # remaining a distinct object that doesn't loop back to `ex`.
+        ex.__cause__ = copy.copy(cause) if cause is ex else cause
     else:
         ex.__cause__ = None
     try:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -970,7 +970,12 @@ def _raise(ex: Exception, cause: Exception) -> None:
         ex.__cause__ = cause
     else:
         ex.__cause__ = None
-    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
+    try:
+        raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
+    finally:
+        # Follow https://peps.python.org/pep-3110/ to break
+        # the exception reference cycle.
+        del ex
 
 
 def format_and_raise(
@@ -992,7 +997,12 @@ def format_and_raise(
         if type_override is not None:
             ex = type_override(str(cause))
             ex.__dict__ = copy.deepcopy(cause.__dict__)
-        _raise(ex, cause)
+        try:
+            _raise(ex, cause)
+        finally:
+            # Follow https://peps.python.org/pep-3110/ to break
+            # the exception reference cycle.
+            del ex
 
     object_type: Optional[Type[Any]]
     object_type_str: Optional[str] = None
@@ -1069,7 +1079,12 @@ def format_and_raise(
         ex.ref_type = ref_type
         ex.ref_type_str = ref_type_str
 
-    _raise(ex, cause)
+    try:
+        _raise(ex, cause)
+    finally:
+        # Follow https://peps.python.org/pep-3110/ to break
+        # the exception reference cycle.
+        del ex
 
 
 def type_str(t: Any, include_module_name: bool = False) -> str:

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -977,6 +977,8 @@ def _raise(ex: Exception, cause: Exception) -> None:
     finally:
         # Follow https://peps.python.org/pep-3110/ to break
         # the exception reference cycle.
+        if cause is ex:
+            del cause
         del ex
 
 
@@ -1004,6 +1006,8 @@ def format_and_raise(
         finally:
             # Follow https://peps.python.org/pep-3110/ to break
             # the exception reference cycle.
+            if cause is ex:
+                del cause
             del ex
 
     object_type: Optional[Type[Any]]

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -971,7 +971,9 @@ def _raise(ex: Exception, cause: Exception) -> None:
     else:
         ex.__cause__ = None
     try:
-        raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
+        raise ex.with_traceback(
+            sys.exc_info()[2]
+        )  # set env var OC_CAUSE=1 for full trace
     finally:
         # Follow https://peps.python.org/pep-3110/ to break
         # the exception reference cycle.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -1017,7 +1017,7 @@ def format_and_raise(
         # Unreachable: `_raise` always raises. The explicit `return` lets static
         # analysis see that the conditional `del cause` above does not escape
         # this branch, so `cause` stays bound for the rest of the function.
-        return
+        return  # pragma: no cover
 
     object_type: Optional[Type[Any]]
     object_type_str: Optional[str] = None

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -966,7 +966,7 @@ def _raise(ex: Exception, cause: Exception) -> None:
     env_var = os.environ["OC_CAUSE"] if "OC_CAUSE" in os.environ else None
     debugging = sys.gettrace() is not None
     full_backtrace = (debugging and not env_var == "0") or (env_var == "1")
-    if full_backtrace:
+    if full_backtrace and cause is not ex:
         ex.__cause__ = cause
     else:
         ex.__cause__ = None

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -1009,6 +1009,10 @@ def format_and_raise(
             if cause is ex:
                 del cause
             del ex
+        # Unreachable: `_raise` always raises. The explicit `return` lets static
+        # analysis see that the conditional `del cause` above does not escape
+        # this branch, so `cause` stays bound for the rest of the function.
+        return
 
     object_type: Optional[Type[Any]]
     object_type_str: Optional[str] = None

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1692,12 +1692,14 @@ def _assert_format_and_raise_releases_frame_local(
             assert False
 
     del_called = [False]
+    was_enabled = gc.isenabled()
     gc.disable()
     try:
         outer()
         assert del_called[0]
     finally:
-        gc.enable()
+        if was_enabled:
+            gc.enable()
 
 
 @mark.parametrize(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from pytest import mark, param, raises
 
@@ -1652,68 +1652,101 @@ def test_assertion_error() -> None:
             assert False
 
 
-def test_exception_no_reference_cycle() -> None:
-    """Test that exception raised by `format_and_raise()` has no reference cycle.
-    See https://github.com/omry/omegaconf/issues/1295 for more details.
-    """
+def _initialized_config_attribute_error() -> ConfigAttributeError:
+    ex = ConfigAttributeError("already initialized")
+    ex._initialized = True
+    return ex
 
-    class LargeObject:
-        def __init__(self, on_del):
-            self._on_del = on_del
 
-        def __del__(self):
-            self._on_del()
+def _assert_format_and_raise_releases_frame_local(
+    *,
+    cause_factory: Callable[[], Exception],
+    expected_type: Type[Exception],
+) -> None:
+    """Verify issue #1295 without relying on cyclic GC."""
 
-    def inner1():
+    class FrameLocal:
+        def __init__(self, on_delete: Callable[[], None]) -> None:
+            self._on_delete = on_delete
+
+        def __del__(self) -> None:
+            self._on_delete()
+
+    def raise_error() -> None:
         format_and_raise(
             node=None,
             key=None,
             value=None,
-            msg="TypeError",
-            cause=TypeError("TypeError"),
+            msg=str(expected_type),
+            cause=cause_factory(),
         )
 
-    def outer1(on_del):
-        # `large_object` is intentionally bound: its frame-lifetime is the test signal.
-        large_object = LargeObject(on_del)  # noqa: F841
+    def outer() -> None:
+        frame_local = FrameLocal(lambda: del_called.__setitem__(0, True))
+        assert frame_local is not None
         try:
-            inner1()
-        except Exception:
+            raise_error()
+        except expected_type:
             pass
+        else:
+            assert False
 
-    def initialized_exception():
-        ex = ConfigAttributeError("already initialized")
-        ex._initialized = True
-        return ex
-
-    def inner2():
-        format_and_raise(
-            node=None,
-            key=None,
-            value=None,
-            msg="already initialized",
-            cause=initialized_exception(),
-        )
-
-    def outer2(on_del):
-        # `large_object` is intentionally bound: its frame-lifetime is the test signal.
-        large_object = LargeObject(on_del)  # noqa: F841
-        try:
-            inner2()
-        except Exception:
-            pass
-
+    del_called = [False]
     gc.disable()
     try:
-        del_called = [False]
-        outer1(lambda: del_called.__setitem__(0, True))
-        assert del_called[0]
-
-        del_called = [False]
-        outer2(lambda: del_called.__setitem__(0, True))
+        outer()
         assert del_called[0]
     finally:
         gc.enable()
+
+
+@mark.parametrize(
+    ("cause_factory", "expected_type"),
+    [
+        param(
+            lambda: ConfigAttributeError("new"),
+            ConfigAttributeError,
+            id="new-exception",
+        ),
+        param(
+            _initialized_config_attribute_error,
+            ConfigAttributeError,
+            id="initialized-exception",
+        ),
+    ],
+)
+def test_format_and_raise_releases_frame_locals(
+    monkeypatch: Any,
+    cause_factory: Callable[[], Exception],
+    expected_type: Type[Exception],
+) -> None:
+    monkeypatch.setenv("OC_CAUSE", "0")
+    _assert_format_and_raise_releases_frame_local(
+        cause_factory=cause_factory,
+        expected_type=expected_type,
+    )
+
+
+def test_format_and_raise_initialized_exception_does_not_self_chain(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OC_CAUSE", "1")
+    cause = _initialized_config_attribute_error()
+
+    try:
+        format_and_raise(
+            node=None,
+            key=None,
+            value=None,
+            msg=str(ConfigAttributeError),
+            cause=cause,
+        )
+    except ConfigAttributeError as exc:
+        assert exc is cause
+        assert exc.__cause__ is not None
+        assert exc.__cause__ is not exc
+    else:
+        assert False
 
 
 @mark.parametrize(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,5 @@
-import re
 import gc
+import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -1674,10 +1674,11 @@ def test_exception_no_reference_cycle() -> None:
         )
 
     def outer1(on_del):
-        large_object = LargeObject(on_del)
+        # `large_object` is intentionally bound: its frame-lifetime is the test signal.
+        large_object = LargeObject(on_del)  # noqa: F841
         try:
             inner1()
-        except:
+        except Exception:
             pass
 
     def initialized_exception():
@@ -1695,10 +1696,11 @@ def test_exception_no_reference_cycle() -> None:
         )
 
     def outer2(on_del):
-        large_object = LargeObject(on_del)
+        # `large_object` is intentionally bound: its frame-lifetime is the test signal.
+        large_object = LargeObject(on_del)  # noqa: F841
         try:
             inner2()
-        except:
+        except Exception:
             pass
 
     gc.disable()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,5 @@
 import re
+import gc
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -1649,6 +1650,68 @@ def test_assertion_error() -> None:
             assert exc2 is exc  # we expect the original exception to be raised
         else:
             assert False
+
+
+def test_exception_no_reference_cycle() -> None:
+    """Test that exception raised by `format_and_raise()` has no reference cycle.
+    See https://github.com/omry/omegaconf/issues/1295 for more details.
+    """
+
+    class LargeObject:
+        def __init__(self, on_del):
+            self._on_del = on_del
+
+        def __del__(self):
+            self._on_del()
+
+    def inner1():
+        format_and_raise(
+            node=None,
+            key=None,
+            value=None,
+            msg="TypeError",
+            cause=TypeError("TypeError"),
+        )
+
+    def outer1(on_del):
+        large_object = LargeObject(on_del)
+        try:
+            inner1()
+        except:
+            pass
+
+    def initialized_exception():
+        ex = ConfigAttributeError("already initialized")
+        ex._initialized = True
+        return ex
+
+    def inner2():
+        format_and_raise(
+            node=None,
+            key=None,
+            value=None,
+            msg="already initialized",
+            cause=initialized_exception(),
+        )
+
+    def outer2(on_del):
+        large_object = LargeObject(on_del)
+        try:
+            inner2()
+        except:
+            pass
+
+    gc.disable()
+    try:
+        del_called = [False]
+        outer1(lambda: del_called.__setitem__(0, True))
+        assert del_called[0]
+
+        del_called = [False]
+        outer2(lambda: del_called.__setitem__(0, True))
+        assert del_called[0]
+    finally:
+        gc.enable()
 
 
 @mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve OmegaConf -->

## Motivation

Currently exceptions raised by omegaconf have reference cycle from `ex -> traceback -> stack frame -> ex` since we store `ex` in local variable which is bad (see https://peps.python.org/pep-3134/#open-issue-garbage-collection for more details). Python has a solution (https://peps.python.org/pep-3110/#semantic-changes) that we can manually do here to break the cycle.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?

Yes

## Test Plan

N/A

## Fixes

What issue does this PR fix? Use https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue to link this PR to a corresponding issue.

Fixes #1295

## Related PRs

(Is this PR part of a group of changes? Link the other relevant PRs.)
