### PR TITLE
Fix ListConfig insert index handling

### DIFF
--- a/news/750.bugfix
+++ b/news/750.bugfix
@@ -1,0 +1,1 @@
+`ListConfig.insert()` now follows Python list semantics for negative and out-of-range indices and leaves the list unchanged when validation fails.

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -1,4 +1,5 @@
 import copy
+import operator
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -292,8 +293,6 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
                 node._metadata.key = i
 
     def insert(self, index: int, item: Any) -> None:
-        from omegaconf.omegaconf import _maybe_wrap
-
         try:
             if self._get_flag("readonly"):
                 raise ReadonlyConfigError("Cannot insert into a read-only ListConfig")
@@ -304,23 +303,20 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
             if self._is_missing():
                 raise MissingMandatoryValue("Cannot insert into missing ListConfig")
 
+            content = self.__dict__["_content"]
+            assert isinstance(content, list)
+            index = operator.index(index)
+            if index < 0:
+                index = max(0, index + len(content))
+            else:
+                index = min(index, len(content))
+
+            content.insert(index, None)
             try:
-                assert isinstance(self.__dict__["_content"], list)
-                # insert place holder
-                self.__dict__["_content"].insert(index, None)
-                is_optional, ref_type = _resolve_optional(self._metadata.element_type)
-                node = _maybe_wrap(
-                    ref_type=ref_type,
-                    key=index,
-                    value=item,
-                    is_optional=is_optional,
-                    parent=self,
-                )
-                self._validate_set(key=index, value=node)
-                self._set_at_index(index, node)
+                self._set_item_impl(index, item)
                 self._update_keys()
             except Exception:
-                del self.__dict__["_content"][index]
+                del content[index]
                 self._update_keys()
                 raise
         except Exception as e:

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -643,6 +643,48 @@ def test_insert(
 
 
 @mark.parametrize(
+    "index,expected",
+    [
+        param(-1, [1, 2, 4, 3], id="negative"),
+        param(-10, [4, 1, 2, 3], id="negative_out_of_range"),
+        param(10, [1, 2, 3, 4], id="positive_out_of_range"),
+    ],
+)
+def test_insert_normalizes_index(index: int, expected: List[int]) -> None:
+    cfg = OmegaConf.create([1, 2, 3])
+
+    cfg.insert(index, 4)
+
+    assert cfg == expected
+    validate_list_keys(cfg)
+
+
+def test_insert_accepts_index_protocol() -> None:
+    class Index:
+        def __index__(self) -> int:
+            return -1
+
+    cfg = OmegaConf.create([1, 2, 3])
+    index: Any = Index()
+
+    cfg.insert(index, 4)
+
+    assert cfg == [1, 2, 4, 3]
+    validate_list_keys(cfg)
+
+
+@mark.parametrize("index", [-1, 10])
+def test_insert_validation_failure_is_atomic(index: int) -> None:
+    cfg = ListConfig(content=[1, 2, 3], element_type=int)
+
+    with raises(ValidationError):
+        cfg.insert(index, "invalid")
+
+    assert cfg == [1, 2, 3]
+    validate_list_keys(cfg)
+
+
+@mark.parametrize(
     "lst,idx,value,expectation",
     [
         (ListConfig(content=None), 0, 10, raises(TypeError)),


### PR DESCRIPTION

Normalize ListConfig insertion indices with Python's integer-index protocol and list insertion rules.

Use _set_item_impl() for wrapping and validation, and roll back atomically on failure. Add regression coverage for negative, out-of-range, and __index__-compatible indices and failed validation.

Closes #750
