### PR TITLE
Fix oc.select defaults for above-root relative keys

### DIFF
--- a/news/1127.bugfix
+++ b/news/1127.bugfix
@@ -1,0 +1,1 @@
+Fixed `OmegaConf.select` and `oc.select` to return the provided default when a relative key climbs above the config root.

--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from omegaconf import Container, DictConfig, ListConfig, Node, ValueNode
-from omegaconf.errors import ConfigTypeError
+from omegaconf.errors import ConfigKeyError, ConfigTypeError
 from omegaconf.nodes import InterpolationResultNode
 
 from ._utils import (
@@ -94,7 +94,11 @@ def select_node(
         if not absolute_key and not key.startswith("."):
             key = f".{key}"
 
-        cfg, key = cfg._resolve_key_and_root(key)
+        try:
+            cfg, key = cfg._resolve_key_and_root(key)
+        except ConfigKeyError:
+            return None
+
         _root, _last_key, node = cfg._select_impl(
             key,
             throw_on_missing=throw_on_missing,

--- a/tests/interpolation/built_in_resolvers/test_oc_select.py
+++ b/tests/interpolation/built_in_resolvers/test_oc_select.py
@@ -1,8 +1,10 @@
+from dataclasses import dataclass
 from typing import Any
 
-from pytest import mark
+from pytest import mark, raises
 
-from omegaconf import OmegaConf
+from omegaconf import SI, OmegaConf
+from omegaconf.errors import InterpolationKeyError
 
 
 def test_oc_select_abs() -> None:
@@ -100,6 +102,34 @@ def test_oc_nested_select_relative_level_up() -> None:
 
     n = cfg.nested
     assert n.a0 == n.a1 == n.a2 == 10
+
+
+def test_oc_select_default_for_relative_key_above_root() -> None:
+    cfg = OmegaConf.create({"a": "${oc.select:..member, 5}"})
+    assert cfg.a == 5
+
+
+def test_oc_select_default_for_relative_key_above_root_in_structured_config() -> None:
+    @dataclass
+    class Config:
+        a: int = SI("${oc.select:..member, 5}")
+
+    cfg = OmegaConf.structured(Config)
+    assert cfg.a == 5
+
+
+def test_oc_select_default_in_dynamic_interpolation() -> None:
+    cfg = OmegaConf.create(
+        {
+            "fallback": 123,
+            "ok": "${${oc.select:..member, fallback}}",
+            "bad": "${${oc.select:..member, nowhere}}",
+        }
+    )
+
+    assert cfg.ok == 123
+    with raises(InterpolationKeyError):
+        cfg.bad
 
 
 @mark.parametrize(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -48,6 +48,7 @@ class TestSelect:
             # relative selection
             param({"a": {"b": {"c": 10}}}, ".a", {"b": {"c": 10}}, id="relative"),
             param({"a": {"b": {"c": 10}}}, ".a.b", {"c": 10}, id="relative"),
+            param({"a": 10}, "..missing", None, id="relative_above_root"),
             # bracket notation without escaping
             param({"a": {"b": 1}}, "a[b]", 1, id="bracket:dict"),
             param({"a": {"b": {"c": 1}}}, "a[b][c]", 1, id="bracket:dict:nested"),
@@ -114,6 +115,7 @@ class TestSelect:
             param({}, "not_found", id="empty"),
             param({"missing": "???"}, "missing", id="missing"),
             param({"int": 0}, "int.y", id="non_container"),
+            param({"a": 10}, "..missing", id="relative_above_root"),
         ],
     )
     def test_select_default_returned(


### PR DESCRIPTION
## Summary

Fixes #1127.

`OmegaConf.select` and `oc.select` already returned the provided default when a selected node was missing or not found. However, relative keys that climbed above the config root failed earlier in `_resolve_key_and_root`, before the default-handling path could run.

This PR treats that above-root relative lookup as "not found" for `select`, allowing the existing default/`None` behavior to apply.

## Details

- Catch `ConfigKeyError` while resolving the starting root for `select_node` and return `None`.
- Add coverage for direct `OmegaConf.select(cfg, "..missing", default=...)`.
- Add coverage for `${oc.select:..member, 5}` in plain and structured configs.
- Add a dynamic interpolation regression test showing that, when `oc.select` feeds an outer interpolation, the default is interpreted as an interpolation target.
- Add `news/1127.bugfix`.

## Validation

- `python -m pytest tests/test_select.py tests/interpolation/built_in_resolvers/test_oc_select.py`
- `python -m pytest`
- `nox -s lint`
- `nox -s coverage`