### PR TITLE
Remove flags from _ensure_container (#580)

### DIFF
--- a/news/580.bugfix
+++ b/news/580.bugfix
@@ -1,0 +1,1 @@
+Removed the internal `flags` argument from `_ensure_container` and made merge conversion preserve `allow_objects` explicitly.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -1083,14 +1083,14 @@ def type_str(t: Any, include_module_name: bool = False) -> str:
         return ret
 
 
-def _ensure_container(target: Any, flags: Optional[Dict[str, bool]] = None) -> Any:
+def _ensure_container(target: Any) -> Any:
     from omegaconf import OmegaConf
 
     if is_primitive_container(target):
         assert isinstance(target, (list, tuple, dict))
-        target = OmegaConf.create(target, flags=flags)
+        target = OmegaConf.create(target)
     elif is_structured_config(target):
-        target = OmegaConf.structured(target, flags=flags)
+        target = OmegaConf.structured(target)
     elif not OmegaConf.is_config(target):
         raise ValueError(
             "Invalid input. Supports one of "

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -23,6 +23,7 @@ from ._utils import (
     is_container_annotation,
     is_dict_annotation,
     is_list_annotation,
+    is_primitive_container,
     is_primitive_dict,
     is_primitive_type_annotation,
     is_structured_config,
@@ -623,6 +624,7 @@ class BaseContainer(Container, ABC):
     ) -> None:
         from .dictconfig import DictConfig
         from .listconfig import ListConfig
+        from .omegaconf import OmegaConf
         from .tupleconfig import TupleConfig
 
         """merge a list of other Config objects into this one, overriding as needed"""
@@ -630,10 +632,19 @@ class BaseContainer(Container, ABC):
             if other is None:
                 raise ValueError("Cannot merge with a None config")
 
-            my_flags = {}
-            if self._get_flag("allow_objects") is True:
+            if self._get_flag("allow_objects") is True and not OmegaConf.is_config(
+                other
+            ):
                 my_flags = {"allow_objects": True}
-            other = _ensure_container(other, flags=my_flags)
+                if is_primitive_container(other):
+                    assert isinstance(other, (list, tuple, dict))
+                    other = OmegaConf.create(other, flags=my_flags)
+                elif is_structured_config(other):
+                    other = OmegaConf.structured(other, flags=my_flags)
+                else:
+                    other = _ensure_container(other)
+            else:
+                other = _ensure_container(other)
             prev_readonly = self._get_node_flag("readonly")
 
             readonly_overridden = (

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1536,6 +1536,18 @@ def test_merge_allow_objects(merge: Any) -> None:
     assert ret == {"a": 10, "foo": iv}
 
 
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+def test_merge_allow_objects_does_not_mutate_existing_config(merge: Any) -> None:
+    cfg = OmegaConf.create({"a": 10})
+    cfg._set_flag("allow_objects", True)
+    other = OmegaConf.create({"foo": "bar"})
+
+    assert other._get_flag("allow_objects") is None
+    ret = merge(cfg, other)
+    assert ret == {"a": 10, "foo": "bar"}
+    assert other._get_flag("allow_objects") is None
+
+
 def test_merge_with_allow_Dataframe() -> None:
     cfg = OmegaConf.create({"a": Dataframe()}, flags={"allow_objects": True})
     ret = OmegaConf.merge({}, cfg)


### PR DESCRIPTION
## Summary

Clean up `_ensure_container()` as discussed in #580: remove its internal `flags` parameter instead of applying flags to existing configs. Merge conversion now preserves `allow_objects` explicitly at the caller, only for raw inputs that need the flag while being converted into OmegaConf containers.

Fixes #580.

## Changes

- `omegaconf/_utils.py`: remove the `flags` argument from `_ensure_container()` and keep existing configs unchanged.
- `omegaconf/basecontainer.py`: when merging into an `allow_objects` config, explicitly convert raw primitive/structured inputs with `flags={"allow_objects": True}`.
- `tests/test_merge.py`: cover that merging into an `allow_objects` config does not mutate an already-built input config.
- `tests/test_utils.py`: remove the obsolete test that expected `_ensure_container()` to apply arbitrary flags.
- `news/580.bugfix`: update the release fragment to describe the cleanup.

## Validation

- `.venv/bin/python -m pytest tests/test_merge.py::test_merge_allow_objects tests/test_merge.py::test_merge_allow_objects_does_not_mutate_existing_config tests/test_merge.py::test_merge_with_allow_Dataframe -q`
- `.venv/bin/python -m pytest tests/test_utils.py::test_ensure_container_raises_ValueError -q`
- `.venv/bin/python -m pytest tests/test_merge.py tests/test_utils.py -q`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/pyrefly check`