### PR TITLE
Fix nested enum list merges

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,.nox,.tox,omegaconf/grammar/gen,build,omegaconf/vendor
+exclude = .git,.nox,.tox,.venv,omegaconf/grammar/gen,build,omegaconf/vendor
 max-line-length = 119
 select = E,F,W,C
 ignore=W503,E203,E701,E704

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,4 +7,4 @@ line_length=88
 ensure_newline_before_comments=True
 known_third_party=attr,pytest
 known_first_party=omegaconf
-skip=.eggs,.nox,omegaconf/grammar/gen,build,omegaconf/vendor,temp
+skip=.eggs,.nox,.venv,omegaconf/grammar/gen,build,omegaconf/vendor,temp

--- a/news/1095.bugfix
+++ b/news/1095.bugfix
@@ -1,0 +1,1 @@
+Fix merging enum names into nested lists in structured configs.

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -989,17 +989,24 @@ def _deep_update_type_hint(node: Node, type_hint: Any) -> None:
 
 def _deep_update_subnode(node: BaseContainer, key: Any, value_type_hint: Any) -> None:
     """Get node[key] and ensure it is compatible with value_type_hint, mutating if necessary."""
+    from .nodes import AnyNode
+
     subnode = node._get_node(key)
     assert isinstance(subnode, Node)
-    if _is_special(subnode) or (
-        is_union_annotation(value_type_hint)
-        and (
-            not isinstance(subnode, UnionNode)
-            or get_type_hint(subnode) != value_type_hint
+    _, ref_type = _resolve_optional(value_type_hint)
+    if (
+        _is_special(subnode)
+        or (isinstance(subnode, AnyNode) and ref_type is not Any)
+        or (
+            is_union_annotation(value_type_hint)
+            and (
+                not isinstance(subnode, UnionNode)
+                or get_type_hint(subnode) != value_type_hint
+            )
         )
     ):
-        # Ensure special values are wrapped in a Node subclass that
-        # is compatible with the type hint.
+        # Ensure dynamically typed or special values are wrapped in a Node
+        # subclass that is compatible with the type hint.
         node._wrap_value_and_set(key, subnode._value(), value_type_hint)
         subnode = node._get_node(key)
         assert isinstance(subnode, Node)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ exclude = '''
     | omegaconf/grammar/gen
     | omegaconf/vendor
     | \.nox
+    | \.venv
     | build
     | subprojects
     | temp
@@ -17,12 +18,18 @@ exclude = '''
 '''
 
 [tool.isort]
-skip_glob = ["temp/*", "omegaconf/vendor/*", "subprojects/*", ".claude/*"]
+skip_glob = [
+    ".venv/*",
+    "temp/*",
+    "omegaconf/vendor/*",
+    "subprojects/*",
+    ".claude/*",
+]
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=append -Werror"
 pythonpath = ["."]
-norecursedirs = ["subprojects", ".git", ".sl"]
+norecursedirs = ["subprojects", ".git", ".sl", ".venv"]
 
 [tool.bumpversion]
 current_version = "2.4.0.dev11"
@@ -102,6 +109,7 @@ project-excludes = [
     "build/**",
     "temp/**",
     ".nox/**",
+    ".venv/**",
     "omegaconf/vendor/**",
     "subprojects/**",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,4 @@ test=pytest
 [flake8]
 max-line-length = 88
 extend-ignore = E203, E501
-exclude = .git,.eggs,.nox,build,temp,vendor,subprojects,omegaconf/grammar/gen,omegaconf/vendor
+exclude = .git,.eggs,.nox,.venv,build,temp,vendor,subprojects,omegaconf/grammar/gen,omegaconf/vendor

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -44,6 +44,7 @@ from tests import (
     A,
     B,
     C,
+    Color,
     ConcretePlugin,
     ConfWithMissingDict,
     Dataframe,
@@ -1216,6 +1217,17 @@ def test_merge_list_list() -> None:
     b = OmegaConf.create([4, 5, 6])
     a.merge_with(b)
     assert a == b
+
+
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+def test_merge_nested_list_of_enum_names(merge: Any) -> None:
+    @dataclass
+    class Config:
+        list_list: List[List[Color]] = field(default_factory=lambda: [[Color.RED]])
+
+    cfg = merge(Config(), OmegaConf.create({"list_list": [["BLUE"]]}))
+
+    assert cfg.list_list == [[Color.BLUE]]
 
 
 @mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])


### PR DESCRIPTION

Re-wrap dynamically typed child nodes when applying nested list or dict type hints so enum names are converted through EnumNode instead of being validated as raw strings.

Add a regression covering both OmegaConf.merge and OmegaConf.unsafe_merge.

Fixes #1095

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/omry/omegaconf/pull/1320).
* __->__ #1320
* #1319