### PR TITLE
Fix structured config node reuse parent mutation

### DIFF
--- a/news/908.bugfix
+++ b/news/908.bugfix
@@ -1,0 +1,1 @@
+Fixed OmegaConf.structured() mutating existing OmegaConf nodes passed as structured config field values.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -340,6 +340,7 @@ def get_attr_class_fields(obj: Any) -> List["AttrAttribute[Any]"]:
 
 
 def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, Any]:
+    from omegaconf.base import Node
     from omegaconf.omegaconf import OmegaConf, _maybe_wrap
 
     flags = {"allow_objects": allow_objects} if allow_objects is not None else {}
@@ -377,6 +378,8 @@ def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, A
                 value = default.factory()
             else:
                 value = default
+        if isinstance(value, Node):
+            value = copy.deepcopy(value)
         if is_union_annotation(type_) and not is_supported_union_annotation(type_):
             e = ConfigValueError(
                 f"Unions of containers are not supported:\n{name}: {type_str(type_)}"  # noqa: E231
@@ -410,6 +413,7 @@ def get_dataclass_fields(obj: Any) -> List["dataclasses.Field[Any]"]:
 def get_dataclass_data(
     obj: Any, allow_objects: Optional[bool] = None
 ) -> Dict[str, Any]:
+    from omegaconf.base import Node
     from omegaconf.omegaconf import MISSING, OmegaConf, _maybe_wrap
 
     flags = {"allow_objects": allow_objects} if allow_objects is not None else {}
@@ -435,6 +439,8 @@ def get_dataclass_data(
                 value = field.default_factory()  # type: ignore
             else:
                 value = MISSING
+        if isinstance(value, Node):
+            value = copy.deepcopy(value)
 
         if is_union_annotation(type_) and not is_supported_union_annotation(type_):
             e = ConfigValueError(

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -5,10 +5,12 @@ import re
 import sys
 from collections import OrderedDict
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, List, Optional
 
+import attr
 import yaml
 from pytest import mark, param, raises
 
@@ -290,6 +292,40 @@ def test_create_node_parent_retained_on_create(node: Any) -> None:
     assert cfg2 == {"zonk": node}
     assert cfg1.foo._get_parent() == cfg1
     assert cfg1.foo._get_parent() is cfg1
+
+
+def test_structured_dataclass_node_parent_retained_on_create() -> None:
+    @dataclass
+    class User:
+        name: str = "Bond"
+
+    @dataclass
+    class HasUser:
+        user: User
+
+    cfg1 = OmegaConf.structured(HasUser(User()))
+    cfg2 = OmegaConf.structured(HasUser(cfg1.user))
+
+    assert cfg1.user._get_parent() is cfg1
+    assert cfg2.user._get_parent() is cfg2
+    assert cfg1.user is not cfg2.user
+
+
+def test_structured_attr_node_parent_retained_on_create() -> None:
+    @attr.s(auto_attribs=True)
+    class User:
+        name: str = "Bond"
+
+    @attr.s(auto_attribs=True)
+    class HasUser:
+        user: User
+
+    cfg1 = OmegaConf.structured(HasUser(User()))
+    cfg2 = OmegaConf.structured(HasUser(cfg1.user))
+
+    assert cfg1.user._get_parent() is cfg1
+    assert cfg2.user._get_parent() is cfg2
+    assert cfg1.user is not cfg2.user
 
 
 @mark.parametrize("node", [({"bar": 10}), ([1, 2, 3])])


### PR DESCRIPTION

Deep-copy existing OmegaConf nodes encountered as dataclass or attrs field values before wrapping them into a new structured config. This prevents _maybe_wrap from reparenting a node that still belongs to another config.

Add dataclass and attrs regression coverage for reusing an existing structured child node, and add the issue 908 news fragment.

Fixes #908
