### PR TITLE
Make register_resolver the canonical resolver API

### DIFF
--- a/docs/notebook/Tutorial.ipynb
+++ b/docs/notebook/Tutorial.ipynb
@@ -954,7 +954,7 @@
     }
    ],
    "source": [
-    "OmegaConf.register_new_resolver(\"plus_10\", lambda x: x + 10)\n",
+    "OmegaConf.register_resolver(\"plus_10\", lambda x: x + 10)\n",
     "conf = OmegaConf.create({\"key\": \"${plus_10:990}\"})\n",
     "conf.key"
    ]
@@ -984,7 +984,7 @@
     }
    ],
    "source": [
-    "OmegaConf.register_new_resolver(\"plus\", lambda x, y: x + y)\n",
+    "OmegaConf.register_resolver(\"plus\", lambda x, y: x + y)\n",
     "conf = OmegaConf.create({\"a\": 1, \"b\": 2, \"a_plus_b\": \"${plus:${a},${b}}\"})\n",
     "conf.a_plus_b"
    ]
@@ -1022,8 +1022,8 @@
     "\n",
     "random.seed(1234)\n",
     "\n",
-    "OmegaConf.register_new_resolver(\"cached\", random.randint, use_cache=True)\n",
-    "OmegaConf.register_new_resolver(\"uncached\", random.randint)\n",
+    "OmegaConf.register_resolver(\"cached\", random.randint, use_cache=True)\n",
+    "OmegaConf.register_resolver(\"uncached\", random.randint)\n",
     "\n",
     "cfg = OmegaConf.create(\n",
     "    {\n",

--- a/docs/source/custom_resolvers.rst
+++ b/docs/source/custom_resolvers.rst
@@ -20,11 +20,11 @@ Resolvers
 Custom resolvers
 ----------------
 
-You can add additional interpolation types by registering custom resolvers with ``OmegaConf.register_new_resolver()``:
+You can add additional interpolation types by registering custom resolvers with ``OmegaConf.register_resolver()``:
 
 .. code-block:: python
 
