### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/subprojects/omegaconf-pydevd/pydevd_plugins/__init__.py
+++ b/subprojects/omegaconf-pydevd/pydevd_plugins/__init__.py
@@ -1,6 +1,0 @@
-try:
-    __import__("pkg_resources").declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-
-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/subprojects/omegaconf-pydevd/pydevd_plugins/extensions/__init__.py
+++ b/subprojects/omegaconf-pydevd/pydevd_plugins/extensions/__init__.py
@@ -1,6 +1,0 @@
-try:
-    __import__("pkg_resources").declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-
-    __path__ = pkgutil.extend_path(__path__, __name__)


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Low` | **File**: `subprojects/omegaconf-pydevd/pydevd_plugins/extensions/__init__.py:L1`

The `__init__.py` files for `pydevd_plugins` and its `extensions` subpackage use `pkg_resources.declare_namespace(__name__)`. `pkg_resources` is part of `setuptools` and its use is discouraged in modern Python. It can also lead to import issues and is a potential vector for dependency confusion attacks if not handled carefully.

## Solution

Migrate to native namespace packages (PEP 420) by removing the `__init__.py` file or by using `importlib.util` if explicit namespace package declaration is still required. This avoids the dependency on `setuptools` at runtime.

## Changes

- `subprojects/omegaconf-pydevd/pydevd_plugins/extensions/__init__.py` (modified)
- `subprojects/omegaconf-pydevd/pydevd_plugins/__init__.py` (modified)