### PR TITLE
Support Literal annotations in structured config unions

### DIFF
--- a/docs/source/structured_config.rst
+++ b/docs/source/structured_config.rst
@@ -261,7 +261,7 @@ Literal types
 ^^^^^^^^^^^^^
 
 ``typing.Literal`` can be used when a field must be exactly one of a fixed set
-of values. Literal annotations are also supported inside containers.
+of values. Literal annotations are also supported inside containers and unions.
 
 .. doctest::
 
@@ -431,7 +431,7 @@ Unions
 ^^^^^^
 
 You can use `typing.Union <https://docs.python.org/3/library/typing.html#typing.Union>`_
-to annotate unions of :ref:`simple_types`. 
+to combine supported simple types, ``Literal`` annotations, and typed container types.
 
 .. doctest::
 

--- a/news/1271.feature
+++ b/news/1271.feature
@@ -1,0 +1,1 @@
+Support ``Literal[...]`` annotations as members of unions in structured configs.

--- a/omegaconf/_utils.py
+++ b/omegaconf/_utils.py
@@ -731,12 +731,14 @@ def is_tuple_annotation(type_: Any) -> bool:
 
 
 def is_supported_union_annotation(obj: Any) -> bool:
-    """Primitives and typed List/Dict containers are supported in Unions."""
+    """Primitives, literals, and typed containers are supported in Unions."""
     if not is_union_annotation(obj):
         return False
     args = obj.__args__
     return all(
-        is_primitive_type_annotation(arg) or is_container_annotation(arg)
+        is_primitive_type_annotation(arg)
+        or is_literal_annotation(arg)
+        or is_container_annotation(arg)
         for arg in args
     )
 
@@ -744,6 +746,14 @@ def is_supported_union_annotation(obj: Any) -> bool:
 def is_literal_annotation(type_: Any) -> bool:
     origin = getattr(type_, "__origin__", None)
     return origin is Literal
+
+
+def type_hint_contains_none_literal(type_: Any) -> bool:
+    if is_literal_annotation(type_):
+        return any(arg is None for arg in type_.__args__)
+    return is_union_annotation(type_) and any(
+        type_hint_contains_none_literal(arg) for arg in type_.__args__
+    )
 
 
 def is_dict_subclass(type_: Any) -> bool:

