### PR TITLE
Improve relative interpolation missing-key errors

### DIFF
--- a/news/1126.bugfix
+++ b/news/1126.bugfix
@@ -1,0 +1,1 @@
+Improved missing-key errors for relative interpolations by showing both the original interpolation key and the resolved lookup path.

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -703,6 +703,7 @@ class Container(Box):
         resolved_node_cache: Optional[Dict[int, "Node"]] = None,
     ) -> "Node":
         """A node interpolation is of the form `${foo.bar}`"""
+        original_inter_key = inter_key
         try:
             root_node, inter_key = self._resolve_key_and_root(inter_key)
         except ConfigKeyError as exc:
@@ -724,7 +725,19 @@ class Container(Box):
             ).with_traceback(sys.exc_info()[2])
 
         if parent is None or value is None:
-            raise InterpolationKeyError(f"Interpolation key '{inter_key}' not found")
+            msg = f"Interpolation key '{inter_key}' not found"
+            if original_inter_key != inter_key:
+                try:
+                    resolved_inter_key = root_node._get_full_key(inter_key)
+                except Exception as exc:
+                    resolved_inter_key = (
+                        f"<unresolvable due to {type(exc).__name__}: {exc}>"
+                    )
+                msg = (
+                    f"Interpolation key '{original_inter_key}' not found"
+                    f" (resolved to '{resolved_inter_key}')"
+                )
+            raise InterpolationKeyError(msg)
         else:
             self._validate_not_dereferencing_to_parent(node=self, target=value)
             return value

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -272,13 +272,26 @@ params = [
             create=lambda: OmegaConf.create({"foo": {"bar": "${.missing}"}}),
             op=lambda cfg: getattr(cfg.foo, "bar"),
             exception_type=InterpolationKeyError,
-            msg="Interpolation key 'missing' not found",
+            msg="Interpolation key '.missing' not found (resolved to 'foo.missing')",
             key="bar",
             full_key="foo.bar",
             child_node=lambda cfg: cfg.foo._get_node("bar"),
             parent_node=lambda cfg: cfg.foo,
         ),
         id="dict,accessing_missing_relative_interpolation",
+    ),
+    param(
+        Expected(
+            create=lambda: OmegaConf.create({"a": {"a": {"a": "${..b}"}}}),
+            op=lambda cfg: getattr(cfg.a.a, "a"),
+            exception_type=InterpolationKeyError,
+            msg="Interpolation key '..b' not found (resolved to 'a.b')",
+            key="a",
+            full_key="a.a.a",
+            child_node=lambda cfg: cfg.a.a._get_node("a"),
+            parent_node=lambda cfg: cfg.a.a,
+        ),
+        id="dict,accessing_missing_parent_relative_interpolation",
     ),
     param(
         Expected(
@@ -1924,6 +1937,26 @@ def test_get_full_key_failure_in_format_and_raise() -> None:
 
     with raises(RecursionError, match=match):
         c.x
+
+
+def test_relative_interpolation_missing_key_preserves_error_type_when_resolved_key_formatting_fails(
+    monkeypatch: Any,
+) -> None:
+    cfg = OmegaConf.create({"foo": {"bar": "${.missing}"}})
+    foo_node = cfg._get_node("foo")
+    assert isinstance(foo_node, DictConfig)
+
+    def fail_get_full_key(self: Any, key: Any) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(DictConfig, "_get_full_key", fail_get_full_key)
+    match = re.escape(
+        "Interpolation key '.missing' not found "
+        "(resolved to '<unresolvable due to RuntimeError: boom>')"
+    )
+
+    with raises(InterpolationKeyError, match=match):
+        cfg.foo.bar
 
 
 def test_list_getitem_slice_zero_step_error() -> None:


### PR DESCRIPTION

Report both the original relative interpolation key and the resolved lookup path when a relative interpolation cannot be found. This makes failures such as ${..b} under a.a.a point to the original `..b` lookup and the resolved `a.b` path.

Keep resolved-key diagnostic formatting best-effort so failures while computing the display path do not mask the intended InterpolationKeyError.

Add regression coverage for single-dot and parent-relative missing interpolation diagnostics, plus the diagnostic-formatting fallback.

Closes #1126
