### PR TITLE
Follow interpolated containers during nested updates

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -921,6 +921,20 @@ The ``force_add`` flag ensures that the path is created even if it will result i
     >>> OmegaConf.update(cfg, "a.b.c.d", 10, force_add=True)
     >>> assert cfg.a.b.c.d == 10
 
+When an intermediate path element is a node interpolation whose reference
+chain ends at an existing config container, ``OmegaConf.update()`` follows the
+interpolation and updates the referenced container. The interpolation itself
+remains unchanged.
+
+.. doctest::
+
+    >>> cfg = OmegaConf.create({"base": {"x": 1}, "alias": "${base}"})
+    >>> OmegaConf.update(cfg, "alias.y", 2)
+    >>> OmegaConf.to_container(cfg, resolve=False)
+    {'base': {'x': 1, 'y': 2}, 'alias': '${base}'}
+    >>> OmegaConf.is_interpolation(cfg, "alias")
+    True
+
 .. _keypath-escaping:
 
 Key path escaping

--- a/news/1329.bugfix
+++ b/news/1329.bugfix
@@ -1,0 +1,3 @@
+``OmegaConf.update()`` now follows intermediate node interpolations whose
+reference chains end at existing config containers, applying nested updates to
+the referenced container while preserving the interpolation.

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -67,7 +67,9 @@ from ._yaml import _DEFAULT_MAX_YAML_EXPANDED_NODES, get_yaml_loader
 from .base import Box, Container, Node, SCMode, UnionNode
 from .basecontainer import BaseContainer
 from .errors import (
+    ConfigKeyError,
     ConfigTypeError,
+    InterpolationKeyError,
     InterpolationResolutionError,
     InterpolationToMissingValueError,
     MissingMandatoryValue,
@@ -1396,6 +1398,10 @@ class OmegaConf:
             k = split[i]
             # if next_root is a primitive (string, int etc) replace it with an empty map
             next_root, key_ = _select_one(root, k, throw_on_missing=False)
+            if next_root is not None:
+                target = _get_update_interpolation_target(next_root)
+                if target is not None:
+                    next_root = target
             if isinstance(next_root, Container) and next_root._is_none():
                 raise ConfigTypeError(
                     f"Cannot set '{key}' because '{root._get_full_key(key_)}' is None"
@@ -1406,7 +1412,9 @@ class OmegaConf:
                         root[key_] = {}
                 else:
                     root[key_] = {}
-            root = root[key_]
+                root = root[key_]
+            else:
+                root = next_root
 
         last = split[-1]
 
@@ -1998,3 +2006,100 @@ def _select_one(
 
     assert val is None or isinstance(val, Node)
     return val, ret_key
+
+
+def _get_update_interpolation_target(
+    node: Node, memo: Optional[Set[int]] = None
+) -> Optional[Container]:
+    if not node._is_interpolation():
+        return None
+    target = _get_update_interpolation_result(node, memo=memo)
+    return target if isinstance(target, Container) else None
+
+
+def _get_update_interpolation_result(
+    node: Node, memo: Optional[Set[int]] = None
+) -> Optional[Node]:
+    if not node._is_interpolation():  # pragma: no cover
+        return node
+
+    from .grammar_parser import OmegaConfGrammarParser, parse
+    from .grammar_visitor import GrammarVisitor
+
+    node_id = id(node)
+    memo = set() if memo is None else memo
+    if node_id in memo:
+        raise InterpolationResolutionError("Recursive interpolation detected")
+
+    memo.add(node_id)
+    try:
+        parse_tree = parse(_get_value(node))
+        assert isinstance(parse_tree, OmegaConfGrammarParser.ConfigValueContext)
+        text = parse_tree.text()
+        assert text is not None
+        interpolation = text.interpolation(0)
+        interpolation_node = interpolation.interpolationNode()
+        if text.getChildCount() != 1 or interpolation_node is None:
+            return None
+
+        parent = node._get_parent_container()
+        if parent is None:  # pragma: no cover
+            return None
+
+        def resolve_node(inter_key: str, _memo: Optional[Set[int]]) -> Optional[Node]:
+            try:
+                target, inter_key = parent._resolve_key_and_root(inter_key)
+            except ConfigKeyError as exc:
+                raise InterpolationKeyError(
+                    f"ConfigKeyError while resolving interpolation: {exc}"
+                ) from exc
+            split = split_key(inter_key)
+            selected: Node = target
+            for index, key in enumerate(split):
+                try:
+                    child, _resolved_key = _select_one(
+                        target, key, throw_on_missing=True
+                    )
+                except MissingMandatoryValue as exc:
+                    raise InterpolationToMissingValueError(
+                        f"MissingMandatoryValue while resolving interpolation: {exc}"
+                    ) from exc
+                if child is None:
+                    raise InterpolationKeyError(
+                        f"Interpolation key '{inter_key}' not found"
+                    )
+                if child._is_interpolation():
+                    child = _get_update_interpolation_result(child, memo=memo)
+                    if child is None:
+                        return None
+                if index < len(split) - 1:
+                    if not isinstance(child, Container):
+                        parent_key = ".".join(split[: index + 1])
+                        child_key = split[index + 1]
+                        raise InterpolationResolutionError(
+                            f"ConfigTypeError raised while resolving interpolation: "
+                            f"Error trying to access {inter_key}: node `{parent_key}` "
+                            f"is not a container and thus cannot contain `{child_key}`"
+                        )
+                    target = child
+                selected = child
+            return selected
+
+        visitor = GrammarVisitor(
+            node_interpolation_callback=resolve_node,
+            resolver_interpolation_callback=lambda **_: None,
+            memo=memo,
+        )
+        target = visitor.visitInterpolationNode(interpolation_node)
+        if isinstance(target, Node):
+            parent._validate_not_dereferencing_to_parent(node=node, target=target)
+            return target
+        return None
+    except InterpolationResolutionError:
+        raise
+    except Exception as exc:
+        raise InterpolationResolutionError(
+            f"{type(exc).__name__} raised while resolving interpolation: {exc}"
+        ) from exc
+    finally:
+        memo.remove(node_id)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,9 +2,14 @@ from typing import Any
 
 from pytest import mark, param, raises
 
-from omegaconf import ListConfig, OmegaConf, ValidationError
+from omegaconf import DictConfig, ListConfig, OmegaConf, ValidationError
 from omegaconf._utils import _ensure_container, is_primitive_container
-from omegaconf.errors import ConfigAttributeError, ConfigKeyError, ConfigTypeError
+from omegaconf.errors import (
+    ConfigAttributeError,
+    ConfigKeyError,
+    ConfigTypeError,
+    InterpolationResolutionError,
+)
 from tests import Group, Package, User
 
 
@@ -192,6 +197,282 @@ def test_update_merge_by_default() -> None:
     cfg = OmegaConf.create({"a": {"b": 10}})
     OmegaConf.update(cfg, "a", {"c": 20})
     assert cfg == {"a": {"b": 10, "c": 20}}
+
+
+@mark.parametrize(
+    "source,key,value,expected",
+    [
+        param(
+            {"arg1": 1, "arg2": 2},
+            "target.arg3",
+            3,
+            {"arg1": 1, "arg2": 2, "arg3": 3},
+            id="dict",
+        ),
+        param(
+            [{"arg1": 1}],
+            "target.0.arg2",
+            2,
+            [{"arg1": 1, "arg2": 2}],
+            id="list",
+        ),
+        param(
+            ({"arg1": 1},),
+            "target.0.arg2",
+            2,
+            ({"arg1": 1, "arg2": 2},),
+            id="tuple",
+        ),
+    ],
+)
+def test_update_follows_intermediate_container_interpolation(
+    source: Any, key: str, value: Any, expected: Any
+) -> None:
+    cfg = OmegaConf.create({"source": source, "target": "${source}"})
+
+    OmegaConf.update(cfg, key, value)
+
+    assert cfg.source == expected
+    assert cfg.target == expected
+    assert OmegaConf.is_interpolation(cfg, "target")
+
+
+@mark.parametrize(
+    "source,target,key,value,expected",
+    [
+        param(
+            {"arg1": 1},
+            DictConfig("${source}"),
+            "target.arg2",
+            2,
+            {"arg1": 1, "arg2": 2},
+            id="dict",
+        ),
+        param(
+            [{"arg1": 1}],
+            ListConfig("${source}"),
+            "target.0.arg2",
+            2,
+            [{"arg1": 1, "arg2": 2}],
+            id="list",
+        ),
+    ],
+)
+def test_update_follows_intermediate_container_config_interpolation(
+    source: Any, target: Any, key: str, value: Any, expected: Any
+) -> None:
+    cfg = OmegaConf.create({"source": source, "target": target})
+
+    OmegaConf.update(cfg, key, value)
+
+    assert cfg.source == expected
+    assert cfg.target == expected
+    assert OmegaConf.is_interpolation(cfg, "target")
+
+
+@mark.parametrize(
+    "content,key,expected",
+    [
+        param(
+            {
+                "source": {"arg1": 1},
+                "middle": "${source}",
+                "target": "${middle}",
+            },
+            "target.arg2",
+            {
+                "source": {"arg1": 1, "arg2": 2},
+                "middle": "${source}",
+                "target": "${middle}",
+            },
+            id="chained",
+        ),
+        param(
+            {"group": {"source": {"arg1": 1}, "target": "${.source}"}},
+            "group.target.arg2",
+            {
+                "group": {
+                    "source": {"arg1": 1, "arg2": 2},
+                    "target": "${.source}",
+                }
+            },
+            id="relative",
+        ),
+        param(
+            {
+                "key": "source",
+                "source": {"arg1": 1},
+                "target": "${${key}}",
+            },
+            "target.arg2",
+            {
+                "key": "source",
+                "source": {"arg1": 1, "arg2": 2},
+                "target": "${${key}}",
+            },
+            id="dynamic",
+        ),
+    ],
+)
+def test_update_follows_intermediate_container_interpolation_path(
+    content: Any, key: str, expected: Any
+) -> None:
+    cfg = OmegaConf.create(content)
+
+    OmegaConf.update(cfg, key, 2)
+
+    assert OmegaConf.to_container(cfg, resolve=False) == expected
+    parent = cfg.group if "group" in content else cfg
+    assert OmegaConf.is_interpolation(parent, "target")
+
+
+def test_update_replaces_intermediate_string_interpolation_without_resolving() -> None:
+    cfg = OmegaConf.create({"target": "prefix${missing}"})
+
+    OmegaConf.update(cfg, "target.x", 1)
+
+    assert cfg == {"target": {"x": 1}}
+
+
+@mark.parametrize(
+    "content,key,error",
+    [
+        param(
+            {"a": {"b": "${a}"}},
+            "a.b.x",
+            "Interpolation to parent node detected",
+            id="ancestor",
+        ),
+        param(
+            {"a": "${b}", "b": "${a}"},
+            "a.x",
+            "Recursive interpolation detected",
+            id="cycle",
+        ),
+        param(
+            {"target": "${missing}"},
+            "target.x",
+            "Interpolation key 'missing' not found",
+            id="missing-key",
+        ),
+        param(
+            {"missing": "???", "target": "${missing}"},
+            "target.x",
+            "MissingMandatoryValue while resolving interpolation",
+            id="mandatory-missing",
+        ),
+        param(
+            {"target": "${..source}"},
+            "target.x",
+            "ConfigKeyError while resolving interpolation",
+            id="invalid-relative-key",
+        ),
+        param(
+            {"source": 1, "target": "${source.x}"},
+            "target.y",
+            "node `source` is not a container",
+            id="path-through-scalar",
+        ),
+        param(
+            {"source": [1], "target": "${source.foo}"},
+            "target.y",
+            "TypeError raised while resolving interpolation",
+            id="invalid-list-key",
+        ),
+    ],
+)
+def test_update_rejects_invalid_intermediate_interpolation(
+    content: Any, key: str, error: str
+) -> None:
+    cfg = OmegaConf.create(content)
+
+    with raises(InterpolationResolutionError, match=error):
+        OmegaConf.update(cfg, key, 1)
+
+    assert OmegaConf.to_container(cfg, resolve=False) == content
+
+
+def test_update_intermediate_interpolation_respects_struct() -> None:
+    cfg = OmegaConf.create({"source": {"arg1": 1}, "target": "${source}"})
+    OmegaConf.set_struct(cfg.source, True)
+
+    with raises((ConfigAttributeError, ConfigKeyError)):
+        OmegaConf.update(cfg, "target.arg2", 2)
+
+    assert OmegaConf.is_interpolation(cfg, "target")
+
+    OmegaConf.update(cfg, "target.arg2", 2, force_add=True)
+
+    assert cfg.source == {"arg1": 1, "arg2": 2}
+    assert OmegaConf.is_interpolation(cfg, "target")
+
+
+def test_update_intermediate_interpolation_respects_structured_config() -> None:
+    cfg = OmegaConf.create(
+        {
+            "source": OmegaConf.structured(User(name="Bond", age=7)),
+            "target": "${source}",
+        }
+    )
+
+    OmegaConf.update(cfg, "target.age", 8)
+
+    assert cfg.source.age == 8
+    assert OmegaConf.is_interpolation(cfg, "target")
+
+    with raises((ConfigAttributeError, ConfigKeyError)):
+        OmegaConf.update(cfg, "target.location", "London")
+
+    assert OmegaConf.is_interpolation(cfg, "target")
+
+
+@mark.parametrize(
+    "resolver_result",
+    [
+        param({"existing": 1}, id="dict"),
+        param(DictConfig({"existing": 1}), id="dict_config"),
+    ],
+)
+@mark.parametrize(
+    "content,expected",
+    [
+        param(
+            {"target": "${test_update_intermediate:}"},
+            {"target": {"added": 2}},
+            id="direct",
+        ),
+        param(
+            {
+                "middle": "${test_update_intermediate:}",
+                "target": "${middle}",
+            },
+            {
+                "middle": "${test_update_intermediate:}",
+                "target": {"added": 2},
+            },
+            id="chained",
+        ),
+    ],
+)
+def test_update_does_not_resolve_intermediate_resolver_interpolation(
+    resolver_result: Any, content: Any, expected: Any
+) -> None:
+    calls = 0
+
+    def resolver() -> Any:
+        nonlocal calls
+        calls += 1
+        return resolver_result
+
+    OmegaConf.register_resolver("test_update_intermediate", resolver)
+    try:
+        cfg = OmegaConf.create(content)
+        OmegaConf.update(cfg, "target.added", 2)
+    finally:
+        OmegaConf.clear_resolver("test_update_intermediate")
+
+    assert OmegaConf.to_container(cfg, resolve=False) == expected
+    assert calls == 0
 
 
 @mark.parametrize(


### PR DESCRIPTION

Follow intermediate node-interpolation chains that end at existing config containers while applying nested updates. Mutate the resolved target while preserving the interpolation, and avoid invoking custom resolvers during traversal.

Cover dict, list, tuple, typed, chained, relative, dynamic, invalid, and permission-controlled interpolation cases. Document the behavior and add a release fragment.

Fixes #1329
