### PR TITLE
Defer interpolation resolution when merging into a structured config (#1020)

### DIFF
--- a/news/1020.bugfix
+++ b/news/1020.bugfix
@@ -1,0 +1,1 @@
+Fix merging an interpolation into a structured config field failing with InterpolationKeyError or ValidationError; the interpolation is now kept unresolved and resolved lazily against the merged result.

--- a/omegaconf/basecontainer.py
+++ b/omegaconf/basecontainer.py
@@ -434,14 +434,20 @@ class BaseContainer(Container, ABC):
 
             src_vk = get_value_kind(src_node)
             src_node_missing = src_vk is ValueKind.MANDATORY_MISSING
+            # An interpolation source must be merged as-is and resolved lazily:
+            # its type is not known until resolution, and resolving it here (in
+            # the source's context, which may lack the referenced keys) is wrong
+            # (issue #1020).
+            src_node_interpolation = src_vk is ValueKind.INTERPOLATION
 
-            if isinstance(dest_node, DictConfig):
+            if isinstance(dest_node, DictConfig) and not src_node_interpolation:
                 dest_node._validate_merge(value=src_node)
 
             if (
                 isinstance(dest_node, Container)
                 and dest_node._is_none()
                 and not src_node_missing
+                and not src_node_interpolation
                 and not _is_none(src_node, resolve=True)
             ):
                 expand(dest_node)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -277,39 +277,6 @@ class InterpolationDict:
     dict: Dict[str, int] = II("optimization.lr")
 
 
-# Structures for merging an interpolation into a structured config (issue #1020).
-@dataclass
-class TableConfig:
-    rows: int = 1
-
-
-@dataclass
-class DatabaseConfig:
-    table_cfg: TableConfig = field(default_factory=TableConfig)
-
-
-@dataclass
-class ModelConfigOptional:
-    data_source: Optional[TableConfig] = None
-
-
-@dataclass
-class ModelConfigStructured:
-    data_source: TableConfig = field(default_factory=TableConfig)
-
-
-@dataclass
-class ServerConfigOptional:
-    db: DatabaseConfig = field(default_factory=DatabaseConfig)
-    model: ModelConfigOptional = field(default_factory=ModelConfigOptional)
-
-
-@dataclass
-class ServerConfigStructured:
-    db: DatabaseConfig = field(default_factory=DatabaseConfig)
-    model: ModelConfigStructured = field(default_factory=ModelConfigStructured)
-
-
 @dataclass
 class Str2Int(Dict[str, int]):
     pass

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -277,6 +277,39 @@ class InterpolationDict:
     dict: Dict[str, int] = II("optimization.lr")
 
 
+# Structures for merging an interpolation into a structured config (issue #1020).
+@dataclass
+class TableConfig:
+    rows: int = 1
+
+
+@dataclass
+class DatabaseConfig:
+    table_cfg: TableConfig = field(default_factory=TableConfig)
+
+
+@dataclass
+class ModelConfigOptional:
+    data_source: Optional[TableConfig] = None
+
+
+@dataclass
+class ModelConfigStructured:
+    data_source: TableConfig = field(default_factory=TableConfig)
+
+
+@dataclass
+class ServerConfigOptional:
+    db: DatabaseConfig = field(default_factory=DatabaseConfig)
+    model: ModelConfigOptional = field(default_factory=ModelConfigOptional)
+
+
+@dataclass
+class ServerConfigStructured:
+    db: DatabaseConfig = field(default_factory=DatabaseConfig)
+    model: ModelConfigStructured = field(default_factory=ModelConfigStructured)
+
+
 @dataclass
 class Str2Int(Dict[str, int]):
     pass

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -62,8 +62,6 @@ from tests import (
     OuterB,
     Package,
     Plugin,
-    ServerConfigOptional,
-    ServerConfigStructured,
     User,
     Users,
 )
@@ -1591,25 +1589,23 @@ def test_merge_with_other_as_interpolation(
 
 @mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
 @mark.parametrize(
-    "server",
-    [ServerConfigOptional, ServerConfigStructured],
+    "model",
+    [C(), B(x=A())],
     ids=["optional_none_target", "structured_target"],
 )
-def test_merge_interpolation_into_structured_config(merge: Any, server: Any) -> None:
-    # Merging an interpolation into a structured-config field must keep it
-    # unresolved (resolved lazily against the merged result) instead of
-    # resolving it in the source's context or type-checking the raw string.
+def test_merge_interpolation_into_structured_config(merge: Any, model: Any) -> None:
+    # An interpolation merged into a structured-config field must be kept
+    # unresolved (resolved lazily against the merged result) instead of being
+    # resolved in the source's context or type-checked as a raw string.
     # https://github.com/omry/omegaconf/issues/1020
     res = merge(
-        server,
-        {"db": {"table_cfg": {"rows": 9}}},
-        {"model": {"data_source": "${db.table_cfg}"}},
+        {"src": A, "model": model},
+        {"src": {"a": 9}},
+        {"model": {"x": "${src}"}},
     )
-    assert OmegaConf.is_interpolation(res.model, "data_source")
-    assert res.model.data_source == {"rows": 9}
-    assert OmegaConf.to_container(res, resolve=True)["model"]["data_source"] == {
-        "rows": 9
-    }
+    assert OmegaConf.is_interpolation(res.model, "x")
+    assert OmegaConf.get_type(res.model.x) is A
+    assert res.model.x.a == 9
 
 
 @mark.parametrize(

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -62,6 +62,8 @@ from tests import (
     OuterB,
     Package,
     Plugin,
+    ServerConfigOptional,
+    ServerConfigStructured,
     User,
     Users,
 )
@@ -1585,6 +1587,29 @@ def test_merge_with_other_as_interpolation(
 ) -> None:
     res = merge(dst, other)
     assert OmegaConf.is_interpolation(res, node)
+
+
+@mark.parametrize("merge", [OmegaConf.merge, OmegaConf.unsafe_merge])
+@mark.parametrize(
+    "server",
+    [ServerConfigOptional, ServerConfigStructured],
+    ids=["optional_none_target", "structured_target"],
+)
+def test_merge_interpolation_into_structured_config(merge: Any, server: Any) -> None:
+    # Merging an interpolation into a structured-config field must keep it
+    # unresolved (resolved lazily against the merged result) instead of
+    # resolving it in the source's context or type-checking the raw string.
+    # https://github.com/omry/omegaconf/issues/1020
+    res = merge(
+        server,
+        {"db": {"table_cfg": {"rows": 9}}},
+        {"model": {"data_source": "${db.table_cfg}"}},
+    )
+    assert OmegaConf.is_interpolation(res.model, "data_source")
+    assert res.model.data_source == {"rows": 9}
+    assert OmegaConf.to_container(res, resolve=True)["model"]["data_source"] == {
+        "rows": 9
+    }
 
 
 @mark.parametrize(


### PR DESCRIPTION
Fixes #1020

### Problem

Merging a config containing an interpolation key into a structured config fails in the two ways described in the issue:

```python
cfg = OmegaConf.merge(
    ServerConfig,
    {"db": DatabaseConfig},
    {"model": {"data_source": "${db.table_cfg}"}},
)
```

- `Optional[TableConfig] = None` target → `InterpolationKeyError: Interpolation key 'db.table_cfg' not found`
- `TableConfig` target → `ValidationError: Merge error: str is not a subclass of TableConfig. value: ${db.table_cfg}`

### Cause

In `BaseContainer._map_merge`, for each source key the merge eagerly inspects the source node:

- `_validate_merge(value=src_node)` type-checks the raw `"${db.table_cfg}"` string (whose `get_type` is `str`) against the structured target type → subclass `ValidationError`.
- `_is_none(src_node, resolve=True)` **resolves** the interpolation to decide whether to `expand()` the destination — but it resolves in the *source's* context, which doesn't contain `db` yet → `InterpolationKeyError`.

An interpolation's type isn't known until resolution, and it must be resolved lazily against the *merged* result.

### Fix

Skip both eager steps when the source node is an interpolation (`get_value_kind(src_node) is ValueKind.INTERPOLATION`); it then falls through to normal assignment and resolves correctly afterwards.

### Verification

- Both failure modes now produce `{'model': {'data_source': {'rows': 1}}}` and resolve to the referenced value.
- Added `test_merge_interpolation_into_structured_config` (both target shapes × `merge`/`unsafe_merge`), which fails on the base branch and passes with this change.
- Full test suite: 8205 passed, zero regressions. `black`/`flake8` clean.