-    def register_new_resolver(
+    def register_resolver(
         name: str,
         resolver: Resolver,
         *,
@@ -34,11 +34,16 @@ You can add additional interpolation types by registering custom resolvers with 
 
 Attempting to register the same resolver twice will raise a ``ValueError`` unless using ``replace=True``.
 
+.. note::
+
+    ``OmegaConf.register_new_resolver()`` and ``OmegaConf.legacy_register_resolver()`` are deprecated and
+    will be removed in a future release. Use ``OmegaConf.register_resolver()`` instead.
+
 The example below creates a resolver that adds ``10`` to the given value.
 
 .. doctest::
 
-    >>> OmegaConf.register_new_resolver("plus_10", lambda x: x + 10)
+    >>> OmegaConf.register_resolver("plus_10", lambda x: x + 10)
     >>> c = OmegaConf.create({'key': '${plus_10:990}'})
     >>> c.key
     1000
@@ -50,7 +55,7 @@ simply use quotes to bypass character limitations in strings.
 
 .. doctest::
 
-    >>> OmegaConf.register_new_resolver("concat", lambda x, y: x+y)
+    >>> OmegaConf.register_resolver("concat", lambda x, y: x+y)
     >>> c = OmegaConf.create({
     ...     'key1': '${concat:Hello,World}',
     ...     'key_trimmed': '${concat:Hello , World}',
@@ -71,7 +76,7 @@ You can take advantage of nested interpolations to perform custom operations ove
 
 .. doctest::
 
-    >>> OmegaConf.register_new_resolver("sum", lambda x, y: x + y)
+    >>> OmegaConf.register_resolver("sum", lambda x, y: x + y)
     >>> c = OmegaConf.create({"a": 1,
     ...                       "b": 2,
     ...                       "a_plus_b": "${sum:${a},${b}}"})
@@ -83,7 +88,7 @@ namespace, and to use interpolations in the name itself. The following example d
 
 .. doctest::
 
-    >>> OmegaConf.register_new_resolver("mylib.plus1", lambda x: x + 1)
+    >>> OmegaConf.register_resolver("mylib.plus1", lambda x: x + 1)
     >>> c = OmegaConf.create(
     ...     {
     ...         "func": "plus1",
@@ -104,10 +109,10 @@ the inputs themselves:
 
     >>> import random
     >>> random.seed(1234)
-    >>> OmegaConf.register_new_resolver(
+    >>> OmegaConf.register_resolver(
     ...    "cached", random.randint, use_cache=True
     ... )
-    >>> OmegaConf.register_new_resolver("uncached", random.randint)
+    >>> OmegaConf.register_resolver("uncached", random.randint)
     >>> c = OmegaConf.create(
     ...     {
     ...         "uncached": "${uncached:0,10000}",
@@ -141,7 +146,7 @@ This is in contrast to the sum we defined earlier where accessing an invalid key
 
     >>> def sum2(a, b, *, _parent_):
     ...     return _parent_.get(a, 0) + _parent_.get(b, 0)
-    >>> OmegaConf.register_new_resolver("sum2", sum2)
+    >>> OmegaConf.register_resolver("sum2", sum2)
     >>> cfg = OmegaConf.create(
     ...     {
     ...         "node": {
@@ -220,7 +225,7 @@ oc.create
 .. doctest::
 
 
-    >>> OmegaConf.register_new_resolver("make_dict", lambda: {"a": 10})
+    >>> OmegaConf.register_resolver("make_dict", lambda: {"a": 10})
     >>> cfg = OmegaConf.create(
     ...     {
     ...         "plain_dict": "${make_dict:}",
@@ -422,7 +427,7 @@ custom resolvers.
 .. doctest::
 
     >>> # register a new resolver: str.lower
-    >>> OmegaConf.register_new_resolver(
+    >>> OmegaConf.register_resolver(
     ...     name='str.lower',
     ...     resolver=lambda x: str(x).lower(),
     ... )

--- a/docs/source/how_to_guides.rst
+++ b/docs/source/how_to_guides.rst
@@ -25,7 +25,7 @@ First, register the ``builtins.eval`` function as a new resolver:
 .. doctest::
 
     >>> from omegaconf import OmegaConf
-    >>> OmegaConf.register_new_resolver("eval", eval)
+    >>> OmegaConf.register_resolver("eval", eval)
 
 Now, define a config and perform some arithmetic using the ``eval`` resolver:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -421,13 +421,13 @@ Interpolated nodes can be any node in the config, not just leaf nodes:
 
 Resolvers
 ^^^^^^^^^
-Add new interpolation types by registering resolvers using ``OmegaConf.register_new_resolver()``.
+Add new interpolation types by registering resolvers using ``OmegaConf.register_resolver()``.
 Such resolvers are called when the config node is accessed.
 The minimal example below shows its most basic usage, see :doc:`custom_resolvers` for more details.
 
 .. doctest::
 
-    >>> OmegaConf.register_new_resolver(
+    >>> OmegaConf.register_resolver(
     ...     "add", lambda *numbers: sum(numbers)
     ... )
     >>> c = OmegaConf.create({'total': '${add:1,2,3}'})

--- a/news/969.api_change
+++ b/news/969.api_change
@@ -1,0 +1,1 @@
+Undeprecated ``OmegaConf.register_resolver()`` as the canonical custom resolver API, and deprecated ``OmegaConf.register_new_resolver()`` and ``OmegaConf.legacy_register_resolver()``.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -109,13 +109,13 @@ def SI(interpolation: str) -> Any:
 def register_default_resolvers() -> None:
     from omegaconf.resolvers import oc
 
-    OmegaConf.register_new_resolver("oc.create", oc.create)
-    OmegaConf.register_new_resolver("oc.decode", oc.decode)
-    OmegaConf.register_new_resolver("oc.deprecated", oc.deprecated)
-    OmegaConf.register_new_resolver("oc.env", oc.env)
-    OmegaConf.register_new_resolver("oc.select", oc.select)
-    OmegaConf.register_new_resolver("oc.dict.keys", oc.dict.keys)
-    OmegaConf.register_new_resolver("oc.dict.values", oc.dict.values)
+    OmegaConf.register_resolver("oc.create", oc.create)
+    OmegaConf.register_resolver("oc.decode", oc.decode)
+    OmegaConf.register_resolver("oc.deprecated", oc.deprecated)
+    OmegaConf.register_resolver("oc.env", oc.env)
+    OmegaConf.register_resolver("oc.select", oc.select)
+    OmegaConf.register_resolver("oc.dict.keys", oc.dict.keys)
+    OmegaConf.register_resolver("oc.dict.values", oc.dict.values)
 
 
 class OmegaConf:
@@ -484,61 +484,7 @@ class OmegaConf:
         return target
 
     @staticmethod
-    def register_resolver(name: str, resolver: Resolver) -> None:
-        warnings.warn(
-            dedent("""\
-            register_resolver() is deprecated.
-            See https://github.com/omry/omegaconf/issues/426 for migration instructions.
-            """),
-            stacklevel=2,
-        )
-        return OmegaConf.legacy_register_resolver(name, resolver)
-
-    # This function will eventually be deprecated and removed.
-    @staticmethod
-    def legacy_register_resolver(name: str, resolver: Resolver) -> None:
-        assert callable(resolver), "resolver must be callable"
-        # noinspection PyProtectedMember
-        assert (
-            name not in BaseContainer._resolvers
-        ), f"resolver '{name}' is already registered"
-
-        def resolver_wrapper(
-            config: BaseContainer,
-            parent: BaseContainer,
-            node: Node,
-            args: Tuple[Any, ...],
-            args_str: Tuple[str, ...],
-        ) -> Any:
-            cache = OmegaConf.get_cache(config)[name]
-            # "Un-escape " spaces and commas.
-            args_unesc = [x.replace(r"\ ", " ").replace(r"\,", ",") for x in args_str]
-
-            # Nested interpolations behave in a potentially surprising way with
-            # legacy resolvers (they remain as strings, e.g., "${foo}"). If any
-            # input looks like an interpolation we thus raise an exception.
-            try:
-                bad_arg = next(i for i in args_unesc if "${" in i)
-            except StopIteration:
-                pass
-            else:
-                raise ValueError(
-                    f"Resolver '{name}' was called with argument '{bad_arg}' that appears "
-                    f"to be an interpolation. Nested interpolations are not supported for "
-                    f"resolvers registered with `[legacy_]register_resolver()`, please use "
-                    f"`register_new_resolver()` instead (see "
-                    f"https://github.com/omry/omegaconf/issues/426 for migration instructions)."  # noqa: E231
-                )
-            key = args_str
-            val = cache[key] if key in cache else resolver(*args_unesc)
-            cache[key] = val
-            return val
-
-        # noinspection PyProtectedMember
-        BaseContainer._resolvers[name] = resolver_wrapper
-
-    @staticmethod
-    def register_new_resolver(
+    def register_resolver(
         name: str,
         resolver: Resolver,
         *,
@@ -614,6 +560,76 @@ class OmegaConf:
 
             ret = resolver(*args, **kwargs)
             return ret
+
+        # noinspection PyProtectedMember
+        BaseContainer._resolvers[name] = resolver_wrapper
+
+    @staticmethod
+    def register_new_resolver(
+        name: str,
+        resolver: Resolver,
+        *,
+        replace: bool = False,
+        use_cache: bool = False,
+    ) -> None:
+        warnings.warn(
+            dedent("""\
+            register_new_resolver() is deprecated and will be removed in a future release.
+            Use register_resolver() instead.
+            See https://github.com/omry/omegaconf/issues/426 for migration instructions.
+            """),
+            stacklevel=2,
+        )
+        return OmegaConf.register_resolver(
+            name, resolver, replace=replace, use_cache=use_cache
+        )
+
+    @staticmethod
+    def legacy_register_resolver(name: str, resolver: Resolver) -> None:
+        warnings.warn(
+            dedent("""\
+            legacy_register_resolver() is deprecated and will be removed in a future release.
+            Use register_resolver() instead.
+            See https://github.com/omry/omegaconf/issues/426 for migration instructions.
+            """),
+            stacklevel=2,
+        )
+        assert callable(resolver), "resolver must be callable"
+        # noinspection PyProtectedMember
+        assert (
+            name not in BaseContainer._resolvers
+        ), f"resolver '{name}' is already registered"
+
+        def resolver_wrapper(
+            config: BaseContainer,
+            parent: BaseContainer,
+            node: Node,
+            args: Tuple[Any, ...],
+            args_str: Tuple[str, ...],
+        ) -> Any:
+            cache = OmegaConf.get_cache(config)[name]
+            # "Un-escape " spaces and commas.
+            args_unesc = [x.replace(r"\ ", " ").replace(r"\,", ",") for x in args_str]
+
+            # Nested interpolations behave in a potentially surprising way with
+            # legacy resolvers (they remain as strings, e.g., "${foo}"). If any
+            # input looks like an interpolation we thus raise an exception.
+            try:
+                bad_arg = next(i for i in args_unesc if "${" in i)
+            except StopIteration:
+                pass
+            else:
+                raise ValueError(
+                    f"Resolver '{name}' was called with argument '{bad_arg}' that appears "
+                    f"to be an interpolation. Nested interpolations are not supported for "
+                    f"resolvers registered with `legacy_register_resolver()`, please use "
+                    f"`register_resolver()` instead (see "
+                    f"https://github.com/omry/omegaconf/issues/426 for migration instructions)."  # noqa: E231
+                )
+            key = args_str
+            val = cache[key] if key in cache else resolver(*args_unesc)
+            cache[key] = val
+            return val
 
         # noinspection PyProtectedMember
         BaseContainer._resolvers[name] = resolver_wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def common_resolvers(restore_resolvers: Any) -> Any:
     def cast(t: Any, v: Any) -> Any:
         return {"str": str, "int": int}[t](v)  # cast `v` to type `t`
 
-    OmegaConf.register_new_resolver("cast", cast)
-    OmegaConf.register_new_resolver("identity", lambda x: x)
+    OmegaConf.register_resolver("cast", cast)
+    OmegaConf.register_resolver("identity", lambda x: x)
 
     yield

--- a/tests/interpolation/built_in_resolvers/test_oc_create.py
+++ b/tests/interpolation/built_in_resolvers/test_oc_create.py
@@ -106,7 +106,7 @@ def test_write_into_output() -> None:
 def test_resolver_output_dict_to_dictconfig(
     restore_resolvers: Any, cfg: Dict[str, Any], expected: Dict[str, Any]
 ) -> None:
-    OmegaConf.register_new_resolver("dict", lambda: cfg)
+    OmegaConf.register_resolver("dict", lambda: cfg)
     c = OmegaConf.create({"x": "${oc.create:${dict:}}", "y": -1})
     assert isinstance(c.x, DictConfig)
     assert c.x == expected
@@ -126,7 +126,7 @@ def test_resolver_output_dict_to_dictconfig(
 def test_resolver_output_list_to_listconfig(
     restore_resolvers: Any, cfg: List[Any], expected: List[Any]
 ) -> None:
-    OmegaConf.register_new_resolver("list", lambda: cfg)
+    OmegaConf.register_resolver("list", lambda: cfg)
     c = OmegaConf.create({"x": "${oc.create:${list:}}", "y": -1})
     assert isinstance(c.x, ListConfig)
     assert c.x == expected

--- a/tests/interpolation/built_in_resolvers/test_oc_dict.py
+++ b/tests/interpolation/built_in_resolvers/test_oc_dict.py
@@ -99,7 +99,7 @@ def test_dict_keys(cfg: Any, key: Any, expected: Any) -> None:
 def test_get_and_validate_dict_input(
     restore_resolvers: Any, cfg: Any, key: Any, expected: Any
 ) -> None:
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "oc.dict.keys_or_values",
         lambda in_dict, _parent_: _get_and_validate_dict_input(
             in_dict, parent=_parent_, resolver_name="oc.dict.keys_or_values"
@@ -214,7 +214,7 @@ def test_dict_values_with_missing_value() -> None:
 def test_dict_values_dictconfig_resolver_output(
     restore_resolvers: Any, make_resolver: Any, key: Any, expected: Any
 ) -> None:
-    OmegaConf.register_new_resolver("make", make_resolver)
+    OmegaConf.register_resolver("make", make_resolver)
     cfg = OmegaConf.create(
         {
             "foo": "${oc.dict.values:bar}",
@@ -302,7 +302,7 @@ def test_relative_path(cfg: Any, expected: Any) -> None:
     ],
 )
 def test_nested_oc_dict(restore_resolvers: Any, cfg: Any, expected: Any) -> None:
-    OmegaConf.register_new_resolver("sum", sum)
+    OmegaConf.register_resolver("sum", sum)
     cfg = OmegaConf.create(cfg)
     assert cfg.x == expected
 

--- a/tests/interpolation/test_custom_resolvers.py
+++ b/tests/interpolation/test_custom_resolvers.py
@@ -10,22 +10,27 @@ from tests import User
 from tests.interpolation import dereference_node
 
 
+def legacy_register_resolver(name: str, resolver: Resolver) -> None:
+    with warns(UserWarning, match="legacy_register_resolver"):
+        OmegaConf.legacy_register_resolver(name, resolver)
+
+
 def test_register_resolver_twice_error(restore_resolvers: Any) -> None:
     def foo(_: Any) -> int:
         return 10
 
-    OmegaConf.register_new_resolver("foo", foo)
+    OmegaConf.register_resolver("foo", foo)
     with raises(ValueError, match=re.escape("resolver 'foo' is already registered")):
-        OmegaConf.register_new_resolver("foo", foo)
+        OmegaConf.register_resolver("foo", foo)
 
 
 def test_register_resolver_twice_error_legacy(restore_resolvers: Any) -> None:
     def foo() -> int:
         return 10
 
-    OmegaConf.legacy_register_resolver("foo", foo)
+    legacy_register_resolver("foo", foo)
     with raises(AssertionError):
-        OmegaConf.legacy_register_resolver("foo", lambda: 10)
+        legacy_register_resolver("foo", lambda: 10)
 
 
 def test_register_resolver_twice_error_legacy_and_regular(
@@ -34,19 +39,19 @@ def test_register_resolver_twice_error_legacy_and_regular(
     def foo() -> int:
         return 10
 
-    OmegaConf.legacy_register_resolver("foo", foo)
+    legacy_register_resolver("foo", foo)
     with raises(ValueError):
-        OmegaConf.register_new_resolver("foo", foo)
+        OmegaConf.register_resolver("foo", foo)
 
 
 def test_register_resolver_error_non_callable(restore_resolvers: Any) -> None:
     with raises(TypeError, match=re.escape("resolver must be callable")):
-        OmegaConf.register_new_resolver("foo", 0)  # type: ignore
+        OmegaConf.register_resolver("foo", 0)  # type: ignore
 
 
 def test_register_resolver_error_empty_name(restore_resolvers: Any) -> None:
     with raises(ValueError, match=re.escape("cannot use an empty resolver name")):
-        OmegaConf.register_new_resolver("", lambda: None)
+        OmegaConf.register_resolver("", lambda: None)
 
 
 def test_register_non_inspectable_resolver(mocker: Any, restore_resolvers: Any) -> None:
@@ -57,7 +62,7 @@ def test_register_non_inspectable_resolver(mocker: Any, restore_resolvers: Any) 
         raise ValueError
 
     mocker.patch("inspect.signature", signature_not_inspectable)
-    OmegaConf.register_new_resolver("not_inspectable", lambda: 123)
+    OmegaConf.register_resolver("not_inspectable", lambda: 123)
     assert OmegaConf.create({"x": "${not_inspectable:}"}).x == 123
 
 
@@ -76,18 +81,16 @@ def test_register_resolver_with_replace(
     use_cache_2: bool,
     expected: Any,
 ) -> None:
-    OmegaConf.register_new_resolver("foo", lambda: 1, use_cache=use_cache_1)
+    OmegaConf.register_resolver("foo", lambda: 1, use_cache=use_cache_1)
     cfg = OmegaConf.create({"x": "${foo:}"})
     assert cfg.x == 1
-    OmegaConf.register_new_resolver(
-        "foo", lambda: 2, use_cache=use_cache_2, replace=True
-    )
+    OmegaConf.register_resolver("foo", lambda: 2, use_cache=use_cache_2, replace=True)
     assert cfg.x == expected
 
 
 def test_clear_resolvers_and_has_resolver(restore_resolvers: Any) -> None:
     assert not OmegaConf.has_resolver("foo")
-    OmegaConf.register_new_resolver("foo", lambda x: x + 10)
+    OmegaConf.register_resolver("foo", lambda x: x + 10)
     assert OmegaConf.has_resolver("foo")
     OmegaConf.clear_resolvers()
     assert not OmegaConf.has_resolver("foo")
@@ -95,14 +98,14 @@ def test_clear_resolvers_and_has_resolver(restore_resolvers: Any) -> None:
 
 def test_clear_resolvers_and_has_resolver_legacy(restore_resolvers: Any) -> None:
     assert not OmegaConf.has_resolver("foo")
-    OmegaConf.legacy_register_resolver("foo", lambda x: int(x) + 10)
+    legacy_register_resolver("foo", lambda x: int(x) + 10)
     assert OmegaConf.has_resolver("foo")
     OmegaConf.clear_resolvers()
     assert not OmegaConf.has_resolver("foo")
 
 
 def test_register_resolver_1(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver("plus_10", lambda x: x + 10)
+    OmegaConf.register_resolver("plus_10", lambda x: x + 10)
     c = OmegaConf.create(
         {"k": "${plus_10:990}", "node": {"bar": 10, "foo": "${plus_10:${.bar}}"}}
     )
@@ -113,7 +116,7 @@ def test_register_resolver_1(restore_resolvers: Any) -> None:
 
 
 def test_register_resolver_1_legacy(restore_resolvers: Any) -> None:
-    OmegaConf.legacy_register_resolver("plus_10", lambda x: int(x) + 10)
+    legacy_register_resolver("plus_10", lambda x: int(x) + 10)
     c = OmegaConf.create({"k": "${plus_10:990}"})
 
     assert type(c.k) is int
@@ -123,7 +126,7 @@ def test_register_resolver_1_legacy(restore_resolvers: Any) -> None:
 def test_resolver_cache_1(restore_resolvers: Any) -> None:
     # The cache is important to allow embedding of functions like time()
     # without having the value change during the program execution.
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "random", lambda _: random.randint(0, 10000000), use_cache=True
     )
     c = OmegaConf.create({"k": "${random:__}"})
@@ -131,7 +134,7 @@ def test_resolver_cache_1(restore_resolvers: Any) -> None:
 
 
 def test_resolver_cache_1_legacy(restore_resolvers: Any) -> None:
-    OmegaConf.legacy_register_resolver("random", lambda _: random.randint(0, 10000000))
+    legacy_register_resolver("random", lambda _: random.randint(0, 10000000))
     c = OmegaConf.create({"k": "${random:_}"})
     assert c.k == c.k
 
@@ -140,7 +143,7 @@ def test_resolver_cache_2(restore_resolvers: Any) -> None:
     """
     Tests that resolver cache is not shared between different OmegaConf objects
     """
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "random", lambda _: random.randint(0, 10000000), use_cache=True
     )
     c1 = OmegaConf.create({"k": "${random:__}"})
@@ -152,7 +155,7 @@ def test_resolver_cache_2(restore_resolvers: Any) -> None:
 
 
 def test_resolver_cache_2_legacy(restore_resolvers: Any) -> None:
-    OmegaConf.legacy_register_resolver("random", lambda _: random.randint(0, 10000000))
+    legacy_register_resolver("random", lambda _: random.randint(0, 10000000))
     c1 = OmegaConf.create({"k": "${random:_}"})
     c2 = OmegaConf.create({"k": "${random:_}"})
 
@@ -168,7 +171,7 @@ def test_resolver_cache_3_dict_list(restore_resolvers: Any) -> None:
     Note that since the cache is based on string literals, changing the order of
     items in a dictionary is considered as a different input.
     """
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "random", lambda _: random.uniform(0, 1), use_cache=True
     )
     c = OmegaConf.create(
@@ -193,7 +196,7 @@ def test_resolver_cache_3_dict_list(restore_resolvers: Any) -> None:
 
 
 def test_resolver_cache_4_interpolation(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver("test", lambda x: x, use_cache=True)
+    OmegaConf.register_resolver("test", lambda x: x, use_cache=True)
     c = OmegaConf.create({"x": "${test:${y}}", "y": 0})
 
     assert c.x == 0
@@ -202,7 +205,7 @@ def test_resolver_cache_4_interpolation(restore_resolvers: Any) -> None:
 
 
 def test_resolver_no_cache(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "random", lambda _: random.uniform(0, 1), use_cache=False
     )
     c = OmegaConf.create({"k": "${random:__}"})
@@ -250,7 +253,7 @@ def test_resolver_dot_start_legacy(common_resolvers: Any) -> None:
 def test_resolver_that_allows_a_list_of_arguments(
     restore_resolvers: Any, resolver: Resolver, name: str, key: str, result: Any
 ) -> None:
-    OmegaConf.register_new_resolver("my_resolver", resolver)
+    OmegaConf.register_resolver("my_resolver", resolver)
     c = OmegaConf.create({name: key})
     assert c[name] == result
 
@@ -277,18 +280,21 @@ def test_resolver_that_allows_a_list_of_arguments(
 def test_resolver_that_allows_a_list_of_arguments_legacy(
     restore_resolvers: Any, resolver: Resolver, name: str, key: str, result: Any
 ) -> None:
-    OmegaConf.legacy_register_resolver("my_resolver", resolver)
+    legacy_register_resolver("my_resolver", resolver)
     c = OmegaConf.create({name: key})
     assert c[name] == result
 
 
-def test_resolver_deprecated_behavior(restore_resolvers: Any) -> None:
-    # Ensure that resolvers registered with the old "register_resolver()" function
-    # behave as expected.
+def test_register_new_resolver_deprecated_alias(restore_resolvers: Any) -> None:
+    with warns(UserWarning, match="register_new_resolver"):
+        OmegaConf.register_new_resolver("plus_10", lambda x: x + 10)
+    cfg = OmegaConf.create({"x": 10, "y": "${plus_10:${x}}"})
+    assert cfg.y == 20
 
-    # The registration should trigger a deprecation warning.
-    with warns(UserWarning):
-        OmegaConf.register_resolver("my_resolver", lambda *args: args)
+
+def test_legacy_register_resolver_deprecated_behavior(restore_resolvers: Any) -> None:
+    # Ensure that resolvers registered with the legacy API behave as expected.
+    legacy_register_resolver("my_resolver", lambda *args: args)
 
     c = OmegaConf.create(
         {
@@ -306,14 +312,13 @@ def test_resolver_deprecated_behavior(restore_resolvers: Any) -> None:
     assert c.bool == ("TruE", "falSE")
     assert c.str == ("a", "b", "c")
 
-    # Trying to nest interpolations should trigger an error (users should switch to
-    # `register_new_resolver()` in order to use nested interpolations).
+    # Trying to nest interpolations should trigger an error.
     with raises(ValueError):
         c.inter
 
 
 def test_copy_cache(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "random", lambda _: random.randint(0, 10000000), use_cache=True
     )
     d = {"k": "${random:__}"}
@@ -333,7 +338,7 @@ def test_copy_cache(restore_resolvers: Any) -> None:
 
 
 def test_clear_cache(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver("random", lambda _: random.randint(0, 10000000))
+    OmegaConf.register_resolver("random", lambda _: random.randint(0, 10000000))
     c = OmegaConf.create({"k": "${random:__}"})
     old = c.k
     OmegaConf.clear_cache(c)
@@ -343,7 +348,7 @@ def test_clear_cache(restore_resolvers: Any) -> None:
 @mark.parametrize("readonly", [True, False])
 def test_resolver_output_dict(restore_resolvers: Any, readonly: bool) -> None:
     some_dict = {"a": 0, "b": "${y}"}
-    OmegaConf.register_new_resolver("dict", lambda: some_dict)
+    OmegaConf.register_resolver("dict", lambda: some_dict)
     c = OmegaConf.create({"x": "${dict:}", "y": -1})
     OmegaConf.set_readonly(c, readonly)
     assert isinstance(c.x, dict)
@@ -364,7 +369,7 @@ def test_resolver_output_dict(restore_resolvers: Any, readonly: bool) -> None:
 def test_resolver_output_plain_dict_list(
     restore_resolvers: Any, readonly: bool, data: Any, expected_type: type
 ) -> None:
-    OmegaConf.register_new_resolver("get_data", lambda: data)
+    OmegaConf.register_resolver("get_data", lambda: data)
     c = OmegaConf.create({"x": "${get_data:}", "y": -1})
     OmegaConf.set_readonly(c, readonly)
 
@@ -378,15 +383,13 @@ def test_resolver_output_plain_dict_list(
 
 def test_register_cached_resolver_with_keyword_unsupported() -> None:
     with raises(ValueError):
-        OmegaConf.register_new_resolver("root", lambda _root_: None, use_cache=True)
+        OmegaConf.register_resolver("root", lambda _root_: None, use_cache=True)
     with raises(ValueError):
-        OmegaConf.register_new_resolver("parent", lambda _parent_: None, use_cache=True)
+        OmegaConf.register_resolver("parent", lambda _parent_: None, use_cache=True)
 
 
 def test_resolver_with_parent(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver(
-        "parent", lambda _parent_: _parent_, use_cache=False
-    )
+    OmegaConf.register_resolver("parent", lambda _parent_: _parent_, use_cache=False)
 
     cfg = OmegaConf.create(
         {
@@ -404,7 +407,7 @@ def test_resolver_with_parent(restore_resolvers: Any) -> None:
 
 
 def test_resolver_with_root(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver("root", lambda _root_: _root_, use_cache=False)
+    OmegaConf.register_resolver("root", lambda _root_: _root_, use_cache=False)
     cfg = OmegaConf.create(
         {
             "a": 10,
@@ -421,7 +424,7 @@ def test_resolver_with_root(restore_resolvers: Any) -> None:
 
 
 def test_resolver_with_root_and_parent(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "both", lambda _root_, _parent_: _root_.add + _parent_.add, use_cache=False
     )
 
@@ -443,7 +446,7 @@ def test_resolver_with_parent_and_default_value(restore_resolvers: Any) -> None:
     def parent_and_default(default: int = 10, *, _parent_: Any) -> Any:
         return _parent_.add + default
 
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "parent_and_default", parent_and_default, use_cache=False
     )
 
@@ -473,7 +476,7 @@ def test_resolver_with_parent_and_default_value(restore_resolvers: Any) -> None:
 def test_merge_into_resolver_output(
     restore_resolvers: Any, cfg2: Any, expected: Any
 ) -> None:
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "make", lambda _parent_: OmegaConf.create({"a": 0}, parent=_parent_)
     )
 
@@ -492,7 +495,7 @@ def test_merge_into_resolver_output(
 def test_resolve_resolver_returning_primitive_container(
     restore_resolvers: Any, primitive_container: Any
 ) -> None:
-    OmegaConf.register_new_resolver("returns_container", lambda: primitive_container)
+    OmegaConf.register_resolver("returns_container", lambda: primitive_container)
     cfg = OmegaConf.create({"foo": "${returns_container:}"})
     assert cfg.foo == primitive_container
     OmegaConf.resolve(cfg)

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -247,7 +247,7 @@ def test_invalid_intermediate_result_when_not_throwing(
     def fail_if_called(x: Any) -> None:
         assert False
 
-    OmegaConf.register_new_resolver("fail_if_called", fail_if_called)
+    OmegaConf.register_resolver("fail_if_called", fail_if_called)
     cfg = OmegaConf.create(
         {
             "x": "${fail_if_called:${%s}}" % ref,
@@ -260,7 +260,7 @@ def test_invalid_intermediate_result_when_not_throwing(
 
 
 def test_none_value_in_quoted_string(restore_resolvers: Any) -> None:
-    OmegaConf.register_new_resolver("test", lambda x: x)
+    OmegaConf.register_resolver("test", lambda x: x)
     cfg = OmegaConf.create({"x": "${test:'${missing}'}", "missing": None})
     assert cfg.x == "None"
 
@@ -319,7 +319,7 @@ def test_interpolation_type_validated_ok(
     def drop_last(s: str) -> str:
         return s[0:-1]  # drop last character from string `s`
 
-    OmegaConf.register_new_resolver("drop_last", drop_last)
+    OmegaConf.register_resolver("drop_last", drop_last)
 
     cfg = OmegaConf.structured(cfg)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
-from pytest import mark, param, raises
+from pytest import mark, param, raises, warns
 
 import tests
 from omegaconf import (
@@ -58,6 +58,14 @@ from tests import (
     User,
     warns_dict_subclass_deprecated,
 )
+
+
+def _register_resolver(register_func: Any, name: str, resolver: Any) -> None:
+    if register_func is OmegaConf.legacy_register_resolver:
+        with warns(UserWarning, match="legacy_register_resolver"):
+            register_func(name, resolver)
+    else:
+        register_func(name, resolver)
 
 
 # tests classes
@@ -1847,13 +1855,13 @@ def test_format_and_raise_initialized_exception_does_not_self_chain(
 
 @mark.parametrize(
     "register_func",
-    [OmegaConf.legacy_register_resolver, OmegaConf.register_new_resolver],
+    [OmegaConf.legacy_register_resolver, OmegaConf.register_resolver],
 )
 def test_resolver_error(restore_resolvers: Any, register_func: Any) -> None:
     def div(x: Any, y: Any) -> float:
         return float(x) / float(y)
 
-    register_func("div", div)
+    _register_resolver(register_func, "div", div)
     c = OmegaConf.create({"div_by_zero": "${div:1,0}"})
     expected_msg = dedent("""\
         ZeroDivisionError raised while resolving interpolation: (float )?division( by zero)?

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -457,9 +457,9 @@ class TestOmegaConfGrammar:
     ) -> None:
         parse_tree, expected_visit = self._parse("singleElement", definition, expected)
 
-        OmegaConf.register_new_resolver("test", self._resolver_test)
-        OmegaConf.register_new_resolver("first", self._resolver_first)
-        OmegaConf.register_new_resolver("ns1.ns2.test", self._resolver_test)
+        OmegaConf.register_resolver("test", self._resolver_test)
+        OmegaConf.register_resolver("first", self._resolver_first)
+        OmegaConf.register_resolver("ns1.ns2.test", self._resolver_test)
 
         self._visit_with_config(parse_tree, expected_visit)
 
@@ -468,7 +468,7 @@ class TestOmegaConfGrammar:
         self, restore_resolvers: Any, definition: str, expected: Any
     ) -> None:
         parse_tree, expected_visit = self._parse("configValue", definition, expected)
-        OmegaConf.register_new_resolver("test", self._resolver_test)
+        OmegaConf.register_resolver("test", self._resolver_test)
         self._visit_with_config(parse_tree, expected_visit)
 
     @parametrize_from(
@@ -487,7 +487,7 @@ class TestOmegaConfGrammar:
     def test_deprecated_empty_args(
         self, restore_resolvers: Any, definition: str, expected: Any
     ) -> None:
-        OmegaConf.register_new_resolver("test", self._resolver_test)
+        OmegaConf.register_resolver("test", self._resolver_test)
 
         parse_tree, expected_visit = self._parse("singleElement", definition, expected)
         with warns(
@@ -754,7 +754,7 @@ def test_custom_resolver_param_supported_chars() -> None:
     supported_chars = r"abc123_:" + UNQUOTED_SPECIAL
     c = OmegaConf.create({"dir1": "${copy:" + supported_chars + "}"})
 
-    OmegaConf.register_new_resolver("copy", lambda x: x)
+    OmegaConf.register_resolver("copy", lambda x: x)
     assert c.dir1 == supported_chars
 
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 from typing import Any, Optional, Union
 
-from pytest import mark, raises
+from pytest import mark, raises, warns
 
 from omegaconf import (
     BooleanNode,
@@ -24,6 +24,14 @@ from omegaconf._utils import _is_optional
 from tests import Color, Group
 
 SKIP = object()
+
+
+def _register_resolver(register_func: Any, name: str, resolver: Any) -> None:
+    if register_func is OmegaConf.legacy_register_resolver:
+        with warns(UserWarning, match="legacy_register_resolver"):
+            register_func(name, resolver)
+    else:
+        register_func(name, resolver)
 
 
 def verify(
@@ -192,13 +200,13 @@ class TestNodeTypesMatrix:
 
     @mark.parametrize(
         "register_func",
-        [OmegaConf.legacy_register_resolver, OmegaConf.register_new_resolver],
+        [OmegaConf.legacy_register_resolver, OmegaConf.register_resolver],
     )
     def test_interpolation(
         self, node_type: Any, values: Any, restore_resolvers: Any, register_func: Any
     ) -> None:
         resolver_output = "9999"
-        register_func("func", lambda: resolver_output)
+        _register_resolver(register_func, "func", lambda: resolver_output)
         values = copy.deepcopy(values)
         for value in values:
             node = {

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
 )
 
-from pytest import mark, param, raises
+from pytest import mark, param, raises, warns
 
 from omegaconf import (
     II,
@@ -65,6 +65,14 @@ from tests import (
     User,
     Users,
 )
+
+
+def _register_resolver(register_func: Any, name: str, resolver: Any) -> None:
+    if register_func is OmegaConf.legacy_register_resolver:
+        with warns(UserWarning, match="legacy_register_resolver"):
+            register_func(name, resolver)
+    else:
+        register_func(name, resolver)
 
 
 @mark.parametrize(
@@ -1577,7 +1585,7 @@ def test_merge_with_error_not_changing_target(c1: Any, c2: Any) -> Any:
 
 @mark.parametrize(
     "register_func",
-    [OmegaConf.legacy_register_resolver, OmegaConf.register_new_resolver],
+    [OmegaConf.legacy_register_resolver, OmegaConf.register_resolver],
 )
 def test_into_custom_resolver_that_throws(
     restore_resolvers: Any, register_func: Any
@@ -1585,7 +1593,7 @@ def test_into_custom_resolver_that_throws(
     def fail() -> None:
         raise ValueError()
 
-    register_func("fail", fail)
+    _register_resolver(register_func, "fail", fail)
 
     configs = (
         {"d": 20, "i": "${fail:}"},

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -560,7 +560,7 @@ def test_resolve_raises_on_interpolation_to_missing(cfg: Any) -> None:
 
 def test_resolve_raises_on_resolver_arg_to_missing(restore_resolvers: Any) -> None:
     """https://github.com/omry/omegaconf/issues/1131"""
-    OmegaConf.register_new_resolver("no_op", lambda x: x)
+    OmegaConf.register_resolver("no_op", lambda x: x)
     cfg = OmegaConf.create({"a": "${no_op:${b}}", "b": "???"})
     assert not OmegaConf.is_missing(cfg, "a")
     with raises(InterpolationToMissingValueError):
@@ -570,7 +570,7 @@ def test_resolve_raises_on_resolver_arg_to_missing(restore_resolvers: Any) -> No
 def test_resolve_does_not_raise_when_resolver_returns_dict_config(
     restore_resolvers: Any,
 ) -> None:
-    OmegaConf.register_new_resolver(
+    OmegaConf.register_resolver(
         "merge_test",
         lambda a, b: OmegaConf.merge(a, b),
         replace=True,
@@ -701,7 +701,7 @@ def test_missing_keys_interpolation_to_missing(cfg: Any, expected: Any) -> None:
 def test_missing_keys_custom_resolver_interpolation_to_missing(
     restore_resolvers: Any,
 ) -> None:
-    OmegaConf.register_new_resolver("add", lambda a, b: a + b)
+    OmegaConf.register_resolver("add", lambda a, b: a + b)
     cfg = OmegaConf.create(
         {
             "a": "???",
@@ -723,7 +723,7 @@ def test_missing_keys_custom_resolver_interpolation_to_missing(
 def test_missing_keys_custom_resolver_body_dereferences_missing(
     restore_resolvers: Any,
 ) -> None:
-    OmegaConf.register_new_resolver("read", lambda *, _root_: _root_.a)
+    OmegaConf.register_resolver("read", lambda *, _root_: _root_.a)
     cfg = OmegaConf.create({"a": "???", "b": "${read:}"})
     assert OmegaConf.missing_keys(cfg) == {"a"}
     assert OmegaConf.missing_keys(cfg, resolve_custom_resolvers=True) == {"a", "b"}
@@ -736,7 +736,7 @@ def test_missing_keys_custom_resolver_non_missing_error(
     def boom() -> None:
         raise ValueError("boom")
 
-    OmegaConf.register_new_resolver("boom", boom)
+    OmegaConf.register_resolver("boom", boom)
     cfg = OmegaConf.create({"missing": "???", "err": "${boom:}"})
     assert OmegaConf.missing_keys(cfg) == {"missing"}
     assert OmegaConf.missing_keys(cfg, resolve_custom_resolvers=False) == {"missing"}
@@ -782,7 +782,7 @@ def test_clear_resolver(
     restore_resolvers: Any, register_resolver_params: Any, name: str, expected: Any
 ) -> None:
     if register_resolver_params:
-        OmegaConf.register_new_resolver(**register_resolver_params)
+        OmegaConf.register_resolver(**register_resolver_params)
     assert expected["pre_clear"] == OmegaConf.has_resolver(name)
 
     assert OmegaConf.clear_resolver(name) == expected["result"]

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,12 +1,20 @@
 from contextlib import AbstractContextManager
 from typing import Any, Optional
 
-from pytest import mark, param, raises
+from pytest import mark, param, raises, warns
 
 from omegaconf import DictConfig, ListConfig, MissingMandatoryValue, OmegaConf
 from omegaconf._impl import select_value
 from omegaconf._utils import _ensure_container
 from omegaconf.errors import InterpolationKeyError
+
+
+def _register_resolver(register_func: Any, name: str, resolver: Any) -> None:
+    if register_func is OmegaConf.legacy_register_resolver:
+        with warns(UserWarning, match="legacy_register_resolver"):
+            register_func(name, resolver)
+    else:
+        register_func(name, resolver)
 
 
 @mark.parametrize(
@@ -82,7 +90,7 @@ class TestSelect:
 
     @mark.parametrize(
         "register_func",
-        [OmegaConf.legacy_register_resolver, OmegaConf.register_new_resolver],
+        [OmegaConf.legacy_register_resolver, OmegaConf.register_resolver],
     )
     @mark.parametrize(
         "cfg, key, expected",
@@ -99,7 +107,7 @@ class TestSelect:
         register_func: Any,
         struct: Optional[bool],
     ) -> None:
-        register_func("func", lambda x: f"_{x}_")
+        _register_resolver(register_func, "func", lambda x: f"_{x}_")
         cfg = _ensure_container(cfg)
         OmegaConf.set_struct(cfg, struct)
         if isinstance(expected, AbstractContextManager):

--- a/tests/test_to_container.py
+++ b/tests/test_to_container.py
@@ -329,7 +329,7 @@ def test_to_container_resolves_referenced_node_once(
         counter += 1
         return counter
 
-    OmegaConf.register_new_resolver("increment", increment)
+    OmegaConf.register_resolver("increment", increment)
     cfg = OmegaConf.create(cfg_data)
 
     assert OmegaConf.to_container(cfg, resolve=True) == expected


### PR DESCRIPTION

Undeprecate OmegaConf.register_resolver() and give it the modern resolver semantics previously exposed through register_new_resolver().

Deprecate register_new_resolver() as a compatibility alias, and deprecate legacy_register_resolver() while preserving its legacy string-only behavior.

Update resolver docs, notebook examples, tests, and the release fragment to point new code at register_resolver().

Fixes #969
