### PR TITLE
Fix nested readonly structured config merges

### DIFF
--- a/news/1102.bugfix
+++ b/news/1102.bugfix
@@ -1,0 +1,1 @@
+Fixed `OmegaConf.merge()` and `OmegaConf.unsafe_merge()` with nested readonly structured configs.

--- a/news/1126.bugfix
+++ b/news/1126.bugfix
@@ -1,0 +1,1 @@
+Improved missing-key errors for relative interpolations by showing both the original interpolation key and the resolved lookup path.

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -703,6 +703,7 @@ class Container(Box):
         resolved_node_cache: Optional[Dict[int, "Node"]] = None,
     ) -> "Node":
         """A node interpolation is of the form `${foo.bar}`"""
+        original_inter_key = inter_key
         try:
             root_node, inter_key = self._resolve_key_and_root(inter_key)
         except ConfigKeyError as exc:
@@ -724,7 +725,19 @@ class Container(Box):
             ).with_traceback(sys.exc_info()[2])
 
         if parent is None or value is None:
-            raise InterpolationKeyError(f"Interpolation key '{inter_key}' not found")
+            msg = f"Interpolation key '{inter_key}' not found"
+            if original_inter_key != inter_key:
+                try:
+                    resolved_inter_key = root_node._get_full_key(inter_key)
+                except Exception as exc:
+                    resolved_inter_key = (
+                        f"<unresolvable due to {type(exc).__name__}: {exc}>"
+                    )
+                msg = (
+                    f"Interpolation key '{original_inter_key}' not found"
+                    f" (resolved to '{resolved_inter_key}')"
+                )
+            raise InterpolationKeyError(msg)
         else:
             self._validate_not_dereferencing_to_parent(node=self, target=value)
             return value

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -359,6 +359,7 @@ class BaseContainer(Container, ABC):
         dest: "BaseContainer",
         src: "BaseContainer",
         list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
+        _allow_readonly_target: bool = False,
     ) -> None:
         """merge src into dest and return a new copy, does not modified input"""
         from omegaconf import AnyNode, DictConfig, ValueNode
@@ -465,6 +466,7 @@ class BaseContainer(Container, ABC):
                         dest_node._merge_with(
                             src_node,
                             list_merge_mode=list_merge_mode,
+                            _allow_readonly_target=_allow_readonly_target,
                         )
                     elif not src_node_missing:
                         dest.__setitem__(key, src_node)
@@ -581,6 +583,7 @@ class BaseContainer(Container, ABC):
             "BaseContainer", Dict[str, Any], List[Any], Tuple[Any, ...], Any
         ],
         list_merge_mode: ListMergeMode = ListMergeMode.REPLACE,
+        _allow_readonly_target: bool = False,
     ) -> None:
         from .dictconfig import DictConfig
         from .listconfig import ListConfig
@@ -594,21 +597,35 @@ class BaseContainer(Container, ABC):
             if self._get_flag("allow_objects") is True:
                 my_flags = {"allow_objects": True}
             other = _ensure_container(other, flags=my_flags)
+            prev_readonly = self._get_node_flag("readonly")
 
-            if isinstance(self, DictConfig) and isinstance(other, DictConfig):
-                BaseContainer._map_merge(
-                    self,
-                    other,
-                    list_merge_mode=list_merge_mode,
-                )
-            elif isinstance(self, ListConfig) and isinstance(other, ListConfig):
-                BaseContainer._list_merge(
-                    self,
-                    other,
-                    list_merge_mode=list_merge_mode,
-                )
-            else:
-                raise TypeError("Cannot merge DictConfig with ListConfig")
+            readonly_overridden = (
+                _allow_readonly_target and self._get_flag("readonly") is True
+            )
+            if readonly_overridden:
+                # Non-public merge construction may target readonly containers.
+                # Temporarily relax them without changing merge_with() semantics.
+                self._set_flag("readonly", False)
+
+            try:
+                if isinstance(self, DictConfig) and isinstance(other, DictConfig):
+                    BaseContainer._map_merge(
+                        self,
+                        other,
+                        list_merge_mode=list_merge_mode,
+                        _allow_readonly_target=_allow_readonly_target,
+                    )
+                elif isinstance(self, ListConfig) and isinstance(other, ListConfig):
+                    BaseContainer._list_merge(
+                        self,
+                        other,
+                        list_merge_mode=list_merge_mode,
+                    )
+                else:
+                    raise TypeError("Cannot merge DictConfig with ListConfig")
+            finally:
+                if readonly_overridden:
+                    self._set_flag("readonly", prev_readonly)
 
         # recursively correct the parent hierarchy after the merge
         self._re_parent()

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -430,15 +430,11 @@ class OmegaConf:
         target = _ensure_container(target)
         assert isinstance(target, (DictConfig, ListConfig))
 
-        with flag_override(target, "readonly", False):
-            target.merge_with(
-                *configs[1:],
-                list_merge_mode=list_merge_mode,
-            )
-            turned_readonly = target._get_flag("readonly") is True
-
-        if turned_readonly:
-            OmegaConf.set_readonly(target, True)
+        target._merge_with(
+            *configs[1:],
+            list_merge_mode=list_merge_mode,
+            _allow_readonly_target=True,
+        )
 
         return target
 
@@ -475,9 +471,10 @@ class OmegaConf:
         with flag_override(
             target, ["readonly", "no_deepcopy_set_nodes"], [False, True]
         ):
