### PR TITLE
Exclude repo-local .venv from developer tooling

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,.nox,.tox,omegaconf/grammar/gen,build,omegaconf/vendor
+exclude = .git,.nox,.tox,.venv,omegaconf/grammar/gen,build,omegaconf/vendor
 max-line-length = 119
 select = E,F,W,C
 ignore=W503,E203,E701,E704

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,4 +7,4 @@ line_length=88
 ensure_newline_before_comments=True
 known_third_party=attr,pytest
 known_first_party=omegaconf
-skip=.eggs,.nox,omegaconf/grammar/gen,build,omegaconf/vendor,temp
+skip=.eggs,.nox,.venv,omegaconf/grammar/gen,build,omegaconf/vendor,temp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ exclude = '''
     | omegaconf/grammar/gen
     | omegaconf/vendor
     | \.nox
+    | \.venv
     | build
     | subprojects
     | temp
@@ -17,12 +18,18 @@ exclude = '''
 '''
 
 [tool.isort]
-skip_glob = ["temp/*", "omegaconf/vendor/*", "subprojects/*", ".claude/*"]
+skip_glob = [
+    ".venv/*",
+    "temp/*",
+    "omegaconf/vendor/*",
+    "subprojects/*",
+    ".claude/*",
+]
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=append -Werror"
 pythonpath = ["."]
-norecursedirs = ["subprojects", ".git", ".sl"]
+norecursedirs = ["subprojects", ".git", ".sl", ".venv"]
 
 [tool.bumpversion]
 current_version = "2.4.0.dev11"
@@ -102,6 +109,7 @@ project-excludes = [
     "build/**",
     "temp/**",
     ".nox/**",
+    ".venv/**",
     "omegaconf/vendor/**",
     "subprojects/**",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,4 @@ test=pytest
 [flake8]
 max-line-length = 88
 extend-ignore = E203, E501
-exclude = .git,.eggs,.nox,build,temp,vendor,subprojects,omegaconf/grammar/gen,omegaconf/vendor
+exclude = .git,.eggs,.nox,.venv,build,temp,vendor,subprojects,omegaconf/grammar/gen,omegaconf/vendor


### PR DESCRIPTION

Skip .venv in Black, isort, pytest, pyrefly, and flake8 configuration so local virtual environments are not scanned during validation.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/omry/omegaconf/pull/1319).
* #1320
* __->__ #1319