### PR TITLE
Invalidate inherited flag cache through unions

### DIFF
--- a/news/1340.bugfix
+++ b/news/1340.bugfix
@@ -1,0 +1,1 @@
+Inherited flags are now updated correctly for containers selected by a union type.

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -926,6 +926,13 @@ class UnionNode(Box):
         else:
             return parent._get_full_key(self._metadata.key)
 
+    def _invalidate_flags_cache(self) -> None:
+        if self.__dict__["_flags_cache"] is not None:
+            super()._invalidate_flags_cache()
+            content = self.__dict__["_content"]
+            if isinstance(content, Node):
+                content._invalidate_flags_cache()
+
     def __eq__(self, other: Any) -> bool:
         content = self.__dict__["_content"]
         if isinstance(content, Node):

--- a/tests/test_container_unions.py
+++ b/tests/test_container_unions.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pytest import mark, param, raises
 
-from omegaconf import OmegaConf, TupleConfig, ValidationError
+from omegaconf import OmegaConf, ReadonlyConfigError, TupleConfig, ValidationError
 from omegaconf._utils import is_supported_union_annotation
 
 # ---------------------------------------------------------------------------
@@ -119,6 +119,22 @@ class TestStructuredConfigCreation:
     def test_create(self, cls: Any, expected: Any) -> None:
         cfg = OmegaConf.structured(cls)
         assert cfg.value == expected
+
+
+def test_inherited_flag_cache_is_invalidated_through_container_union() -> None:
+    @dataclass
+    class Config:
+        value: Union[List[int], int] = field(default_factory=lambda: [1])
+
+    cfg = OmegaConf.structured(Config)
+    value = cfg.value
+    assert OmegaConf.is_readonly(value) is None
+
+    OmegaConf.set_readonly(cfg, True)
+
+    assert OmegaConf.is_readonly(value) is True
+    with raises(ReadonlyConfigError):
+        value.append(2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

Propagate flag-cache invalidation from a UnionNode to its selected child when inherited flags have been cached.

Add regression coverage for readonly enforcement on a container-valued union.

Closes #1340