-            target.merge_with(
+            target._merge_with(
                 *configs[1:],
                 list_merge_mode=list_merge_mode,
+                _allow_readonly_target=True,
             )
             turned_readonly = target._get_flag("readonly") is True
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -272,13 +272,26 @@ params = [
             create=lambda: OmegaConf.create({"foo": {"bar": "${.missing}"}}),
             op=lambda cfg: getattr(cfg.foo, "bar"),
             exception_type=InterpolationKeyError,
-            msg="Interpolation key 'missing' not found",
+            msg="Interpolation key '.missing' not found (resolved to 'foo.missing')",
             key="bar",
             full_key="foo.bar",
             child_node=lambda cfg: cfg.foo._get_node("bar"),
             parent_node=lambda cfg: cfg.foo,
         ),
         id="dict,accessing_missing_relative_interpolation",
+    ),
+    param(
+        Expected(
+            create=lambda: OmegaConf.create({"a": {"a": {"a": "${..b}"}}}),
+            op=lambda cfg: getattr(cfg.a.a, "a"),
+            exception_type=InterpolationKeyError,
+            msg="Interpolation key '..b' not found (resolved to 'a.b')",
+            key="a",
+            full_key="a.a.a",
+            child_node=lambda cfg: cfg.a.a._get_node("a"),
+            parent_node=lambda cfg: cfg.a.a,
+        ),
+        id="dict,accessing_missing_parent_relative_interpolation",
     ),
     param(
         Expected(
@@ -1924,6 +1937,26 @@ def test_get_full_key_failure_in_format_and_raise() -> None:
 
     with raises(RecursionError, match=match):
         c.x
+
+
+def test_relative_interpolation_missing_key_preserves_error_type_when_resolved_key_formatting_fails(
+    monkeypatch: Any,
+) -> None:
+    cfg = OmegaConf.create({"foo": {"bar": "${.missing}"}})
+    foo_node = cfg._get_node("foo")
+    assert isinstance(foo_node, DictConfig)
+
+    def fail_get_full_key(self: Any, key: Any) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(DictConfig, "_get_full_key", fail_get_full_key)
+    match = re.escape(
+        "Interpolation key '.missing' not found "
+        "(resolved to '<unresolvable due to RuntimeError: boom>')"
+    )
+
+    with raises(InterpolationKeyError, match=match):
+        cfg.foo.bar
 
 
 def test_list_getitem_slice_zero_step_error() -> None:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1295,6 +1295,71 @@ def test_with_readonly_c1(merge: Any, c1: Any, c2: Any) -> None:
     assert OmegaConf.is_readonly(cfg3)
 
 
+@mark.parametrize(
+    "merge, input_unchanged",
+    [(OmegaConf.merge, True), (OmegaConf.unsafe_merge, False)],
+)
+def test_merge_nested_frozen_structured_config(
+    merge: Any, input_unchanged: bool
+) -> None:
+    @dataclass(frozen=True)
+    class Inner:
+        x: int = MISSING
+
+    @dataclass(frozen=True)
+    class Outer:
+        inner: Inner = MISSING
+        y: int = 1
+
+    cfg = OmegaConf.structured(Outer(inner=Inner()))
+
+    with raises(ReadonlyConfigError):
+        cfg.merge_with({"inner": {"x": 3}})
+
+    merged = merge(cfg, {"inner": {"x": 3}})
+    assert merged == {"inner": {"x": 3}, "y": 1}
+    if input_unchanged:
+        assert OmegaConf.is_missing(cfg.inner, "x")
+    else:
+        assert merged is cfg
+    assert OmegaConf.is_readonly(merged)
+    assert OmegaConf.is_readonly(merged.inner)
+
+
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+def test_merge_restores_nested_readonly_flag(merge: Any) -> None:
+    cfg = OmegaConf.create({"node": {"x": 1}})
+    src = OmegaConf.create({"node": {"x": 2}})
+    OmegaConf.set_readonly(cfg.node, True)
+    OmegaConf.set_readonly(src.node, False)
+
+    merged = merge(cfg, src)
+
+    assert merged == {"node": {"x": 2}}
+    assert merged.node._get_node_flag("readonly") is True
+    assert OmegaConf.is_readonly(merged.node)
+
+
+@mark.parametrize(
+    "merge, input_unchanged",
+    [(OmegaConf.merge, True), (OmegaConf.unsafe_merge, False)],
+)
+def test_merge_inner_node_inherits_readonly(merge: Any, input_unchanged: bool) -> None:
+    cfg = OmegaConf.create({"inner": {"x": 1}})
+    src = OmegaConf.create({"inner": {"x": 2}})
+    OmegaConf.set_readonly(cfg, True)
+
+    merged = merge(cfg.inner, src.inner)
+
+    assert merged == {"x": 2}
+    assert merged._get_node_flag("readonly") is None
+    assert OmegaConf.is_readonly(merged)
+    if input_unchanged:
+        assert cfg.inner.x == 1
+    else:
+        assert merged is cfg.inner
+
+
 @mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
 @mark.parametrize(
     "c1, c2",


### PR DESCRIPTION

OmegaConf.merge() and OmegaConf.unsafe_merge() construct their results by mutating an internal merge target. Nested frozen structured configs can carry explicit readonly flags on destination containers, so recursive merge writes into those containers could raise ReadonlyConfigError even though public merge_with() is the operation that should reject readonly mutation.

Thread a private _allow_readonly_target flag through the merge internals so non-public merge construction can temporarily relax a destination container's local readonly flag, then restore the saved flag after the merge. Keep public merge_with() semantics unchanged.

Add regression coverage for OmegaConf.merge() and OmegaConf.unsafe_merge() with nested frozen structured configs, their input mutation contracts, and nested readonly flag restoration.

Fixes #1102

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/omry/omegaconf/pull/1318).
* __->__ #1318
* #1317