### PR TITLE
Add resolver annotation validation

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -10,6 +10,7 @@ documents from [`TEMPLATE.md`](TEMPLATE.md).
 
 ## Active design guidance
 
+- [Resolver annotation validation](resolver-annotation-validation.md)
 - [TupleConfig](tuple-config.md)
 
 ## Draft and planned design work

--- a/docs/design/resolver-annotation-validation.md
+++ b/docs/design/resolver-annotation-validation.md
@@ -1,0 +1,174 @@
+---
+status: Active
+updated: 2026-07-20
+summary: Runtime validation and staged enforcement of custom-resolver annotations.
+---
+
+# Resolver Annotation Validation
+
+Tracking issue: [issue #612](https://github.com/omry/omegaconf/issues/612)
+
+## Summary
+
+OmegaConf will optionally validate custom-resolver arguments and return values
+against the resolver's parameter and return annotations. Validation defaults to
+advisory in 2.4 and enforced in 2.5; both modes remain available explicitly.
+
+Validation observes the actual values passed to and returned by the resolver.
+It never coerces values and remains separate from validation and conversion of
+resolver results by the interpolation's target node.
+
+## Problem
+
+`OmegaConf.register_resolver()` already inspects resolver signatures to detect
+the special `_parent_`, `_node_`, and `_root_` parameters, but ordinary
+annotations have no runtime effect. For example, a parameter annotated as
+`int` may currently receive a quoted string, a boolean, or a list, and a
+resolver annotated to return `int` may return another type unchecked.
+
+Type checkers can detect many return mismatches in statically analyzable
+resolver implementations. Runtime validation also covers dynamically registered
+or untyped callables and resolver composition expressed in configuration, such
+as `${outer:${inner:}}`. Because mismatches can originate in either composed
+configuration or resolver Python code, advisory validation remains useful
+beyond the default transition.
+
+The proposal follows Hydra's typed grammar-function registry, with a staged
+rollout because OmegaConf resolvers are a public extension point.
+
+## Public interface and rollout
+
+Add a keyword-only
+`annotation_validation: Literal["off", "warn", "error"]` parameter to
+`OmegaConf.register_resolver()`. `"off"` disables validation, `"warn"` emits
+`UserWarning` on a mismatch and continues with the original argument or result,
+and `"error"` raises `TypeError`. Registration errors expose that `TypeError`
+directly. A mismatch during interpolation resolution is exposed to callers as
+an `InterpolationResolutionError` caused by the `TypeError`. The default is
+`"warn"` in 2.4 and `"error"` in 2.5; explicit modes behave identically in
+both releases. Other values are invalid.
+
+## Validation model
+
+Unannotated parameters, an absent return annotation, and `Any` are skipped.
+`_parent_`, `_node_`, and `_root_` are supplied by OmegaConf and excluded from
+parameter validation.
+
+At resolution time:
+
+1. Evaluate argument interpolations through the existing grammar machinery,
+   producing the values passed to the resolver.
+2. Bind them to the signature, apply omitted parameter defaults, and validate
+   annotated ordinary and variadic parameters.
+3. Apply the configured policy to an argument mismatch.
+4. Consult the resolver cache, then invoke the resolver on a cache miss.
+5. Validate the cached or newly computed result against the return annotation.
+6. Apply the configured policy to a return mismatch, cache a newly computed
+   result, and return it unchanged.
+
+Argument validation precedes cache lookup. Return validation applies to both
+newly computed and cached results, so a cache populated before resolver
+replacement cannot bypass the current resolver's annotation. A cached-result
+mismatch explicitly identifies the cache as the value's source. In `"error"`
+mode, the resolver is not invoked and the cache remains unchanged. The caller
+can clear the config's entire resolver cache with `OmegaConf.clear_cache(cfg)`;
+there is no dedicated public operation for clearing one resolver or cache
+entry. In `"error"` mode, a mismatched new result is not cached. Validation
+never converts values. Primitive matching is strict (`bool` does not satisfy
+`int`). Initial container validation is shallow: parameterized containers check
+their outer runtime kind without traversing or resolving elements. Abstract
+collection annotations follow their runtime ABC relationships.
+
+In `"error"` mode, an uninspectable callable or unresolvable parameter or
+return annotation is a registration error because validation cannot be
+guaranteed. `"warn"` emits `UserWarning` at registration and permits the
+callable; `"off"` permits it without inspection.
+
+## Interpolation interactions
+
+Parameter validation applies to the actual value the resolver receives after
+argument interpolations have been evaluated. Existing distinctions remain
+observable:
+
+| Resolver argument expression | Runtime value presented for validation |
+| --- | --- |
+| `${resolver:${integer}}` | `int` |
+| `${resolver:"${integer}"}` | `str` |
+| `${resolver:value-${integer}}` | `str` |
+| `${resolver:[1, 2]}` | native `list` |
+| `${resolver:${list_node}}` | `ListConfig` |
+| `${resolver:${tuple_node}}` | `TupleConfig` |
+| `${resolver:${returns_list:}}` | the inner resolver's native `list` |
+
+Nested resolvers validate independently from the inside out. The inner
+resolver's arguments are validated first, followed by its return value; only
+then is the result presented for validation as an argument to the outer
+resolver. This covers resolver composition embedded in configuration, which
+type checkers cannot analyze.
+
+OmegaConf containers remain distinct from native containers, and validation
+uses the actual runtime type without treating the paired types as
+interchangeable. Resolver authors should annotate the precise representation
+they expect. A resolver that intentionally supports both can declare that with
+`DictConfig | dict`, `ListConfig | list`, `TupleConfig | tuple`, or an
+appropriate abstract collection annotation. Quoting or concatenating an
+interpolation produces a string before validation. Failed argument
+interpolation prevents validation and resolver invocation.
+
+Resolver results still pass through the target node's existing validation and
+conversion after return-annotation validation. Return validation enforces the
+resolver's declared contract without converting its result; it neither uses nor
+replaces the target type. For a nested resolver, this check occurs before the
+result is passed to the outer resolver, independently of whether the outer
+parameter is annotated.
+
+Missing arguments currently fail before the resolver is called. Any future
+resolver opt-in for receiving missing values must run its missing-value policy
+before ordinary annotation validation and define how the missing sentinel can
+be accepted. This remains coordinated with
+[issue #1301](https://github.com/omry/omegaconf/issues/1301) and
+[issue #1302](https://github.com/omry/omegaconf/issues/1302).
+
+## Diagnostics
+
+Warnings and `TypeError` messages identify the resolver, parameter (and
+variadic index), expected annotation, actual type, and full key. Return
+diagnostics identify the resolver, return annotation, actual result type, and
+full key. When a return value came from the resolver cache, the diagnostic says
+so explicitly and directs the caller to `OmegaConf.clear_cache(cfg)` when the
+cache is stale. In `"warn"` mode, parameter mismatches still call the resolver
+with the original argument and return mismatches expose the original result.
+
+## Test plan
+
+- Cover `"off"`, `"warn"`, `"error"`, omitted, and invalid registration values
+  under both release defaults.
+- Verify explicit `"warn"` remains advisory in 2.5.
+- Cover annotated, unannotated, `Any`, optional, union, variadic, and shallow
+  container parameters.
+- Verify omitted annotated parameters are validated against their defaults.
+- Cover annotated, unannotated, `Any`, optional, union, and shallow container
+  return values.
+- Verify exact primitive matching, including the `bool`/`int` distinction.
+- Verify diagnostics contain resolver, parameter, annotation, actual type, and
+  full key.
+- Verify return diagnostics contain resolver, return annotation, actual result
+  type, and full key.
+- Verify bare, quoted, concatenated, node, container, and nested-resolver
+  interpolation arguments.
+- Verify an inner resolver's return value is validated before outer argument
+  validation and invocation, including when the outer parameter is unannotated.
+- Verify native containers remain distinct from OmegaConf containers and that
+  `DictConfig | dict`, `ListConfig | list`, and `TupleConfig | tuple` accept
+  their corresponding representations.
+- Verify argument validation happens before resolver cache lookup and return
+  validation applies to both cache misses and hits.
+- Verify a cache-hit return mismatch identifies the cached source, does not
+  invoke the resolver in `"error"` mode, and recommends clearing the config's
+  resolver cache.
+- Verify a return mismatch in `"error"` mode is not cached.
+- Verify target-node validation of resolver outputs remains independent.
+- Verify missing argument resolution prevents resolver invocation under the
+  current contract.
+- Verify uninspectable callables and unresolved parameter and return annotations
+  follow the selected registration policy.

--- a/docs/source/custom_resolvers.rst
+++ b/docs/source/custom_resolvers.rst
@@ -30,6 +30,7 @@ You can add additional interpolation types by registering custom resolvers with 
         *,
         replace: bool = False,
         use_cache: bool = False,
+        annotation_validation: Literal["off", "warn", "error"] = "warn",
     ) -> None
 
 Attempting to register the same resolver twice will raise a ``ValueError`` unless using ``replace=True``.
@@ -47,6 +48,65 @@ The example below creates a resolver that adds ``10`` to the given value.
     >>> c = OmegaConf.create({'key': '${plus_10:990}'})
     >>> c.key
     1000
+
+Resolver annotation validation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``OmegaConf.register_resolver()`` can validate resolver arguments and return
+values against their annotations at runtime. This also covers resolver calls
+composed in configuration, which static type checkers cannot inspect.
+
+For example, a type checker can verify the resolver definition below, but it
+cannot detect that the interpolation passes a string where an ``int`` is
+expected. Runtime validation reports the mismatch when ``cfg.result`` is
+accessed, before ``double`` is called.
+
+.. code-block:: python
+
+    def double(value: int) -> int:
+        return value * 2
+
+    OmegaConf.register_resolver(
+        "double", double, annotation_validation="error"
+    )
+    cfg = OmegaConf.create(
+        {
+            "value": "not an integer",
+            "result": "${double:${value}}",
+        }
+    )
+    cfg.result  # raises InterpolationResolutionError
+
+Set ``annotation_validation`` to one of the following modes:
+
+- ``"off"`` disables annotation validation.
+- ``"warn"`` emits ``UserWarning`` on a mismatch and passes through the
+  original argument or result.
+- ``"error"`` raises ``TypeError`` for registration problems. A mismatch while
+  resolving an interpolation is exposed as ``InterpolationResolutionError``
+  caused by the ``TypeError``.
+
+OmegaConf 2.4 defaults to ``"warn"``. OmegaConf 2.5 will default to
+``"error"``; explicit modes retain the same behavior across both releases.
+Validation never converts values. Parameter validation occurs after nested
+argument interpolations are evaluated, includes omitted parameter defaults, and
+precedes resolver cache lookup. Return validation occurs before a new result is
+cached and also checks cache hits.
+
+Runtime-checkable classes, unions, ``Optional``, ``Literal``, and ``Annotated``
+are supported. For ``Annotated``, validation uses the underlying type and
+ignores metadata. If a callable cannot be inspected or an annotation cannot be
+resolved or checked at runtime, ``"warn"`` reports the problem at registration
+and registers the resolver without annotation validation, while ``"error"``
+rejects registration. ``"off"`` does not inspect ordinary annotations.
+
+Container annotations describe the actual runtime representation. For example,
+``ListConfig`` and ``list`` remain distinct; use ``ListConfig | list`` only
+when the resolver intentionally accepts both. The same rule applies to
+``DictConfig | dict`` and ``TupleConfig | tuple``. Parameterized containers are
+validated shallowly, without checking individual element types. OmegaConf's
+injected ``_parent_``, ``_node_``, and ``_root_`` parameters are excluded from
+runtime annotation validation.
 
 Custom resolvers support variadic argument lists in the form of a comma-separated list of zero or more values.
 In a variadic argument list, whitespace is stripped from the ends of each value ("foo,bar" gives the same result as "foo, bar ").

--- a/news/612.feature
+++ b/news/612.feature
@@ -1,0 +1,1 @@
+Custom resolvers can now validate runtime arguments and return values against their annotations using explicit ``"off"``, ``"warn"``, and ``"error"`` policies. OmegaConf 2.4 defaults to advisory warnings.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1,6 +1,7 @@
 """OmegaConf module"""
 
 import copy
+import functools
 import inspect
 import io
 import os
@@ -14,17 +15,23 @@ from enum import Enum
 from textwrap import dedent
 from typing import (
     IO,
+    Annotated,
     Any,
     Callable,
     Dict,
+    ForwardRef,
     Generator,
     Iterable,
     List,
+    Literal,
     Optional,
     Set,
     Tuple,
     Type,
     Union,
+    get_args,
+    get_origin,
+    get_type_hints,
     overload,
 )
 
@@ -85,6 +92,85 @@ MISSING: Any = "???"
 
 Resolver = Callable[..., Any]
 _CUSTOM_RESOLVER_INTERPOLATION_PATTERN = re.compile(r"\${[^}]*:")
+_RESOLVER_ANNOTATION_VALIDATION_POLICIES = ("off", "warn", "error")
+_SPECIAL_RESOLVER_PARAMETERS = ("_parent_", "_node_", "_root_")
+_STRICT_PRIMITIVE_TYPES = (bool, bytes, float, int, str)
+
+
+def _resolver_warning_stacklevel() -> int:
+    package_dir = pathlib.Path(__file__).parent.resolve()
+    frame = inspect.currentframe()
+    stacklevel = 1
+    while frame is not None and frame.f_back is not None:
+        frame = frame.f_back
+        if (
+            not pathlib.Path(frame.f_code.co_filename)
+            .resolve()
+            .is_relative_to(package_dir)
+        ):
+            break
+        stacklevel += 1
+    return stacklevel
+
+
+def _is_supported_resolver_annotation(annotation: Any) -> bool:
+    if annotation in (Any, inspect.Signature.empty, None, type(None)):
+        return True
+    if is_union_annotation(annotation):
+        return all(
+            _is_supported_resolver_annotation(arg) for arg in get_args(annotation)
+        )
+
+    origin = get_origin(annotation)
+    if origin is Literal:
+        return True
+    if origin is Annotated:
+        return _is_supported_resolver_annotation(get_args(annotation)[0])
+    runtime_type = origin if origin is not None else annotation
+    if not isinstance(runtime_type, type):
+        return False
+    try:
+        _ = isinstance(None, runtime_type)
+    except TypeError:
+        return False
+    return True
+
+
+def _resolver_annotation_needs_resolution(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    if origin is Literal:
+        return False
+    if origin is Annotated:
+        return _resolver_annotation_needs_resolution(get_args(annotation)[0])
+    return isinstance(annotation, (str, ForwardRef)) or any(
+        _resolver_annotation_needs_resolution(arg) for arg in get_args(annotation)
+    )
+
+
+def _value_matches_resolver_annotation(value: Any, annotation: Any) -> bool:
+    if annotation in (Any, inspect.Signature.empty):
+        return True
+    if annotation in (None, type(None)):
+        return value is None
+    if is_union_annotation(annotation):
+        return any(
+            _value_matches_resolver_annotation(value, arg)
+            for arg in get_args(annotation)
+        )
+
+    origin = get_origin(annotation)
+    if origin is Literal:
+        return any(
+            type(value) is type(expected) and value == expected
+            for expected in get_args(annotation)
+        )
+    if origin is Annotated:
+        return _value_matches_resolver_annotation(value, get_args(annotation)[0])
+
+    runtime_type = origin if origin is not None else annotation
+    if runtime_type in _STRICT_PRIMITIVE_TYPES:
+        return type(value) is runtime_type
+    return isinstance(value, runtime_type)
 
 
 def II(interpolation: str) -> Any:
@@ -110,13 +196,19 @@ def SI(interpolation: str) -> Any:
 def register_default_resolvers() -> None:
     from omegaconf.resolvers import oc
 
-    OmegaConf.register_resolver("oc.create", oc.create)
-    OmegaConf.register_resolver("oc.decode", oc.decode)
-    OmegaConf.register_resolver("oc.deprecated", oc.deprecated)
-    OmegaConf.register_resolver("oc.env", oc.env)
-    OmegaConf.register_resolver("oc.select", oc.select)
-    OmegaConf.register_resolver("oc.dict.keys", oc.dict.keys)
-    OmegaConf.register_resolver("oc.dict.values", oc.dict.values)
+    OmegaConf.register_resolver("oc.create", oc.create, annotation_validation="off")
+    OmegaConf.register_resolver("oc.decode", oc.decode, annotation_validation="off")
+    OmegaConf.register_resolver(
+        "oc.deprecated", oc.deprecated, annotation_validation="off"
+    )
+    OmegaConf.register_resolver("oc.env", oc.env, annotation_validation="off")
+    OmegaConf.register_resolver("oc.select", oc.select, annotation_validation="off")
+    OmegaConf.register_resolver(
+        "oc.dict.keys", oc.dict.keys, annotation_validation="off"
+    )
+    OmegaConf.register_resolver(
+        "oc.dict.values", oc.dict.values, annotation_validation="off"
+    )
 
 
 class OmegaConf:
@@ -532,6 +624,7 @@ class OmegaConf:
         *,
         replace: bool = False,
         use_cache: bool = False,
+        annotation_validation: Literal["off", "warn", "error"] = "warn",
     ) -> None:
         """
         Register a resolver.
@@ -549,7 +642,19 @@ class OmegaConf:
             based only on the string literals representing the resolver arguments, e.g.,
             ${foo:${bar}} will always return the same value regardless of the value of
             ``bar`` if the cache is enabled for ``foo``.
+        :param annotation_validation: Runtime policy for resolver parameter and return
+            annotations. ``"off"`` disables validation, ``"warn"`` emits
+            ``UserWarning`` and preserves the value, and ``"error"`` rejects
+            registration problems with ``TypeError``. Validation mismatches during
+            interpolation resolution are exposed as ``InterpolationResolutionError``.
+            Defaults to ``"warn"`` in OmegaConf 2.4.
         """
+        if annotation_validation not in _RESOLVER_ANNOTATION_VALIDATION_POLICIES:
+            raise TypeError(
+                "annotation_validation must be one of "
+                f"{_RESOLVER_ANNOTATION_VALIDATION_POLICIES}, "
+                f"got {annotation_validation!r}"
+            )
         if not callable(resolver):
             raise TypeError("resolver must be callable")
         if not name:
@@ -558,10 +663,81 @@ class OmegaConf:
         if not replace and OmegaConf.has_resolver(name):
             raise ValueError(f"resolver '{name}' is already registered")
 
+        def handle_registration_failure(message: str) -> None:
+            if annotation_validation == "error":
+                raise TypeError(message)
+            if annotation_validation == "warn":
+                warnings.warn(
+                    message,
+                    UserWarning,
+                    stacklevel=_resolver_warning_stacklevel(),
+                )
+
+        validation_enabled = annotation_validation != "off"
         try:
             sig: Optional[inspect.Signature] = inspect.signature(resolver)
-        except ValueError:
+        except (TypeError, ValueError) as exc:
             sig = None
+            validation_enabled = False
+            handle_registration_failure(
+                f"Resolver '{name}' cannot be inspected for annotation validation: "
+                f"{exc}"
+            )
+
+        resolved_annotations: Dict[str, Any] = {}
+        if validation_enabled:
+            assert sig is not None
+            resolved_annotations = {
+                parameter_name: parameter.annotation
+                for parameter_name, parameter in sig.parameters.items()
+                if parameter_name not in _SPECIAL_RESOLVER_PARAMETERS
+            }
+            resolved_annotations["return"] = sig.return_annotation
+            if any(
+                _resolver_annotation_needs_resolution(annotation)
+                for annotation in resolved_annotations.values()
+            ):
+                try:
+                    annotation_target = resolver
+                    while isinstance(annotation_target, functools.partial):
+                        annotation_target = annotation_target.func
+                    if not inspect.isroutine(annotation_target) and not inspect.isclass(
+                        annotation_target
+                    ):
+                        annotation_target = annotation_target.__call__
+                    hints = get_type_hints(annotation_target, include_extras=True)
+                except Exception as exc:
+                    validation_enabled = False
+                    handle_registration_failure(
+                        f"Resolver '{name}' cannot resolve annotations for runtime "
+                        f"validation: {exc}"
+                    )
+                else:
+                    resolved_annotations.update(
+                        {
+                            annotation_name: annotation
+                            for annotation_name, annotation in hints.items()
+                            if annotation_name in resolved_annotations
+                        }
+                    )
+
+        if validation_enabled:
+            assert sig is not None
+            for annotation_name, annotation in resolved_annotations.items():
+                if not _is_supported_resolver_annotation(annotation):
+                    validation_enabled = False
+                    handle_registration_failure(
+                        f"Resolver '{name}' annotation for '{annotation_name}' cannot "
+                        f"be checked at runtime: {annotation!r}"
+                    )
+                    break
+
+        parameter_annotations = {
+            annotation_name: annotation
+            for annotation_name, annotation in resolved_annotations.items()
+            if annotation_name != "return"
+            and annotation not in (Any, inspect.Signature.empty)
+        }
 
         def _should_pass(special: str) -> bool:
             ret = sig is not None and special in sig.parameters
@@ -575,6 +751,89 @@ class OmegaConf:
         pass_node = _should_pass("_node_")
         pass_root = _should_pass("_root_")
 
+        def handle_mismatch(message: str) -> None:
+            if annotation_validation == "error":
+                raise TypeError(message)
+            assert annotation_validation == "warn"
+            warnings.warn(
+                message,
+                UserWarning,
+                stacklevel=_resolver_warning_stacklevel(),
+            )
+
+        def validation_message(
+            *,
+            target: str,
+            annotation: Any,
+            value: Any,
+            node: Node,
+            cached: bool = False,
+        ) -> str:
+            full_key = node._get_full_key(key=None) or "<root>"
+            cached_prefix = "cached " if cached else ""
+            message = (
+                f"Resolver '{name}' {cached_prefix}{target} expected "
+                f"{type_str(annotation)}, got {type(value).__name__} at full key "
+                f"'{full_key}'"
+            )
+            if cached:
+                message += (
+                    ". The cached result may be stale; call OmegaConf.clear_cache(cfg)."
+                )
+            return message
+
+        def validate_arguments(
+            args: Tuple[Any, ...], kwargs: Dict[str, Node], node: Node
+        ) -> None:
+            if not validation_enabled or not parameter_annotations:
+                return
+            assert sig is not None
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            for parameter_name, value in bound.arguments.items():
+                if parameter_name not in parameter_annotations:
+                    continue
+                parameter = sig.parameters[parameter_name]
+                annotation = parameter_annotations[parameter_name]
+                if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+                    values = enumerate(value)
+                elif parameter.kind is inspect.Parameter.VAR_KEYWORD:
+                    values = value.items()
+                else:
+                    values = ((None, value),)
+
+                for index, item in values:
+                    if _value_matches_resolver_annotation(item, annotation):
+                        continue
+                    label = parameter_name
+                    if index is not None:
+                        label += f"[{index}]"
+                    handle_mismatch(
+                        validation_message(
+                            target=f"parameter '{label}'",
+                            annotation=annotation,
+                            value=item,
+                            node=node,
+                        )
+                    )
+
+        def validate_return(value: Any, node: Node, *, cached: bool = False) -> None:
+            if not validation_enabled:
+                return
+            assert sig is not None
+            annotation = resolved_annotations.get("return", sig.return_annotation)
+            if _value_matches_resolver_annotation(value, annotation):
+                return
+            handle_mismatch(
+                validation_message(
+                    target="return value",
+                    annotation=annotation,
+                    value=value,
+                    node=node,
+                    cached=cached,
+                )
+            )
+
         def resolver_wrapper(
             config: BaseContainer,
             parent: Container,
@@ -582,16 +841,6 @@ class OmegaConf:
             args: Tuple[Any, ...],
             args_str: Tuple[str, ...],
         ) -> Any:
-            if use_cache:
-                cache = OmegaConf.get_cache(config)[name]
-                try:
-                    return cache[args_str]
-                except KeyError:
-                    ret = resolver(*args)
-                    cache[args_str] = ret
-                    return ret
-
-            # Call resolver.
             kwargs: Dict[str, Node] = {}
             if pass_parent:
                 kwargs["_parent_"] = parent
@@ -600,7 +849,23 @@ class OmegaConf:
             if pass_root:
                 kwargs["_root_"] = config
 
+            validate_arguments(args, kwargs, node)
+
+            if use_cache:
+                cache = OmegaConf.get_cache(config)[name]
+                try:
+                    ret = cache[args_str]
+                except KeyError:
+                    ret = resolver(*args)
+                    validate_return(ret, node)
+                    cache[args_str] = ret
+                    return ret
+                validate_return(ret, node, cached=True)
+                return ret
+
+            # Call resolver.
             ret = resolver(*args, **kwargs)
+            validate_return(ret, node)
             return ret
 
         # noinspection PyProtectedMember

--- a/tests/interpolation/test_custom_resolvers.py
+++ b/tests/interpolation/test_custom_resolvers.py
@@ -62,7 +62,9 @@ def test_register_non_inspectable_resolver(mocker: Any, restore_resolvers: Any) 
         raise ValueError
 
     mocker.patch("inspect.signature", signature_not_inspectable)
-    OmegaConf.register_resolver("not_inspectable", lambda: 123)
+    with warns(UserWarning, match="cannot be inspected") as warning_records:
+        OmegaConf.register_resolver("not_inspectable", lambda: 123)
+    assert warning_records[0].filename == __file__
     assert OmegaConf.create({"x": "${not_inspectable:}"}).x == 123
 
 

--- a/tests/interpolation/test_resolver_annotation_validation.py
+++ b/tests/interpolation/test_resolver_annotation_validation.py
@@ -1,0 +1,522 @@
+import inspect
+from collections.abc import Sequence
+from dataclasses import dataclass
+from functools import partial
+from typing import Annotated, Any, Literal, Optional, Protocol, TypedDict, TypeVar
+
+from pytest import mark, raises, warns
+
+from omegaconf import DictConfig, ListConfig, OmegaConf, TupleConfig
+from omegaconf.errors import InterpolationResolutionError
+
+
+def test_invalid_annotation_validation_policy(restore_resolvers: Any) -> None:
+    with raises(TypeError, match="annotation_validation"):
+        OmegaConf.register_resolver(
+            "typed",
+            lambda: None,
+            annotation_validation="invalid",  # type: ignore
+        )
+
+
+def test_annotation_validation_off(restore_resolvers: Any) -> None:
+    def resolver(value: int) -> int:
+        return value
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="off")
+    cfg = OmegaConf.create({"value": '${typed:"not an int"}'})
+    assert cfg.value == "not an int"
+
+
+def test_unannotated_callable_object_does_not_warn(restore_resolvers: Any) -> None:
+    class CallableResolver:
+        __call__ = staticmethod(lambda value: value)
+
+    OmegaConf.register_resolver("typed", CallableResolver())
+    cfg = OmegaConf.create({"value": "${typed:10}"})
+    assert cfg.value == 10
+
+
+def test_callable_object_literal_is_not_treated_as_forward_reference(
+    restore_resolvers: Any,
+) -> None:
+    class CallableResolver:
+        def __call__(self, value: Literal["expected"]) -> str:
+            return value
+
+    OmegaConf.register_resolver("typed", CallableResolver())
+    cfg = OmegaConf.create({"value": "${typed:expected}"})
+    assert cfg.value == "expected"
+
+
+def test_callable_object_forward_references_are_resolved(
+    restore_resolvers: Any,
+) -> None:
+    class CallableResolver:
+        def __call__(self, value: "int") -> "int":
+            return value
+
+    OmegaConf.register_resolver(
+        "typed", CallableResolver(), annotation_validation="error"
+    )
+    cfg = OmegaConf.create({"value": "${typed:10}"})
+    assert cfg.value == 10
+
+
+def test_partial_forward_references_are_resolved(restore_resolvers: Any) -> None:
+    def resolver(value: "int") -> "int":
+        return value
+
+    OmegaConf.register_resolver(
+        "typed", partial(resolver), annotation_validation="error"
+    )
+    cfg = OmegaConf.create({"valid": "${typed:10}", "invalid": '${typed:"not an int"}'})
+    assert cfg.valid == 10
+    with raises(InterpolationResolutionError, match=r"expected int.*str"):
+        _ = cfg.invalid
+
+
+@mark.parametrize("policy", ["warn", None])
+def test_annotation_validation_warns_and_preserves_argument(
+    restore_resolvers: Any, policy: Optional[str]
+) -> None:
+    received = []
+
+    def resolver(value: int) -> str:
+        received.append(value)
+        return str(value)
+
+    kwargs = {} if policy is None else {"annotation_validation": policy}
+    OmegaConf.register_resolver("typed", resolver, **kwargs)  # type: ignore[arg-type]
+    cfg = OmegaConf.create({"nested": {"value": '${typed:"not an int"}'}})
+
+    with warns(
+        UserWarning,
+        match=r"Resolver 'typed'.*parameter 'value'.*expected int.*str.*nested.value",
+    ) as warning_records:
+        assert cfg.nested.value == "not an int"
+    assert warning_records[0].filename == __file__
+    assert received == ["not an int"]
+
+
+def test_annotation_validation_error_prevents_resolver_call(
+    restore_resolvers: Any,
+) -> None:
+    received = []
+
+    def resolver(value: int) -> int:
+        received.append(value)
+        return value
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"nested": {"value": '${typed:"not an int"}'}})
+
+    with raises(
+        InterpolationResolutionError,
+        match=r"Resolver 'typed'.*parameter 'value'.*expected int.*str.*nested.value",
+    ):
+        _ = cfg.nested.value
+    assert received == []
+
+
+def test_annotation_validation_applies_parameter_defaults(
+    restore_resolvers: Any,
+) -> None:
+    received = []
+    default: Any = "not an int"
+
+    def resolver(value: int = default) -> int:
+        received.append(value)
+        return value
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"value": "${typed:}"})
+
+    with raises(
+        InterpolationResolutionError,
+        match=r"parameter 'value'.*expected int.*str",
+    ):
+        _ = cfg.value
+    assert received == []
+
+
+def test_primitive_matching_is_exact(restore_resolvers: Any) -> None:
+    def resolver(value: int) -> int:
+        return value
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"value": "${typed:true}"})
+
+    with raises(InterpolationResolutionError, match=r"expected int.*bool"):
+        _ = cfg.value
+
+
+@mark.parametrize(
+    ("annotation", "expression", "expected"),
+    [
+        (Optional[int], "null", None),
+        (int | str, "text", "text"),
+        (Annotated[int, "metadata"], "10", 10),
+        (list[int], "[wrong, element, types]", ["wrong", "element", "types"]),
+        (Sequence[int], "[wrong, element, types]", ["wrong", "element", "types"]),
+    ],
+)
+def test_supported_annotations_and_shallow_container_validation(
+    restore_resolvers: Any, annotation: Any, expression: str, expected: Any
+) -> None:
+    def resolver(value: Any) -> Any:
+        return value
+
+    resolver.__annotations__["value"] = annotation
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"value": f"${{typed:{expression}}}"})
+    assert cfg.value == expected
+
+
+@mark.parametrize(
+    ("expression", "annotation", "expected"),
+    [
+        ("${integer}", int, 10),
+        ('"${integer}"', str, "10"),
+        ("value-${integer}", str, "value-10"),
+    ],
+)
+def test_interpolation_argument_forms(
+    restore_resolvers: Any, expression: str, annotation: Any, expected: Any
+) -> None:
+    def resolver(value: Any) -> Any:
+        return value
+
+    resolver.__annotations__["value"] = annotation
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"integer": 10, "value": f"${{typed:{expression}}}"})
+    assert cfg.value == expected
+
+
+def test_variadic_parameter_diagnostic_includes_index(
+    restore_resolvers: Any,
+) -> None:
+    def resolver(*values: int) -> tuple[int, ...]:
+        return values
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"value": "${typed:1,two}"})
+
+    with raises(InterpolationResolutionError, match=r"parameter 'values\[1\]'"):
+        _ = cfg.value
+
+
+@mark.parametrize(
+    ("value", "annotation", "expected_type"),
+    [
+        ({"key": "value"}, DictConfig | dict, DictConfig),
+        ([1, 2], ListConfig | list, ListConfig),
+        ((1, 2), TupleConfig | tuple, TupleConfig),
+    ],
+)
+def test_omegaconf_container_unions(
+    restore_resolvers: Any, value: Any, annotation: Any, expected_type: type
+) -> None:
+    def resolver(container: Any) -> str:
+        assert isinstance(container, expected_type)
+        return type(container).__name__
+
+    resolver.__annotations__["container"] = annotation
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"container": value, "value": "${typed:${container}}"})
+    assert cfg.value == expected_type.__name__
+
+
+@mark.parametrize(
+    ("value", "annotation", "expected_type"),
+    [
+        ({"key": "value"}, DictConfig | dict, dict),
+        ([1, 2], ListConfig | list, list),
+        ((1, 2), TupleConfig | tuple, tuple),
+    ],
+)
+def test_native_container_unions(
+    restore_resolvers: Any, value: Any, annotation: Any, expected_type: type
+) -> None:
+    def source() -> Any:
+        return value
+
+    def resolver(container: Any) -> str:
+        assert type(container) is expected_type
+        return type(container).__name__
+
+    resolver.__annotations__["container"] = annotation
+    OmegaConf.register_resolver("source", source, annotation_validation="error")
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"value": "${typed:${source:}}"})
+    assert cfg.value == expected_type.__name__
+
+
+def test_native_container_annotation_rejects_omegaconf_container(
+    restore_resolvers: Any,
+) -> None:
+    def resolver(container: list) -> None:
+        return None
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"container": [1, 2], "value": "${typed:${container}}"})
+
+    with raises(InterpolationResolutionError, match=r"expected list.*ListConfig"):
+        _ = cfg.value
+
+
+def test_special_parameters_are_excluded(restore_resolvers: Any) -> None:
+    def resolver(*, _node_: str) -> str:
+        return type(_node_).__name__
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"value": "${typed:}"})
+    assert cfg.value == "AnyNode"
+
+
+def test_return_annotation_warns_and_preserves_result(
+    restore_resolvers: Any,
+) -> None:
+    def resolver() -> int:
+        return "not an int"  # type: ignore[return-value]
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="warn")
+    cfg = OmegaConf.create({"value": "${typed:}"})
+
+    with warns(
+        UserWarning,
+        match=r"Resolver 'typed'.*return value.*expected int.*str.*value",
+    ):
+        assert cfg.value == "not an int"
+
+
+@mark.parametrize(
+    ("annotation", "result"),
+    [
+        (Optional[int], None),
+        (int | str, "value"),
+        (list[int], ["shallow", "validation"]),
+    ],
+)
+def test_supported_return_annotations(
+    restore_resolvers: Any, annotation: Any, result: Any
+) -> None:
+    def resolver() -> Any:
+        return result
+
+    resolver.__annotations__["return"] = annotation
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"value": "${typed:}"})
+    assert cfg.value == result
+
+
+def test_nested_return_validation_precedes_outer_call(
+    restore_resolvers: Any,
+) -> None:
+    calls = []
+
+    def inner() -> int:
+        calls.append("inner")
+        return "not an int"  # type: ignore[return-value]
+
+    def outer(value: Any) -> Any:
+        calls.append("outer")
+        return value
+
+    OmegaConf.register_resolver("inner", inner, annotation_validation="error")
+    OmegaConf.register_resolver("outer", outer, annotation_validation="error")
+    cfg = OmegaConf.create({"value": "${outer:${inner:}}"})
+
+    with raises(InterpolationResolutionError, match=r"Resolver 'inner'.*return value"):
+        _ = cfg.value
+    assert calls == ["inner"]
+
+
+def test_missing_argument_prevents_resolver_call(restore_resolvers: Any) -> None:
+    calls = 0
+
+    def resolver(value: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return value
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.create({"argument": "???", "value": "${typed:${argument}}"})
+
+    with raises(InterpolationResolutionError):
+        _ = cfg.value
+    assert calls == 0
+
+
+def test_return_mismatch_is_not_cached(restore_resolvers: Any) -> None:
+    calls = 0
+
+    def resolver() -> int:
+        nonlocal calls
+        calls += 1
+        return "not an int"  # type: ignore[return-value]
+
+    OmegaConf.register_resolver(
+        "typed", resolver, use_cache=True, annotation_validation="error"
+    )
+    cfg = OmegaConf.create({"value": "${typed:}"})
+
+    for _ in range(2):
+        with raises(InterpolationResolutionError, match=r"return value"):
+            _ = cfg.value
+    assert calls == 2
+    assert OmegaConf.get_cache(cfg)["typed"] == {}
+
+
+def test_argument_validation_precedes_cache_hit(restore_resolvers: Any) -> None:
+    calls = 0
+
+    def resolver(value: int) -> int:
+        nonlocal calls
+        calls += 1
+        return value
+
+    OmegaConf.register_resolver(
+        "typed", resolver, use_cache=True, annotation_validation="error"
+    )
+    cfg = OmegaConf.create({"argument": 10, "value": "${typed:${argument}}"})
+    assert cfg.value == 10
+    cfg.argument = "not an int"
+
+    with raises(InterpolationResolutionError, match=r"parameter 'value'.*str"):
+        _ = cfg.value
+    assert calls == 1
+
+
+def test_cached_return_mismatch_identifies_cache(
+    restore_resolvers: Any,
+) -> None:
+    calls = 0
+
+    def old_resolver() -> str:
+        return "cached"
+
+    def replacement() -> int:
+        nonlocal calls
+        calls += 1
+        return 10
+
+    OmegaConf.register_resolver(
+        "typed", old_resolver, use_cache=True, annotation_validation="error"
+    )
+    cfg = OmegaConf.create({"value": "${typed:}"})
+    assert cfg.value == "cached"
+
+    OmegaConf.register_resolver(
+        "typed",
+        replacement,
+        use_cache=True,
+        replace=True,
+        annotation_validation="error",
+    )
+    with raises(
+        InterpolationResolutionError,
+        match=r"cached return value.*expected int.*str.*OmegaConf.clear_cache",
+    ):
+        _ = cfg.value
+    assert calls == 0
+
+    OmegaConf.clear_cache(cfg)
+    assert cfg.value == 10
+    assert calls == 1
+
+
+def test_target_node_validation_remains_independent(restore_resolvers: Any) -> None:
+    @dataclass
+    class Config:
+        value: int = "${typed:}"  # type: ignore[assignment]
+
+    def resolver() -> str:
+        return "10"
+
+    OmegaConf.register_resolver("typed", resolver, annotation_validation="error")
+    cfg = OmegaConf.structured(Config)
+    assert cfg.value == 10
+
+
+@mark.parametrize("policy", ["warn", "error"])
+def test_uninspectable_resolver_follows_policy(
+    mocker: Any, restore_resolvers: Any, policy: str
+) -> None:
+    mocker.patch.object(inspect, "signature", side_effect=ValueError("no signature"))
+
+    if policy == "warn":
+        with warns(UserWarning, match=r"Resolver 'typed'.*cannot be inspected"):
+            OmegaConf.register_resolver(
+                "typed",
+                lambda: 10,
+                annotation_validation=policy,  # type: ignore[arg-type]
+            )
+    else:
+        with raises(TypeError, match=r"Resolver 'typed'.*cannot be inspected"):
+            OmegaConf.register_resolver(
+                "typed",
+                lambda: 10,
+                annotation_validation=policy,  # type: ignore[arg-type]
+            )
+
+
+@mark.parametrize("policy", ["warn", "error"])
+def test_unresolvable_annotation_follows_policy(
+    restore_resolvers: Any, policy: str
+) -> None:
+    def resolver(value: "MissingType") -> Any:  # type: ignore[name-defined]  # noqa: F821
+        return value
+
+    if policy == "warn":
+        with warns(UserWarning, match=r"Resolver 'typed'.*cannot resolve annotations"):
+            OmegaConf.register_resolver(
+                "typed",
+                resolver,
+                annotation_validation=policy,  # type: ignore[arg-type]
+            )
+    else:
+        with raises(TypeError, match=r"Resolver 'typed'.*cannot resolve annotations"):
+            OmegaConf.register_resolver(
+                "typed",
+                resolver,
+                annotation_validation=policy,  # type: ignore[arg-type]
+            )
+
+
+class ResolverProtocol(Protocol):
+    value: int
+
+
+class ResolverTypedDict(TypedDict):
+    value: int
+
+
+ResolverTypeVar = TypeVar("ResolverTypeVar")
+
+
+@mark.parametrize("annotation", [ResolverProtocol, ResolverTypedDict, ResolverTypeVar])
+@mark.parametrize("policy", ["warn", "error"])
+def test_runtime_uncheckable_annotation_follows_policy(
+    restore_resolvers: Any, annotation: Any, policy: str
+) -> None:
+    def resolver(value: Any) -> Any:
+        return value
+
+    resolver.__annotations__["value"] = annotation
+    if policy == "warn":
+        with warns(UserWarning, match=r"cannot be checked at runtime"):
+            OmegaConf.register_resolver(
+                "typed",
+                resolver,
+                annotation_validation=policy,  # type: ignore[arg-type]
+            )
+        cfg = OmegaConf.create({"value": "${typed:10}"})
+        assert cfg.value == 10
+    else:
+        with raises(TypeError, match=r"cannot be checked at runtime"):
+            OmegaConf.register_resolver(
+                "typed",
+                resolver,
+                annotation_validation=policy,  # type: ignore[arg-type]
+            )


### PR DESCRIPTION

Add annotation_validation policies for custom resolver parameters and return values, defaulting to advisory warnings in OmegaConf 2.4. Validate resolved arguments before cache lookup and validate new or cached results without coercion, with strict primitive matching and clear cache diagnostics.

Support unions, shallow parameterized containers, runtime-checkable classes, callable objects, and functools.partial forward annotations. Preserve existing built-in resolver diagnostics and report warnings at caller locations.

Document the rollout and runtime container semantics, add the release fragment, and cover validation policies, interpolation forms, cache behavior, annotation variants, return values, and failure paths.

Closes #612
