### PR TITLE
Preserve ValueNode types in OmegaConf.masked_copy (#813)

### DIFF
--- a/news/813.bugfix
+++ b/news/813.bugfix
@@ -1,1 +1,1 @@
-Fixed `OmegaConf.masked_copy` losing typed leaf node classes (e.g. `IntegerNode`, `StringNode`, `EnumNode`) at the top level of the copy.
+Fixed `OmegaConf.masked_copy` losing typed leaf node classes at the top level of the copy.

--- a/news/813.bugfix
+++ b/news/813.bugfix
@@ -1,0 +1,1 @@
+Fixed `OmegaConf.masked_copy` losing typed leaf node classes (e.g. `IntegerNode`, `StringNode`, `EnumNode`) at the top level of the copy.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -814,6 +814,8 @@ class OmegaConf:
         :param keys: keys to preserve in the copy
         :return: The masked ``DictConfig`` object.
         """
+        import copy as _copy
+
         from .dictconfig import DictConfig
 
         if not isinstance(conf, DictConfig):
@@ -821,7 +823,17 @@ class OmegaConf:
 
         if isinstance(keys, str):
             keys = [keys]
-        content = {key: value for key, value in conf.items_ex(resolve=False, keys=keys)}
+        # Issue #813: copy nodes rather than values. items_ex(resolve=False)
+        # unwraps top-level ValueNodes to their raw Python value, which then
+        # round-trips through DictConfig.__init__ as an AnyNode and drops the
+        # IntegerNode / StringNode / EnumNode typing. Deep-copying the node
+        # itself preserves both the leaf node class and (recursively) any
+        # nested container's node-level typing.
+        content = {
+            key: _copy.deepcopy(conf._get_node(key))
+            for key in conf.keys()
+            if key in keys
+        }
         return DictConfig(content=content)
 
     @staticmethod

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -814,8 +814,6 @@ class OmegaConf:
         :param keys: keys to preserve in the copy
         :return: The masked ``DictConfig`` object.
         """
-        import copy as _copy
-
         from .dictconfig import DictConfig
 
         if not isinstance(conf, DictConfig):
@@ -823,17 +821,8 @@ class OmegaConf:
 
         if isinstance(keys, str):
             keys = [keys]
-        # Issue #813: copy nodes rather than values. items_ex(resolve=False)
-        # unwraps top-level ValueNodes to their raw Python value, which then
-        # round-trips through DictConfig.__init__ as an AnyNode and drops the
-        # IntegerNode / StringNode / EnumNode typing. Deep-copying the node
-        # itself preserves both the leaf node class and (recursively) any
-        # nested container's node-level typing.
-        content = {
-            key: _copy.deepcopy(conf._get_node(key))
-            for key in conf.keys()
-            if key in keys
-        }
+        # Preserve node type and metadata instead of unwrapping ValueNodes.
+        content = {key: conf._get_node(key) for key in conf.keys() if key in keys}
         return DictConfig(content=content)
 
     @staticmethod

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -924,44 +924,16 @@ def test_masked_copy_is_deep() -> None:
         OmegaConf.masked_copy("fail", [])  # type: ignore
 
 
-# Regression test for https://github.com/omry/omegaconf/issues/813 — when
-# masked_copy was implemented via items_ex(resolve=False) the top-level
-# ValueNodes were unwrapped to their raw Python values and lost their typed
-# node class (IntegerNode/StringNode/etc) in the copy. The nested DictConfig
-# kept its typing because items_ex did not unwrap container nodes — only
-# leaf ValueNodes. The fix is to deep-copy nodes (not values) into the new
-# DictConfig so leaf typing survives.
 def test_masked_copy_preserves_value_node_types() -> None:
-    from dataclasses import dataclass, field
-
     from omegaconf import IntegerNode, StringNode
 
-    @dataclass
-    class Nested:
-        x: int = 123
-        y: str = "abc"
+    cfg = OmegaConf.structured(User(name="alice", age=10))
+    masked = OmegaConf.masked_copy(cfg, ["name", "age"])
 
-    @dataclass
-    class MySchema:
-        a: int = 456
-        b: str = "xyz"
-        nested: Nested = field(default_factory=Nested)
-
-    cfg = OmegaConf.structured(MySchema)
-
-    # Sanity: source has typed nodes at both levels.
-    assert isinstance(cfg._get_node("a"), IntegerNode)
-    assert isinstance(cfg._get_node("b"), StringNode)
-    assert isinstance(cfg.nested._get_node("x"), IntegerNode)
-
-    masked = OmegaConf.masked_copy(cfg, ["a", "b", "nested"])
-
-    # Top-level typing was the regression: it must survive the copy.
-    assert isinstance(masked._get_node("a"), IntegerNode)
-    assert isinstance(masked._get_node("b"), StringNode)
-    # Nested typing should also still be intact.
-    assert isinstance(masked.nested._get_node("x"), IntegerNode)
-    assert isinstance(masked.nested._get_node("y"), StringNode)
+    assert isinstance(masked._get_node("name"), StringNode)
+    assert isinstance(masked._get_node("age"), IntegerNode)
+    with raises(ValidationError):
+        masked.age = "not an integer"
 
 
 def test_shallow_copy() -> None:

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -924,6 +924,46 @@ def test_masked_copy_is_deep() -> None:
         OmegaConf.masked_copy("fail", [])  # type: ignore
 
 
+# Regression test for https://github.com/omry/omegaconf/issues/813 — when
+# masked_copy was implemented via items_ex(resolve=False) the top-level
+# ValueNodes were unwrapped to their raw Python values and lost their typed
+# node class (IntegerNode/StringNode/etc) in the copy. The nested DictConfig
+# kept its typing because items_ex did not unwrap container nodes — only
+# leaf ValueNodes. The fix is to deep-copy nodes (not values) into the new
+# DictConfig so leaf typing survives.
+def test_masked_copy_preserves_value_node_types() -> None:
+    from dataclasses import dataclass, field
+
+    from omegaconf import IntegerNode, StringNode
+
+    @dataclass
+    class Nested:
+        x: int = 123
+        y: str = "abc"
+
+    @dataclass
+    class MySchema:
+        a: int = 456
+        b: str = "xyz"
+        nested: Nested = field(default_factory=Nested)
+
+    cfg = OmegaConf.create(MySchema)
+
+    # Sanity: source has typed nodes at both levels.
+    assert isinstance(cfg._get_node("a"), IntegerNode)
+    assert isinstance(cfg._get_node("b"), StringNode)
+    assert isinstance(cfg.nested._get_node("x"), IntegerNode)
+
+    masked = OmegaConf.masked_copy(cfg, ["a", "b", "nested"])
+
+    # Top-level typing was the regression: it must survive the copy.
+    assert isinstance(masked._get_node("a"), IntegerNode)
+    assert isinstance(masked._get_node("b"), StringNode)
+    # Nested typing should also still be intact.
+    assert isinstance(masked.nested._get_node("x"), IntegerNode)
+    assert isinstance(masked.nested._get_node("y"), StringNode)
+
+
 def test_shallow_copy() -> None:
     cfg = OmegaConf.create({"a": 1, "b": 2})
     c = cfg.copy()

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -947,7 +947,7 @@ def test_masked_copy_preserves_value_node_types() -> None:
         b: str = "xyz"
         nested: Nested = field(default_factory=Nested)
 
-    cfg = OmegaConf.create(MySchema)
+    cfg = OmegaConf.structured(MySchema)
 
     # Sanity: source has typed nodes at both levels.
     assert isinstance(cfg._get_node("a"), IntegerNode)


### PR DESCRIPTION
## Motivation

`OmegaConf.masked_copy()` currently unwraps top-level `ValueNode` instances through `items_ex(resolve=False)`. Reconstructing the result from those raw Python values turns typed leaves into `AnyNode` instances and discards their validation.

This change passes the selected nodes into the new `DictConfig` instead. Normal `DictConfig` construction deep-copies those nodes, preserving their type and metadata without sharing state with the source.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/main/CONTRIBUTING.md)?

Yes.

### For any non-trivial change: is there an issue or design discussion where maintainers agreed on the direction?

[Issue #813](https://github.com/omry/omegaconf/issues/813).

## Test Plan

- `pytest tests/test_basic_ops_dict.py -k masked_copy -q`
- `pytest tests/test_basic_ops_dict.py -q`
- `pytest -q`
- `nox -s lint`

The regression test verifies that copied string and integer leaves retain their node types and that invalid assignment is still rejected.

## Fixes

Fixes #813

## Related PRs

None.
