### PR TITLE
Report full keys for nested structured config errors

### DIFF
--- a/news/702.bugfix
+++ b/news/702.bugfix
@@ -1,0 +1,1 @@
+Report the complete key path when creating a nested Structured Config fails.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -52,6 +52,8 @@ if TYPE_CHECKING:
     import attr
     from attr import Attribute as AttrAttribute
 
+    from .basecontainer import BaseContainer
+
 
 NoneType: Type[None] = type(None)
 
@@ -350,7 +352,11 @@ def get_attr_class_fields(obj: Any) -> List["AttrAttribute[Any]"]:
     return [f for f in fields if f.metadata.get("omegaconf_ignore") is not True]
 
 
-def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, Any]:
+def get_attr_data(
+    obj: Any,
+    allow_objects: Optional[bool] = None,
+    parent: Optional["BaseContainer"] = None,
+) -> Dict[str, Any]:
     from omegaconf.base import Node
     from omegaconf.omegaconf import OmegaConf, _maybe_wrap
 
@@ -363,6 +369,9 @@ def get_attr_data(obj: Any, allow_objects: Optional[bool] = None) -> Dict[str, A
     obj_type = obj if is_type else type(obj)
     dummy_parent = OmegaConf.create({}, flags=flags)
     dummy_parent._metadata.object_type = obj_type
+    if parent is not None:
+        dummy_parent._set_key(parent._key())
+        dummy_parent._set_parent(parent._get_parent())
     resolved_hints = get_type_hints(obj_type)
 
     for attrib in get_attr_class_fields(obj):
@@ -422,7 +431,9 @@ def get_dataclass_fields(obj: Any) -> List["dataclasses.Field[Any]"]:
 
 
 def get_dataclass_data(
-    obj: Any, allow_objects: Optional[bool] = None
+    obj: Any,
+    allow_objects: Optional[bool] = None,
+    parent: Optional["BaseContainer"] = None,
 ) -> Dict[str, Any]:
     from omegaconf.base import Node
     from omegaconf.omegaconf import MISSING, OmegaConf, _maybe_wrap
@@ -433,6 +444,9 @@ def get_dataclass_data(
     obj_type = get_type_of(obj)
     dummy_parent = OmegaConf.create({}, flags=flags)
     dummy_parent._metadata.object_type = obj_type
+    if parent is not None:
+        dummy_parent._set_key(parent._key())
+        dummy_parent._set_parent(parent._get_parent())
     resolved_hints = get_type_hints(obj_type)
     for field in get_dataclass_fields(obj):
         name = field.name
@@ -552,12 +566,14 @@ def get_structured_config_init_field_aliases(obj: Any) -> Dict[str, str]:
 
 
 def get_structured_config_data(
-    obj: Any, allow_objects: Optional[bool] = None
+    obj: Any,
+    allow_objects: Optional[bool] = None,
+    parent: Optional["BaseContainer"] = None,
 ) -> Dict[str, Any]:
     if is_dataclass(obj):
-        return get_dataclass_data(obj, allow_objects=allow_objects)
+        return get_dataclass_data(obj, allow_objects=allow_objects, parent=parent)
     elif is_attr_class(obj):
-        return get_attr_data(obj, allow_objects=allow_objects)
+        return get_attr_data(obj, allow_objects=allow_objects, parent=parent)
     else:
         raise ValueError(f"Unsupported type: {type(obj).__name__}")
 

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -683,7 +683,7 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             if is_structured_config(value):
                 self._metadata.object_type = None
                 ao = self._get_flag("allow_objects")
-                data = get_structured_config_data(value, allow_objects=ao)
+                data = get_structured_config_data(value, allow_objects=ao, parent=self)
                 with flag_override(self, ["struct", "readonly"], False):
                     for k, v in data.items():
                         self.__setitem__(k, v)

--- a/tests/structured_conf/data/attr_classes.py
+++ b/tests/structured_conf/data/attr_classes.py
@@ -424,6 +424,16 @@ class ErrorListUnsupportedValue:
 
 
 @attr.s(auto_attribs=True)
+class InvalidNestedValue:
+    value: int = "not-an-int"  # type: ignore[assignment]
+
+
+@attr.s(auto_attribs=True)
+class StructuredWithInvalidNestedValue:
+    inner: InvalidNestedValue = attr.Factory(InvalidNestedValue)
+
+
+@attr.s(auto_attribs=True)
 class ListExamples:
     any: List[Any] = [1, "foo"]
     ints: List[int] = [1, 2]

--- a/tests/structured_conf/data/dataclasses.py
+++ b/tests/structured_conf/data/dataclasses.py
@@ -439,6 +439,16 @@ class ErrorListUnsupportedStructuredConfig:
 
 
 @dataclass
+class InvalidNestedValue:
+    value: int = "not-an-int"  # type: ignore[assignment]
+
+
+@dataclass
+class StructuredWithInvalidNestedValue:
+    inner: InvalidNestedValue = field(default_factory=InvalidNestedValue)
+
+
+@dataclass
 class ListExamples:
     any: List[Any] = field(default_factory=lambda: [1, "foo"])
     ints: List[int] = field(default_factory=lambda: [1, 2])

--- a/tests/structured_conf/data/dataclasses_pre_311.py
+++ b/tests/structured_conf/data/dataclasses_pre_311.py
@@ -437,6 +437,16 @@ class ErrorListUnsupportedStructuredConfig:
 
 
 @dataclass
+class InvalidNestedValue:
+    value: int = "not-an-int"  # type: ignore[assignment]
+
+
+@dataclass
+class StructuredWithInvalidNestedValue:
+    inner: InvalidNestedValue = field(default_factory=InvalidNestedValue)
+
+
+@dataclass
 class ListExamples:
     any: List[Any] = field(default_factory=lambda: [1, "foo"])
     ints: List[int] = field(default_factory=lambda: [1, 2])

--- a/tests/structured_conf/test_structured_basic.py
+++ b/tests/structured_conf/test_structured_basic.py
@@ -65,6 +65,12 @@ class TestStructured:
             ):
                 OmegaConf.structured(module.User(age="seven"))
 
+        def test_nested_creation_error_has_full_key(self, module: Any) -> None:
+            with raises(ValidationError) as exc_info:
+                OmegaConf.structured(module.StructuredWithInvalidNestedValue)
+
+            assert exc_info.value.full_key == "inner.value"
+
         def test_assignment_of_subclass(self, module: Any) -> None:
             cfg = OmegaConf.create({"plugin": module.Plugin})
             cfg.plugin = OmegaConf.structured(module.ConcretePlugin)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -717,7 +717,7 @@ params = [
             exception_type=ValidationError,
             msg="Value 'x' of type 'str' could not be converted to Integer",
             key="foo",
-            full_key="foo",
+            full_key="params.foo",
             parent_node=lambda _: {},
             object_type=ConcretePlugin.FoobarParams,
         ),


### PR DESCRIPTION

Preserve parent path context while extracting dataclass and attrs fields so validation failures report the complete nested key.

Add backend-parity regression coverage and update the existing error contract.

Closes #702
