### PR TITLE
fix: preserve compatible values during DictConfig promotion

### DIFF
--- a/news/898.bugfix
+++ b/news/898.bugfix
@@ -1,0 +1,1 @@
+Preserve existing compatible values when promoting a ``DictConfig`` to a structured config.

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -642,13 +642,23 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
 
         from omegaconf import OmegaConf
 
+        previous_nodes = {
+            key: copy.deepcopy(self._get_node(key, validate_access=False))
+            for key in self.keys()
+        }
         proto: DictConfig = OmegaConf.structured(type_or_prototype)
         object_type = proto._metadata.object_type
-        # remove the type to prevent assignment validation from rejecting the promotion.
+        # Remove the type to prevent assignment validation from rejecting the promotion.
         proto._metadata.object_type = None
         self.merge_with(proto)
-        # restore the type.
         self._metadata.object_type = object_type
+
+        for key, node in previous_nodes.items():
+            if key in self:
+                try:
+                    self[key] = node
+                except ValidationError:
+                    pass
 
     def _set_value(self, value: Any, flags: Optional[Dict[str, bool]] = None) -> None:
         previous_content = self.__dict__["_content"]

--- a/tests/structured_conf/test_structured_config.py
+++ b/tests/structured_conf/test_structured_config.py
@@ -982,7 +982,7 @@ class TestConfigs:
         @dataclasses.dataclass
         class Foo:
             foo: pathlib.Path
-            bar: str
+            bar: str = "goodbye.err"
             qub: int = 5
 
         x = DictConfig({"foo": "hello.txt", "bar": "hello.txt"})
@@ -991,6 +991,7 @@ class TestConfigs:
 
         x._promote(Foo)
         assert isinstance(x.foo, pathlib.Path)
+        assert x.bar == "hello.txt"
         assert isinstance(x.bar, str)
         assert x.qub == 5
 


### PR DESCRIPTION
Fixes #898.

`DictConfig._promote()` currently merges the structured prototype into the existing config. That correctly adds missing default fields and converts compatible values, but it also lets dataclass defaults overwrite existing compatible values.

This keeps the existing promotion behavior for incompatible values by starting with the current merge direction, then restores only previous top-level values that still pass validation against the promoted structured config. That preserves values like an existing `str` field while still falling back to the target default for values that cannot be converted to the promoted type.

Verification:

```text
uv run --with pytest --with attrs --with PyYAML --with antlr4-python3-runtime --with-editable . pytest tests/structured_conf/test_structured_config.py -q -k promote
uv run --with pytest --with attrs --with PyYAML --with antlr4-python3-runtime --with-editable . pytest tests/structured_conf/test_structured_config.py -q
uv run --with black black --check omegaconf/dictconfig.py tests/structured_conf/test_structured_config.py
uv run --with isort isort --check-only omegaconf/dictconfig.py tests/structured_conf/test_structured_config.py
git diff --check
```