### PR TITLE
Add OmegaConf.can_select

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -834,6 +834,35 @@ Keys containing literal dots, brackets, or ``=`` can be escaped with a backslash
     omegaconf.errors.MissingMandatoryValue: missing node selected
         full_key: foo.missing
 
+OmegaConf.can_select
+^^^^^^^^^^^^^^^^^^^^
+``OmegaConf.can_select()`` checks whether ``OmegaConf.select()`` can select a
+config node or value without returning a default or raising. It uses the same
+key path syntax and behavior flag names as ``OmegaConf.select()`` for
+convenience, but ``OmegaConf.can_select()`` itself does not raise for select
+failures. A selected ``None`` value is considered selectable.
+
+.. doctest::
+
+    >>> cfg = OmegaConf.create({
+    ...     "foo": {
+    ...         "bar": 10,
+    ...         "none": None,
+    ...         "missing": "???",
+    ...     },
+    ...     "bad": "${not_found}",
+    ... })
+    >>> assert OmegaConf.can_select(cfg, "foo.bar")
+    >>> assert OmegaConf.can_select(cfg, "foo.none")
+    >>> assert not OmegaConf.can_select(cfg, "foo.missing")
+    >>> assert not OmegaConf.can_select(cfg, "foo.no_such_key")
+    >>> assert not OmegaConf.can_select(cfg, "bad")
+    >>> assert not OmegaConf.can_select(
+    ...     cfg,
+    ...     "bad",
+    ...     throw_on_resolution_failure=False,
+    ... )
+
 OmegaConf.update
 ^^^^^^^^^^^^^^^^
 ``OmegaConf.update()`` allows you to update values in your config using either a dot-notation or brackets to denote sub-keys.

--- a/news/1129.feature
+++ b/news/1129.feature
@@ -1,0 +1,1 @@
+Added ``OmegaConf.can_select()`` for checking if a select-style key path can produce a value without returning a default or raising.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -924,6 +924,48 @@ class OmegaConf:
         return OmegaConf._get_obj_type(c)
 
     @staticmethod
+    def can_select(
+        cfg: Container,
+        key: str,
+        *,
+        throw_on_resolution_failure: bool = True,
+        throw_on_missing: bool = False,
+    ) -> bool:
+        r"""
+        Return ``True`` if ``OmegaConf.select()`` can select a value from a config.
+
+        This uses the same key path syntax and behavior flag names as
+        ``select()`` for convenience, but ``can_select()`` does not raise for
+        select failures. It returns ``False`` instead of raising or returning a
+        default when the path cannot be selected. A selected ``None`` value
+        counts as selectable.
+
+        :param cfg: Config node to select from
+        :param key: Key path to select (dot/bracket notation, backslash-escapable)
+        :param throw_on_resolution_failure: Treat an interpolation resolution error
+               as not selectable
+        :param throw_on_missing: Treat selecting a missing key (with the value
+               '???') as not selectable
+        :return: ``True`` if the key can be selected, otherwise ``False``.
+        """
+        from ._impl import select_value
+
+        default = object()
+        try:
+            return (
+                select_value(
+                    cfg=cfg,
+                    key=key,
+                    default=default,
+                    throw_on_resolution_failure=throw_on_resolution_failure,
+                    throw_on_missing=throw_on_missing,
+                )
+                is not default
+            )
+        except Exception:
+            return False
+
+    @staticmethod
     def select(
         cfg: Container,
         key: str,

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -246,6 +246,57 @@ class TestSelect:
         assert OmegaConf.select(cfg, "missing", throw_on_missing=False) is None
         assert OmegaConf.select(cfg, "missing") is None
 
+    @mark.parametrize(
+        ("cfg", "key", "expected"),
+        [
+            param({"model": {"name": "resnet"}}, "model.name", True, id="nested"),
+            param({"model": {"name": None}}, "model.name", True, id="none"),
+            param({"model": {"name": "???"}}, "model.name", False, id="missing"),
+            param({"model": {}}, "model.name", False, id="not_found"),
+            param({"items": [10, None, "???"]}, "items.0", True, id="list_value"),
+            param({"items": [10, None, "???"]}, "items.1", True, id="list_none"),
+            param({"items": [10, None, "???"]}, "items.2", False, id="list_missing"),
+            param({"items": [10, None, "???"]}, "items.3", False, id="list_oob"),
+            param({"a.b": 10}, r"a\.b", True, id="escaped_dot"),
+            param({"a.b": 10}, "a.b", False, id="unescaped_dot"),
+            param({"a": 10}, "..missing", False, id="relative_above_root"),
+        ],
+    )
+    def test_can_select(
+        self, cfg: Any, key: str, expected: bool, struct: Optional[bool]
+    ) -> None:
+        cfg = _ensure_container(cfg)
+        OmegaConf.set_struct(cfg, struct)
+        assert OmegaConf.can_select(cfg, key) is expected
+
+    def test_can_select_returns_false_instead_of_throwing(
+        self, struct: Optional[bool]
+    ) -> None:
+        cfg = _ensure_container(
+            {
+                "missing": "???",
+                "bad_interpolation": "${not_found}",
+                "interpolation_to_missing": "${missing}",
+                "items": [10],
+            }
+        )
+        OmegaConf.set_struct(cfg, struct)
+
+        assert not OmegaConf.can_select(cfg, "missing", throw_on_missing=True)
+        assert not OmegaConf.can_select(
+            cfg, "bad_interpolation", throw_on_resolution_failure=True
+        )
+        assert not OmegaConf.can_select(
+            cfg, "bad_interpolation", throw_on_resolution_failure=False
+        )
+        assert not OmegaConf.can_select(
+            cfg, "interpolation_to_missing", throw_on_resolution_failure=True
+        )
+        assert not OmegaConf.can_select(
+            cfg, "interpolation_to_missing", throw_on_resolution_failure=False
+        )
+        assert not OmegaConf.can_select(cfg, "items.bad_index")
+
 
 @mark.parametrize(
     "cfg,key,expected",


### PR DESCRIPTION
## Summary

Adds `OmegaConf.can_select()` as a boolean companion to `OmegaConf.select()`.

The new helper uses the same key-path syntax and behavior flag names as `select()`, but returns `False` for selection failures instead of returning a default or raising. A selected `None` value is considered selectable.

Closes #1129.

## Validation

- `pytest tests/test_select.py -q`
- `pytest -q`
- `nox -s lint`
- `nox -s docs`