--- a/omegaconf/base.py
+++ b/omegaconf/base.py
@@ -34,6 +34,7 @@ from ._utils import (
     is_union_annotation,
     is_valid_value_annotation,
     split_key,
+    type_hint_contains_none_literal,
     type_str,
 )
 from .errors import (
@@ -979,13 +980,16 @@ class UnionNode(Box):
         type_hint = self._metadata.type_hint
 
         value = _get_value(value)
-        if _is_special(value):
+        if _is_special(value) and not (
+            value is None
+            and not self._is_optional()
+            and type_hint_contains_none_literal(ref_type)
+        ):
             assert isinstance(value, (str, NoneType))
-            if value is None:
-                if not self._is_optional():
-                    raise ValidationError(
-                        f"Value '$VALUE' is incompatible with type hint '{type_str(type_hint)}'"
-                    )
+            if value is None and not self._is_optional():
+                raise ValidationError(
+                    f"Value '$VALUE' is incompatible with type hint '{type_str(type_hint)}'"
+                )
             self.__dict__["_content"] = value
         elif isinstance(value, (list, tuple, ListConfig, TupleConfig)):
             sequence_candidates = [

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -37,6 +37,7 @@ from ._utils import (
     is_primitive_dict,
     is_structured_config,
     is_structured_config_frozen,
+    type_hint_contains_none_literal,
     type_str,
 )
 from .base import Box, Container, ContainerMetadata, DictKeyType, Node
@@ -263,7 +264,15 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
             else:
                 field_is_optional = self._is_optional()
 
-            if not field_is_optional:
+            target = self._get_node(key) if key is not None else self
+            target_type = (
+                self._metadata.element_type
+                if target is None
+                else target._metadata.ref_type
+            )
+            if not field_is_optional and not type_hint_contains_none_literal(
+                target_type
+            ):
                 self._format_and_raise(
                     key=key,
                     value=value,

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -29,6 +29,7 @@ from ._utils import (
     is_int,
     is_primitive_list,
     is_structured_config,
+    type_hint_contains_none_literal,
     type_str,
 )
 from .base import Box, ContainerMetadata, Node
@@ -105,7 +106,11 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
             target = self._get_node(key)
             if target is not None:
                 assert isinstance(target, Node)
-                if value is None and not target._is_optional():
+                if (
+                    value is None
+                    and not target._is_optional()
+                    and not type_hint_contains_none_literal(target._metadata.ref_type)
+                ):
                     raise ValidationError(
                         "$FULL_KEY is not optional and cannot be assigned None"
                     )
@@ -122,7 +127,11 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
             )
             value_type = OmegaConf.get_type(value)
 
-            if (value_is_none and not is_optional) or (
+            if (
+                value_is_none
+                and not is_optional
+                and not type_hint_contains_none_literal(target_type)
+            ) or (
                 is_structured_config(target_type)
                 and not value_is_none
                 and value_type is not None

--- a/omegaconf/nodes.py
+++ b/omegaconf/nodes.py
@@ -566,8 +566,18 @@ class LiteralNode(ValueNode):  # lgtm [py/missing-equals] : Intentional.
             ),
         )
 
+    def validate_and_convert(self, value: Any) -> Any:
+        if value is None and any(field is None for field in self.ref_type.__args__):
+            return self.validate_and_convert_to_literal(
+                ref_type=self.ref_type, value=value
+            )
+        return super().validate_and_convert(value)
+
     def _validate_and_convert_impl(self, value: Any) -> Any:
         return self.validate_and_convert_to_literal(ref_type=self.ref_type, value=value)
+
+    def _strict_validate_type(self, value: Any) -> None:
+        self.validate_and_convert_to_literal(ref_type=self.ref_type, value=value)
 
     @staticmethod
     def validate_and_convert_to_literal(ref_type: Any, value: Any) -> Any:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -667,6 +667,12 @@ def test_literal_node_type_mismatch() -> None:
         LiteralNode(ref_type=Literal[0], value=False)
 
 
+def test_literal_node_accepts_none_literal() -> None:
+    node = LiteralNode(ref_type=Literal[None], value=None, is_optional=False)
+
+    assert node._value() is None
+
+
 @mark.parametrize(
     "ref_type,value",
     [

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -1,11 +1,68 @@
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Dict, List, Literal, Union
 
 from pytest import mark, param, raises
 
 from omegaconf import OmegaConf, UnionNode, ValidationError
 from omegaconf._utils import _get_value
 from tests import Color
+
+
+@dataclass
+class LiteralOrIntConfig:
+    value: Union[Literal["auto", "manual"], int] = "auto"
+
+
+@dataclass
+class NoneLiteralOrIntConfig:
+    value: Union[Literal[None], int] = None
+    sequence: List[Union[Literal[None], int]] = field(default_factory=lambda: [None, 1])
+    mapping: Dict[str, Union[Literal[None], int]] = field(
+        default_factory=lambda: {"none": None, "int": 1}
+    )
+
+
+def test_structured_config_union_with_literal_creation() -> None:
+    cfg = OmegaConf.structured(LiteralOrIntConfig)
+
+    assert cfg.value == "auto"
+
+
+def test_structured_config_union_with_literal_assignment() -> None:
+    cfg = OmegaConf.structured(LiteralOrIntConfig)
+
+    cfg.value = "manual"
+    assert cfg.value == "manual"
+
+    cfg.value = 10
+    assert cfg.value == 10
+
+    with raises(ValidationError):
+        cfg.value = "invalid"
+
+
+def test_structured_config_union_with_none_literal_creation() -> None:
+    cfg = OmegaConf.structured(NoneLiteralOrIntConfig)
+
+    assert cfg.value is None
+    assert cfg.sequence == [None, 1]
+    assert cfg.mapping == {"none": None, "int": 1}
+
+
+def test_structured_config_union_with_none_literal_assignment() -> None:
+    cfg = OmegaConf.structured(NoneLiteralOrIntConfig)
+
+    cfg.value = 10
+    cfg.value = None
+    cfg.sequence.append(None)
+    cfg.sequence[1] = None
+    cfg.mapping["int"] = None
+    cfg.mapping["new"] = None
+
+    assert cfg.value is None
+    assert cfg.sequence == [None, None, None]
+    assert cfg.mapping == {"none": None, "int": None, "new": None}
 
 
 @mark.parametrize(


### PR DESCRIPTION
## Summary

- support `Literal[...]` annotations as members of structured-config unions
- preserve exact literal validation under unions' no-conversion policy
- support explicit `Literal[None]` members during scalar and nested-container creation and updates
- document the supported combination and add regression coverage and a release fragment

## Root cause

`is_supported_union_annotation()` accepted primitive and container members but rejected `Literal[...]`. Once admitted, literal candidates also needed strict literal validation because `UnionNode` disables conversion. Explicit `Literal[None]` additionally crossed special-value and container-level optionality checks before candidate dispatch; those checks now recognize only annotations that explicitly contain a None literal.

## Validation

- focused node and union tests — 1,054 passed
- full pytest suite — 8,457 passed, 362 skipped
- docs HTML build and 463 doctests — passed
- Ruff format and lint — passed
- Pyrefly — zero errors

Fixes #1271