### PR TITLE
Migrate Python tooling to Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-exclude = .git,.nox,.tox,.venv,omegaconf/grammar/gen,build,omegaconf/vendor
-max-line-length = 119
-select = E,F,W,C
-ignore=W503,E203,E701,E704

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,5 +16,11 @@ A clear and concise description of what you want to happen.
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
+**Are you willing to open a pull request?** (See [CONTRIBUTING](https://github.com/omry/omegaconf/blob/main/CONTRIBUTING.md))
+
+For non-trivial features, API changes, or behavior changes, please wait for
+maintainer feedback on the direction before starting substantial implementation
+work.
+
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,14 @@
 
 (Write your motivation for proposed changes here.)
 
-### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/master/CONTRIBUTING.md)?
+### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/main/CONTRIBUTING.md)?
 
 Yes/No
+
+### For any non-trivial change: is there an issue or design discussion where maintainers agreed on the direction?
+
+(Link to the issue or discussion. Pull requests without prior design alignment
+may be redirected to discussion before implementation review.)
 
 ## Test Plan
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+# Copilot instructions
+
+When generating code or reviewing pull requests for this repository, use
+`CONTRIBUTING.md` as the source of truth for contributor requirements.
+
+For pull request reviews, check the changed files against the contributor
+guidelines and call out only actionable gaps, especially:
+
+- missing or insufficient tests for code changes;
+- missing documentation updates for API or behavior changes;
+- missing news fragments for non-trivial user-visible changes;
+- news fragments with the wrong filename or category;
+- non-trivial changes that do not link to prior maintainer agreement in an
+  issue or design discussion;
+- validation claims that are not supported by the tests or checks shown in the
+  pull request.
+
+Do not request a news fragment for developer-only tooling, repository
+maintenance, or CI-only changes unless the change affects the shipped product
+experience.
+
+Keep review comments specific and actionable. Prefer pointing to the relevant
+guideline in `CONTRIBUTING.md` over restating the whole policy.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,17 +5,11 @@ exclude: ^(temp/|omegaconf/vendor/)
 
 # Hook versions should match those in requirements/dev.txt
 repos:
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.22
     hooks:
-      - id: isort
-
-  - repo: https://github.com/psf/black
-    rev: 24.2.0
-    hooks:
-      - id: black
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
+      - id: ruff-check
+        args: [--fix]
+        types_or: [python, pyi]
+      - id: ruff-format
+        types_or: [python, pyi, jupyter]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,19 +87,18 @@ When asked to create a reproduction for an issue, place files under `temp/`:
 
 ## Linting and formatting
 
-This project uses several linting and formatting tools. Run them via `nox -s lint` or individually:
+Run linting and formatting checks via `nox -s lint` or individually:
 
-- `black .` / `black --check .` — code formatting
-- `flake8` — style and error checks (may need `--jobs=1` on some Python versions)
-- `isort . --check` — import sorting
+- `ruff format .` / `ruff format --check .` — code formatting
+- `ruff check .` / `ruff check --fix .` — linting and import sorting
 - `pyrefly check` — static type checking
 
-All four must pass before a change is considered clean.
+All three checks must pass before a change is considered clean.
 
 ## Environment and hooks
 
 - Use the repo-local `.venv` directory as the default development environment.
-- Prefer `.venv/bin/python -m ...` for Python module commands and `.venv/bin/<tool>` for installed tools such as `pytest`, `nox`, `black`, and `isort`.
+- Prefer `.venv/bin/python -m ...` for Python module commands and `.venv/bin/<tool>` for installed tools such as `pytest`, `nox`, and `ruff`.
 - If `.venv` is missing and environment setup is part of the task, create it with `python3 -m venv .venv` and install development dependencies with `.venv/bin/python -m pip install -r requirements/dev.txt -e .`.
 - When validating contributor setup, shell initialization, or hook behavior, verify it from the same `.venv` environment a developer would actually use, such as a normal shell session or `sl commit`, not only from a temporary sandbox-only environment.
 - Prefer hooks that do not depend on nontrivial user-environment tooling.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,24 @@ To build the docs execute `nox -s docs` or `make`(inside docs folder). Make give
 
 #### Submitting a PR
 
+We welcome your pull requests.
+
 When submitting a PR please ensure that it includes:
 - automated tests for any new feature or bugfix
 - documentation for any user-facing change
-- a one-line news fragment under the `news` folder (valid extensions are: `.feature`, `.bugfix`, `.api_change`, `.docs`, `.misc`)
+- a one-line news fragment under the `news` folder for any non-trivial
+  user-visible change. Use the issue or pull request number as the filename,
+  with one of these extensions: `.feature`, `.bugfix`, `.api_change`, `.docs`,
+  `.misc` (for example, `news/1234.bugfix`).
+
+Developer-only tooling, repository maintenance, and CI-only changes do not need
+a news fragment unless they affect the shipped product experience.
+
+For any non-trivial change, please open an issue or design discussion and wait
+for maintainer feedback before starting substantial implementation work. Pull
+requests in these areas should link to the issue or discussion where the
+direction was agreed. Pull requests without prior design alignment may be
+redirected to discussion before implementation review.
 
 #### Modifying the Jupyter notebook
 
@@ -109,7 +123,7 @@ OmegaConf uses GitHub Actions with PyPI Trusted Publishers for automated release
 
 4. Create the `pypi-publish-dev` environment in GitHub repository settings:
    - Allow publishing from the development branch you use for dev releases
-     (for example `master`)
+     (for example `main`)
    - Add protection rules (e.g., require manual approval)
 
 **Official release process:**
@@ -134,10 +148,14 @@ The workflow handles:
 - Publishing to PyPI via Trusted Publishers (no API tokens needed)
 
 **Development release process:**
-1. Bump the dev version with `bump-my-version bump pre_n`
-2. Commit changes and push to the branch you use for dev releases
-3. Run the `Publish dev release to PyPI` workflow manually from GitHub Actions
-4. Approve the `pypi-publish-dev` environment if required
+1. Ensure the dev version to publish is committed and pushed to the branch you
+   use for dev releases.
+2. Run the `Publish dev release to PyPI` workflow manually from GitHub Actions,
+   or run `gh workflow run publish_dev.yml --ref <branch>`.
+3. Approve the `pypi-publish-dev` environment if required.
+4. After the release publishes successfully, advance to the next dev version
+   with `bump-my-version bump pre_n`.
+5. Commit and push the version bump.
 
 **Manual release (fallback):**
 If you need to publish manually:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,12 +54,11 @@ Sessions defined in /home/omry/dev/omegaconf/noxfile.py:
 * test_jupyter_notebook-3.10
 ```
 
-To run a specific session use `-s`, for example `nox -s lint` will run linting
+To run a specific session use `-s`, for example `nox -s lint` will run linting.
 
-
-OmegaConf is formatted with black, to format your code automatically use `black .`
-
-Imports are sorted using isort, use `isort .` to sort all imports prior to pushing.
+OmegaConf uses Ruff for formatting, linting, and import sorting. Run
+`ruff format .` to format code and `ruff check .` to lint it. Use
+`ruff check --fix .` to apply import-sorting fixes.
 
 To build the docs execute `nox -s docs` or `make`(inside docs folder). Make gives you different options, for example, you can build the docs as html files with `make html`. Once the docs are built you can open `index.html` in the build directory to view the generated docs with your browser.
 

--- a/build_helpers/__init__.py
+++ b/build_helpers/__init__.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F401, I001
+
 # Order of imports is important (see warning otherwise when running tests)
-import setuptools  # isort:skip # noqa
-import distutils  # isort:skip # noqa
+import setuptools
+import distutils

--- a/build_helpers/get_vendored.py
+++ b/build_helpers/get_vendored.py
@@ -6,10 +6,12 @@ from itertools import chain
 from pathlib import Path
 from typing import Callable, FrozenSet, Generator, List, Set, Tuple, Union
 
-WHITELIST = {'README.txt', '__init__.py', 'vendor.txt'}
+WHITELIST = {"README.txt", "__init__.py", "vendor.txt"}
 
 
-def delete_all(*paths: Path, whitelist: Union[Set[str], FrozenSet[str]] = frozenset()) -> None:
+def delete_all(
+    *paths: Path, whitelist: Union[Set[str], FrozenSet[str]] = frozenset()
+) -> None:
     """Clear all the items in each of the indicated paths, except for elements listed
     in the whitelist"""
     for item in paths:
@@ -34,13 +36,15 @@ def iter_subtree(path: Path, depth: int = 0) -> Generator[Tuple[Path, int], None
 
 def patch_vendor_imports(file: Path, replacements: List[Callable[[str], str]]) -> None:
     """Apply a list of replacements/patches to a given file"""
-    text = file.read_text('utf8')
+    text = file.read_text("utf8")
     for replacement in replacements:
         text = replacement(text)
-    file.write_text(text, 'utf8')
+    file.write_text(text, "utf8")
 
 
-def find_vendored_libs(vendor_dir: Path, whitelist: Set[str]) -> Tuple[List[str], List[Path]]:
+def find_vendored_libs(
+    vendor_dir: Path, whitelist: Set[str]
+) -> Tuple[List[str], List[Path]]:
     vendored_libs = []
     paths = []
     for item in vendor_dir.iterdir():
@@ -56,23 +60,31 @@ def find_vendored_libs(vendor_dir: Path, whitelist: Set[str]) -> Tuple[List[str]
 
 def vendor(vendor_dir: Path, relative_imports: bool = False) -> None:
     # target package is <parent>.<vendor_dir>; foo/vendor -> foo.vendor
-    pkgname = f'{vendor_dir.parent.name}.{vendor_dir.name}'
+    pkgname = f"{vendor_dir.parent.name}.{vendor_dir.name}"
 
     # remove everything
     delete_all(*vendor_dir.iterdir(), whitelist=WHITELIST)
 
     # install with pip
-    subprocess.run([
-        'pip', 'install', '-t', str(vendor_dir),
-        '-r', str(vendor_dir / 'vendor.txt'),
-        '--no-compile', '--no-deps'
-    ])
+    subprocess.run(
+        [
+            "pip",
+            "install",
+            "-t",
+            str(vendor_dir),
+            "-r",
+            str(vendor_dir / "vendor.txt"),
+            "--no-compile",
+            "--no-deps",
+        ]
+    )
 
     # delete stuff that's not needed
     delete_all(
-        *vendor_dir.glob('*.dist-info'),
-        *vendor_dir.glob('*.egg-info'),
-        vendor_dir / 'bin')
+        *vendor_dir.glob("*.dist-info"),
+        *vendor_dir.glob("*.egg-info"),
+        vendor_dir / "bin",
+    )
 
     vendored_libs, paths = find_vendored_libs(vendor_dir, WHITELIST)
 
@@ -81,41 +93,45 @@ def vendor(vendor_dir: Path, relative_imports: bool = False) -> None:
         for lib in vendored_libs:
             replacements += (
                 partial(  # import bar -> import foo.vendor.bar
-                    re.compile(r'(^\s*)import {}\n'.format(lib), flags=re.M).sub,
-                    r'\1from {} import {}\n'.format(pkgname, lib)
+                    re.compile(r"(^\s*)import {}\n".format(lib), flags=re.M).sub,
+                    r"\1from {} import {}\n".format(pkgname, lib),
                 ),
                 partial(  # from bar -> from foo.vendor.bar
-                    re.compile(r'(^\s*)from {}(\.|\s+)'.format(lib), flags=re.M).sub,
-                    r'\1from {}.{}\2'.format(pkgname, lib)
+                    re.compile(r"(^\s*)from {}(\.|\s+)".format(lib), flags=re.M).sub,
+                    r"\1from {}.{}\2".format(pkgname, lib),
                 ),
             )
 
     for file, depth in chain.from_iterable(map(iter_subtree, paths)):
         if relative_imports:
-            pkgname = '.' * (depth - 1)
+            pkgname = "." * (depth - 1)
             replacements = []
             for lib in vendored_libs:
                 replacements += (
                     partial(
-                        re.compile(r'(^\s*)import {}\n'.format(lib), flags=re.M).sub,
-                        r'\1from {} import {}\n'.format(pkgname, "")
+                        re.compile(r"(^\s*)import {}\n".format(lib), flags=re.M).sub,
+                        r"\1from {} import {}\n".format(pkgname, ""),
                     ),
                     partial(
-                        re.compile(r'^from {}(\s+)'.format(lib), flags=re.M).sub,
-                        r'from .{}\1'.format(pkgname)
+                        re.compile(r"^from {}(\s+)".format(lib), flags=re.M).sub,
+                        r"from .{}\1".format(pkgname),
                     ),
                     partial(
-                        re.compile(r'(^\s*)from {}(\.+)'.format(lib), flags=re.M).sub,
-                        r'\1from {}\2'.format(pkgname)
+                        re.compile(r"(^\s*)from {}(\.+)".format(lib), flags=re.M).sub,
+                        r"\1from {}\2".format(pkgname),
                     ),
                 )
         patch_vendor_imports(file, replacements)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # this assumes this is a script in `build_helpers`
-    here = Path('__file__').resolve().parent
-    vendor_dir = here / 'omegaconf' / 'vendor'
-    assert (vendor_dir / 'vendor.txt').exists(), 'omegaconf/vendor/vendor.txt file not found'
-    assert (vendor_dir / '__init__.py').exists(), 'omegaconf/vendor/__init__.py file not found'
+    repo_root = Path(__file__).resolve().parent.parent
+    vendor_dir = repo_root / "omegaconf" / "vendor"
+    assert (vendor_dir / "vendor.txt").exists(), (
+        "omegaconf/vendor/vendor.txt file not found"
+    )
+    assert (vendor_dir / "__init__.py").exists(), (
+        "omegaconf/vendor/__init__.py file not found"
+    )
     vendor(vendor_dir, relative_imports=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,11 +66,10 @@ def version_string_to_tuple(version: str) -> Tuple[int, ...]:
 
 @nox.session(python=["3.10"])  # type: ignore
 def fix(session: Session) -> None:
-    """Auto-fix formatting issues with isort and black."""
+    """Auto-fix formatting and import sorting issues with Ruff."""
     deps(session, editable_install=True)
-    session.run("isort", ".")
-    session.run("black", ".")
-    session.run("black", "docs/notebook/Tutorial.ipynb")
+    session.run("ruff", "check", ".", "--fix")
+    session.run("ruff", "format", ".")
 
 
 @nox.session(python=["3.10"])  # type: ignore
@@ -78,10 +77,8 @@ def lint(session: Session) -> None:
     # Note: Linting only runs on Python 3.10 to avoid running it on every CI job
     deps(session, editable_install=True)
     session.run("pyrefly", "check", silent=True)
-    session.run("isort", ".", "--check", silent=True)
-    session.run("black", "--check", ".", silent=True)
-    session.run("black", "--check", "docs/notebook/Tutorial.ipynb", silent=True)
-    session.run("flake8")
+    session.run("ruff", "check", ".", silent=True)
+    session.run("ruff", "format", "--check", ".", silent=True)
 
 
 @nox.session(python=PYTHON_VERSIONS)  # type: ignore

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -95,7 +95,8 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
             return res
         else:
             assert isinstance(child, TerminalNode) and isinstance(
-                child.symbol.text, str  # type: ignore[attr-defined]
+                child.symbol.text,  # type: ignore[attr-defined]
+                str,
             )
             return child.symbol.text  # type: ignore[attr-defined]
 

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -638,9 +638,9 @@ class OmegaConf:
         )
         assert callable(resolver), "resolver must be callable"
         # noinspection PyProtectedMember
-        assert (
-            name not in BaseContainer._resolvers
-        ), f"resolver '{name}' is already registered"
+        assert name not in BaseContainer._resolvers, (
+            f"resolver '{name}' is already registered"
+        )
 
         def resolver_wrapper(
             config: BaseContainer,
@@ -1144,8 +1144,7 @@ class OmegaConf:
             next_root, key_ = _select_one(root, k, throw_on_missing=False)
             if isinstance(next_root, Container) and next_root._is_none():
                 raise ConfigTypeError(
-                    f"Cannot set '{key}' because"
-                    f" '{root._get_full_key(key_)}' is None"
+                    f"Cannot set '{key}' because '{root._get_full_key(key_)}' is None"
                 )
             if not isinstance(next_root, Container):
                 if force_add:
@@ -1157,9 +1156,9 @@ class OmegaConf:
 
         last = split[-1]
 
-        assert isinstance(
-            root, Container
-        ), f"Unexpected type for root: {type(root).__name__}"
+        assert isinstance(root, Container), (
+            f"Unexpected type for root: {type(root).__name__}"
+        )
 
         last_key: Union[str, int] = last
         if OmegaConf.is_sequence(root):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,24 @@
-[tool.black]
-exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | omegaconf/grammar/gen
-    | omegaconf/vendor
-    | \.nox
-    | \.venv
-    | build
-    | subprojects
-    | temp
-    | vendor
-    | \.claude
-  )
-)
-'''
-
-[tool.isort]
-skip_glob = [
-    ".venv/*",
-    "temp/*",
-    "omegaconf/vendor/*",
-    "subprojects/*",
-    ".claude/*",
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+include = ["*.py", "*.pyi", "*.ipynb"]
+extend-exclude = [
+    ".claude",
+    ".sl",
+    "omegaconf/grammar/gen",
+    "omegaconf/vendor",
+    "subprojects",
+    "temp",
 ]
+
+[tool.ruff.lint]
+exclude = ["docs/notebook/Tutorial.ipynb"]
+fixable = ["I"]
+ignore = ["E501", "E701", "E714", "E721"]
+select = ["E", "F", "I", "W"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["omegaconf"]
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=append -Werror"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,19 +1,16 @@
 -r base.txt
 -r docs.txt
 attrs
-black[jupyter]==26.3.1
 build
 bump-my-version
 coveralls
-flake8==7.3.0
-isort==5.13.2
 nox[pbs]
 pre-commit
-pyflakes
 pyrefly==0.62.0
 pytest
 pytest-benchmark
 pytest-mock
+ruff==0.15.22
 towncrier
 twine
 pydevd

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,2 @@
 [aliases]
 test=pytest
-
-[flake8]
-max-line-length = 88
-extend-ignore = E203, E501
-exclude = .git,.eggs,.nox,.venv,build,temp,vendor,subprojects,omegaconf/grammar/gen,omegaconf/vendor

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -20,10 +20,13 @@ from omegaconf import (
     ValidationError,
 )
 from omegaconf._utils import _ensure_container
-from omegaconf.errors import InterpolationKeyError
-from omegaconf.errors import InterpolationResolutionError
+from omegaconf.errors import (
+    InterpolationKeyError,
+    InterpolationResolutionError,
+    InterpolationValidationError,
+    ReadonlyConfigError,
+)
 from omegaconf.errors import InterpolationResolutionError as IRE
-from omegaconf.errors import InterpolationValidationError, ReadonlyConfigError
 from omegaconf.nodes import InterpolationResultNode
 from tests import (
     Color,
@@ -340,10 +343,12 @@ def test_interpolation_type_validated_ok(
             "age",
             raises(
                 InterpolationValidationError,
-                match=re.escape(dedent("""\
+                match=re.escape(
+                    dedent("""\
                         Value 'seven' of type 'str' could not be converted to Integer
                             full_key: age
-                        """)),
+                        """)
+                ),
             ),
             id="type_mismatch_resolver",
         ),

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -349,9 +349,11 @@ def test_nested_list_assign_illegal_value() -> None:
     c = OmegaConf.create({"a": [None]})
     with raises(
         UnsupportedValueType,
-        match=re.escape(dedent("""\
+        match=re.escape(
+            dedent("""\
                 Value 'IllegalType' is not a supported primitive type
-                    full_key: a[0]""")),
+                    full_key: a[0]""")
+        ),
     ):
         c.a[0] = IllegalType()
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -439,7 +439,8 @@ def test_create_float_yaml() -> None:
     #   c_s not parsed as float. antlr does parse as float
     #   e_s and f_s not parsed. antlr does parse as float
     #   h_f and i_f parsed as float. antlr does not parse as float
-    cfg = OmegaConf.create(dedent("""\
+    cfg = OmegaConf.create(
+        dedent("""\
             a_s: 0_e0
             b_i: 0_0
             c_s: 1_0e1_0
@@ -449,7 +450,8 @@ def test_create_float_yaml() -> None:
             g_f: 1_1_2.1
             h_f: 1__2.1
             i_f: 1.2_
-            """))
+            """)
+    )
     assert cfg == {
         "a_s": "0_e0",
         "b_i": 0,
@@ -699,16 +701,20 @@ def test_yaml_merge_sequence_error() -> None:
 
 def test_yaml_merge_invalid_value() -> None:
     with raises(yaml.constructor.ConstructorError):
-        OmegaConf.create(dedent("""\
+        OmegaConf.create(
+            dedent("""\
             a:
                 <<: 123
-            """))
+            """)
+        )
 
 
 def test_yaml_value_key() -> None:
-    cfg = OmegaConf.create(dedent("""\
+    cfg = OmegaConf.create(
+        dedent("""\
         = : value
-        """))
+        """)
+    )
     assert cfg == {"=": "value"}
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -680,11 +680,13 @@ def test_merge_missing_dict_annotation_keeps_structured_child_ref_types(
             ),
             raises(
                 ValidationError,
-                match=re.escape(dedent("""\
+                match=re.escape(
+                    dedent("""\
                         field 'foo' is not Optional
                             full_key: foo
                             reference_type=User
-                            object_type=User""")),
+                            object_type=User""")
+                ),
             ),
             None,
             None,
@@ -741,10 +743,12 @@ def test_merge_missing_dict_annotation_keeps_structured_child_ref_types(
             (DictConfig(content={}, element_type=User), {"foo": None}),
             raises(
                 ValidationError,
-                match=re.escape(dedent("""\
+                match=re.escape(
+                    dedent("""\
                         field 'foo' is not Optional
                             full_key: foo
-                            object_type=dict""")),
+                            object_type=dict""")
+                ),
             ),
             None,
             None,
@@ -795,11 +799,13 @@ def test_merge_missing_dict_annotation_keeps_structured_child_ref_types(
             (DictConfig(content={"foo": MISSING}, element_type=User), {"foo": None}),
             raises(
                 ValidationError,
-                match=re.escape(dedent("""\
+                match=re.escape(
+                    dedent("""\
                         field 'foo' is not Optional
                             full_key: foo
                             reference_type=User
-                            object_type=NoneType""")),
+                            object_type=NoneType""")
+                ),
             ),
             None,
             None,


### PR DESCRIPTION

Replace Black, isort, Flake8, and Pyflakes with Ruff across development dependencies, pre-commit hooks, and nox lint and fix sessions.

Configure Ruff for OmegaConf source and notebook formatting while excluding generated, vendored, scratch, and subproject code. Update contributor guidance and apply Ruff formatting and import normalization.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/omry/omegaconf/pull/1342).
* __->__ #1342
* #1341