### PR TITLE
fix: keep key context on OmegaConf.resolve() interpolation errors

### DIFF
--- a/news/1330.bugfix
+++ b/news/1330.bugfix
@@ -1,0 +1,1 @@
+Keep the failing key and object type on interpolation errors raised through `OmegaConf.resolve()`, so they match the errors raised by direct node access.

--- a/omegaconf/_impl.py
+++ b/omegaconf/_impl.py
@@ -22,7 +22,13 @@ def _resolve_container_value(cfg: Container, key: Any) -> None:
     node = cfg._get_child(key)
     assert isinstance(node, Node)
     if node._is_interpolation():
-        resolved = node._dereference_node()
+        try:
+            resolved = node._dereference_node()
+        except Exception as e:
+            # Attach the same key/object_type context that direct node access
+            # reports, so errors surfaced through OmegaConf.resolve() stay
+            # diagnosable.
+            cfg._format_and_raise(key=key, value=None, cause=e)
         if isinstance(resolved, Container):
             _resolve(resolved)
         if isinstance(resolved, InterpolationResultNode):

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -572,6 +572,20 @@ def test_resolve_raises_on_resolver_arg_to_missing(restore_resolvers: Any) -> No
         OmegaConf.resolve(cfg)
 
 
+def test_resolve_error_keeps_key_and_object_type() -> None:
+    """https://github.com/omry/omegaconf/issues/1330"""
+    cfg = OmegaConf.structured(StructuredWithMissing)
+    cfg.num = "${no_such_key}"
+
+    with raises(InterpolationKeyError) as direct:
+        cfg.num
+    with raises(InterpolationKeyError) as resolved:
+        OmegaConf.resolve(cfg)
+
+    assert resolved.value.full_key == direct.value.full_key == "num"
+    assert resolved.value.object_type is direct.value.object_type
+
+
 def test_resolve_does_not_raise_when_resolver_returns_dict_config(
     restore_resolvers: Any,
 ) -> None:

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -583,7 +583,8 @@ def test_resolve_error_keeps_key_and_object_type() -> None:
         OmegaConf.resolve(cfg)
 
     assert resolved.value.full_key == direct.value.full_key == "num"
-    assert resolved.value.object_type is direct.value.object_type
+    assert direct.value.object_type is StructuredWithMissing
+    assert resolved.value.object_type is StructuredWithMissing
 
 
 def test_resolve_does_not_raise_when_resolver_returns_dict_config(


### PR DESCRIPTION
## Motivation

`OmegaConf.resolve()` dropped the diagnostic context from interpolation errors: the same failure reported `full_key` and `object_type` on direct node access, but arrived with both set to `None` when raised from `resolve()`. This is visible through Hydra's `instantiate()`, which resolves a copy of its config.

`_resolve_container_value` called `node._dereference_node()` outside the `_format_and_raise` wrapper that direct access (`DictConfig.__getattr__`) uses, so the exception escaped before the key/type context was attached. Dereference errors are now routed through `cfg._format_and_raise`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/omry/omegaconf/blob/main/CONTRIBUTING.md)?

Yes

### For any non-trivial change: is there an issue or design discussion where maintainers agreed on the direction?

#1330 describes the bug and the expected behavior. The change is a one-branch fix that makes `resolve()` match the existing direct-access behavior; no new API or semantics.

## Test Plan

`tests/test_omegaconf.py::test_resolve_error_keeps_key_and_object_type` asserts that the error from `OmegaConf.resolve()` carries the same `full_key` and `object_type` as the error from direct access. It fails on `main` (`None != 'num'`) and passes with the fix. No special setup required.

Full suite: 8514 passed, 362 skipped (baseline 8513 passed, same 5 pre-existing errors from a missing `pytest-mock` in my environment).

## Fixes

Fixes #1330

## Related PRs

N/A
