### PR TITLE
Fix structured metadata merge from missing dict annotations

### DIFF
--- a/news/998.bugfix
+++ b/news/998.bugfix
@@ -1,0 +1,1 @@
+Preserve structured child type metadata when merging a missing dict-annotated field over an existing structured config.

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -934,6 +934,19 @@ def _update_types(node: Node, ref_type: Any, object_type: Optional[type]) -> Non
         node._metadata.object_type = object_type
 
     if node._metadata.ref_type is Any:
+        new_is_optional, new_ref_type = _resolve_optional(ref_type)
+        if is_dict_annotation(new_ref_type) and is_structured_config(
+            node._metadata.object_type
+        ):
+            from ._utils import get_dict_key_value_types
+
+            assert isinstance(node._metadata, ContainerMetadata)
+            node._metadata.optional = new_is_optional
+            node._metadata.ref_type = new_ref_type
+            node._metadata.key_type, node._metadata.element_type = (
+                get_dict_key_value_types(new_ref_type)
+            )
+            return
         _deep_update_type_hint(node, ref_type)
 
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -417,6 +417,9 @@ class OmegaConf:
         """
         Merge a list of previously created configs into a single one
 
+        Note for maintainers: changes to merge behavior should also consider
+        whether OmegaConf.unsafe_merge() needs the same coverage.
+
         :param configs: Input configs
         :param list_merge_mode: Behavior for merging lists
             REPLACE: Replaces the target list with the new one (default)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -478,6 +478,27 @@ def test_merge_missing_structured_keeps_interpolation_target() -> None:
     assert OmegaConf.is_interpolation(merged.child, "ref")
 
 
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+def test_merge_missing_dict_annotation_keeps_structured_child_ref_types(
+    merge: Any,
+) -> None:
+    @dataclass
+    class HydraConf:
+        mode: Color = Color.RED
+
+    @dataclass
+    class AppConf:
+        hydra: Dict[str, Any]
+
+    cfg = merge(
+        {"hydra": HydraConf},
+        AppConf,
+    )
+
+    assert cfg.hydra._metadata.object_type == HydraConf
+    assert cfg.hydra._get_node("mode")._metadata.ref_type == Color
+
+
 @mark.parametrize(
     "inputs,expected,ref_type,is_optional",
     [


### PR DESCRIPTION

Preserve structured child ref_type metadata when a missing dict-annotated source is merged over an existing structured config.

Add regression coverage for both OmegaConf.merge and OmegaConf.unsafe_merge, and note that merge behavior changes should consider unsafe_merge coverage.

Fixes #998
