### PR TITLE
Support interpolation to integer keys

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -80,6 +80,13 @@ Here is an example of various supported key types:
 
 OmegaConf supports ``str``, ``int``, ``bool``, ``float`` ``bytes``, and ``Enum`` as dictionary key types.
 
+Integer keys can be referenced by interpolation and key-path selection in the
+same way that integer path elements select list indices. For example, ``${1}``
+can reference either the integer key ``1`` or the string key ``"1"``. A
+``DictConfig`` cannot contain both forms because that would make the
+interpolation ambiguous. This fallback applies only to integers; float,
+boolean, and enum keys are not inferred from string path elements.
+
 From a list
 ^^^^^^^^^^^
 
@@ -831,6 +838,8 @@ OmegaConf.select
 ^^^^^^^^^^^^^^^^
 ``OmegaConf.select()`` allows you to select a config node or value, using either a dot-notation or brackets to denote sub-keys.
 Keys containing literal dots, brackets, or ``=`` can be escaped with a backslash (see :ref:`keypath-escaping`).
+String path elements that represent integers can also select integer dictionary
+keys, consistent with integer list-index selection.
 
 .. doctest::
 
@@ -853,6 +862,7 @@ Keys containing literal dots, brackets, or ``=`` can be escaped with a backslash
     ... }
     >>> assert OmegaConf.select(cfg, "foo.bar.zonk") == 10    # dots
     >>> assert OmegaConf.select(cfg, "foo[bar][zonk]") == 10  # brackets
+    >>> assert OmegaConf.select(OmegaConf.create({1: "one"}), "1") == "one"
     >>> assert OmegaConf.select(cfg, "no_such_key", default=99) == 99
     >>> assert OmegaConf.select(cfg, "foo.missing") is None
     >>> assert OmegaConf.select(cfg, "foo.missing", default=99) == 99

--- a/news/651.bugfix
+++ b/news/651.bugfix
@@ -1,0 +1,1 @@
+Integer interpolation segments and integer-looking string paths used by ``OmegaConf.select()`` and ``OmegaConf.update()`` can now resolve integer dictionary keys. Configurations reject ambiguous pairs such as ``1`` and ``"1"``.

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -34,6 +34,7 @@ from ._utils import (
     get_value_kind,
     is_container_annotation,
     is_dict,
+    is_int,
     is_primitive_dict,
     is_structured_config,
     is_structured_config_frozen,
@@ -334,7 +335,33 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
 
     def __set_impl(self, key: DictKeyType, value: Any) -> None:
         key = self._validate_and_normalize_key(key)
+        self._validate_non_ambiguous_key(key)
         self._set_item_impl(key, value)
+
+    def _validate_non_ambiguous_key(self, key: DictKeyType) -> None:
+        content = self.__dict__["_content"]
+        if self._metadata.key_type is not Any or not isinstance(content, dict):
+            return
+
+        conflicting_key: Optional[DictKeyType] = None
+        if isinstance(key, str) and is_int(key):
+            numeric_key = int(key)
+            node = content.get(numeric_key)
+            if (
+                str(numeric_key) == key
+                and isinstance(node, Node)
+                and type(node._key()) is int
+            ):
+                conflicting_key = numeric_key
+        elif type(key) is int and str(key) in content:
+            node = content.get(key)
+            if not isinstance(node, Node) or type(node._key()) is int:
+                conflicting_key = str(key)
+
+        if conflicting_key is not None:
+            raise KeyValidationError(
+                f"Conflicting integer and string keys: {conflicting_key!r} and {key!r}"
+            )
 
     # hide content while inspecting in debugger
     def __dir__(self) -> Iterable[str]:

--- a/omegaconf/grammar_visitor.py
+++ b/omegaconf/grammar_visitor.py
@@ -86,10 +86,12 @@ class GrammarVisitor(OmegaConfGrammarParserVisitor):
         if isinstance(child, OmegaConfGrammarParser.InterpolationContext):
             child_text = child.getText()
             res = _get_value(self.visitInterpolation(child))
-            if not isinstance(res, str):
+            if type(res) is int:
+                return str(res)
+            elif not isinstance(res, str):
                 raise InterpolationResolutionError(
                     f"The following interpolation is used to denote a config key and "
-                    f"thus should return a string, but instead returned `{res}` of "
+                    f"thus should return a string or integer, but instead returned `{res}` of "
                     f"type `{type(res)}`: {child_text}"
                 )
             return res

--- a/omegaconf/omegaconf.py
+++ b/omegaconf/omegaconf.py
@@ -1423,7 +1423,9 @@ class OmegaConf:
         )
 
         last_key: Union[str, int] = last
-        if OmegaConf.is_sequence(root):
+        if OmegaConf.is_dict(root):
+            _, last_key = _select_one(root, last, throw_on_missing=False)
+        elif OmegaConf.is_sequence(root):
             last_key = int(last)
 
         ctx = flag_override(root, "struct", False) if force_add else nullcontext()
@@ -1438,8 +1440,10 @@ class OmegaConf:
                         return
 
             if OmegaConf.is_dict(root):
-                assert isinstance(last_key, str)
-                root.__setattr__(last_key, value)
+                if isinstance(last_key, int):
+                    root.__setitem__(last_key, value)
+                else:
+                    root.__setattr__(last_key, value)
             elif OmegaConf.is_sequence(root):
                 assert isinstance(last_key, int)
                 root.__setitem__(last_key, value)
@@ -1973,6 +1977,14 @@ def _select_one(
     if isinstance(c, DictConfig):
         assert isinstance(ret_key, str)
         val = c._get_child(ret_key, validate_access=False)
+        if val is None and is_int(ret_key):
+            numeric_key = int(ret_key)
+            raw_node = c._get_node(numeric_key, validate_access=False)
+            if isinstance(raw_node, Node) and type(raw_node._key()) is int:
+                val = c._get_child(numeric_key, validate_access=False)
+                ret_key = numeric_key
+            else:
+                val = None
     elif isinstance(c, (ListConfig, TupleConfig)):
         assert isinstance(ret_key, str)
         if not is_int(ret_key):

--- a/tests/interpolation/test_interpolation.py
+++ b/tests/interpolation/test_interpolation.py
@@ -2,7 +2,7 @@ import copy
 import re
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Tuple
+from typing import Any, Tuple, Union
 
 from pytest import mark, param, raises
 
@@ -212,6 +212,59 @@ def test_resolve_key_and_root(
 def test_interpolation_after_copy(copy_func: Any, data: Any, key: Any) -> None:
     dict_cfg = OmegaConf.create(data)
     assert copy_func(dict_cfg._get_node(key))._dereference_node() == 10
+
+
+@mark.parametrize("key", [param(1, id="int"), param("1", id="str")])
+def test_interpolation_to_integer_key(key: Any) -> None:
+    cfg = OmegaConf.create({key: "value", "ref": "${1}"})
+
+    assert cfg.ref == "value"
+
+
+@mark.parametrize("resolution", [param(224, id="int"), param("224", id="str")])
+def test_interpolation_with_nested_integer_key(resolution: Any) -> None:
+    cfg = OmegaConf.create(
+        {
+            "anchors": {"imagenet": {resolution: {"data": "value"}}},
+            "dataset": "imagenet",
+            "resolution": 224,
+            "ref": "${anchors.${dataset}.${resolution}.data}",
+        }
+    )
+
+    assert cfg.ref == "value"
+
+
+def test_interpolation_with_nested_integer_key_from_yaml() -> None:
+    cfg = OmegaConf.create(
+        dedent(
+            """
+            anchors:
+              coco2014:
+                224:
+                  data: [1, 2, 3]
+            dataset: coco2014
+            resolution: 224
+            ref: ${anchors.${dataset}.${resolution}.data}
+            """
+        )
+    )
+
+    assert cfg.ref == [1, 2, 3]
+
+
+def test_interpolation_to_typed_integer_key() -> None:
+    values = DictConfig({1: "value"}, key_type=int)
+    cfg = OmegaConf.create({"values": values, "ref": "${values.1}"})
+
+    assert cfg.ref == "value"
+
+
+def test_interpolation_to_union_typed_integer_key() -> None:
+    values = DictConfig({1: 10}, element_type=Union[int, str])
+    cfg = OmegaConf.create({"values": values, "ref": "${values.1}"})
+
+    assert cfg.ref == 10
 
 
 def test_resolve_interpolation_without_parent() -> None:

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -988,6 +988,49 @@ def test_creation_with_invalid_key() -> None:
         OmegaConf.create({object(): "a"})
 
 
+@mark.parametrize(
+    "items",
+    [
+        param([(1, "numeric"), ("1", "string")], id="int-first"),
+        param([("1", "string"), (1, "numeric")], id="str-first"),
+    ],
+)
+def test_creation_with_ambiguous_integer_key(items: Any) -> None:
+    with raises(KeyValidationError, match="integer and string keys"):
+        OmegaConf.create(dict(items))
+
+
+@mark.parametrize(
+    ("initial_key", "new_key"),
+    [param(1, "1", id="int-first"), param("1", 1, id="str-first")],
+)
+def test_setitem_with_ambiguous_integer_key(initial_key: Any, new_key: Any) -> None:
+    cfg = OmegaConf.create({initial_key: "initial"})
+
+    with raises(KeyValidationError, match="integer and string keys"):
+        cfg[new_key] = "new"
+
+
+def test_float_and_string_keys_are_not_ambiguous() -> None:
+    cfg = OmegaConf.create({1.5: "float", "1.5": "string"})
+
+    assert cfg[1.5] == "float"
+    assert cfg["1.5"] == "string"
+
+
+@mark.parametrize("stored_key", [param(True, id="bool"), param(1.0, id="float")])
+def test_setitem_integer_key_updates_equal_non_integer_key(stored_key: Any) -> None:
+    cfg = OmegaConf.create({stored_key: "initial", "1": "string"})
+
+    cfg[1] = "updated"
+
+    assert cfg[stored_key] == "updated"
+    assert cfg["1"] == "string"
+    node = cfg._get_node(stored_key)
+    assert node is not None
+    assert type(node._key()) is type(stored_key)
+
+
 def test_setitem_with_invalid_key() -> None:
     cfg = OmegaConf.create()
     with raises(KeyValidationError):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,5 +1,5 @@
 from contextlib import AbstractContextManager
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from pytest import mark, param, raises, warns
 
@@ -7,6 +7,7 @@ from omegaconf import DictConfig, ListConfig, MissingMandatoryValue, OmegaConf
 from omegaconf._impl import select_value
 from omegaconf._utils import _ensure_container
 from omegaconf.errors import InterpolationKeyError
+from tests import Color
 
 
 def _register_resolver(register_func: Any, name: str, resolver: Any) -> None:
@@ -35,6 +36,16 @@ class TestSelect:
             param({"a": ListConfig(None)}, "a.b", None, id="dict:nesting_into_none"),
             # value returned
             param({"c": 1}, "c", 1, id="dict:int"),
+            param({1: "one"}, "1", "one", id="dict:integer-key"),
+            param(
+                DictConfig({1: 10}, element_type=Union[int, str]),
+                "1",
+                10,
+                id="dict:union-typed-integer-key",
+            ),
+            param({True: "bool"}, "1", None, id="dict:bool-key-not-coerced"),
+            param({1.5: "float"}, r"1\.5", None, id="dict:float-key-not-coerced"),
+            param({Color.RED: "red"}, "RED", None, id="dict:enum-key-not-coerced"),
             param({"a": {"v": 1}}, "a.v", 1, id="dict:int"),
             param({"a": {"v": 1}}, "a", {"v": 1}, id="dict:dict"),
             param({"missing": "???"}, "missing", None, id="dict:missing"),
@@ -87,6 +98,12 @@ class TestSelect:
                 OmegaConf.select(cfg, key)
         else:
             assert OmegaConf.select(cfg, key) == expected
+
+    def test_can_select_integer_key(self, struct: Optional[bool]) -> None:
+        cfg = _ensure_container({1: "one"})
+        OmegaConf.set_struct(cfg, struct)
+
+        assert OmegaConf.can_select(cfg, "1")
 
     @mark.parametrize(
         "register_func",

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Union
 
 from pytest import mark, param, raises
 
@@ -18,6 +18,7 @@ from tests import Group, Package, User
     [
         # dict
         param({"a": "b"}, "a", "c", {"a": "c"}, id="replace:string"),
+        param({1: "old"}, "1", "new", {1: "new"}, id="replace:integer-key"),
         param({"a": "b"}, "c", "d", {"a": "b", "c": "d"}, id="add:string"),
         param({"a": "b"}, "c", None, {"a": "b", "c": None}, id="none_value"),
         param({}, "a", {}, {"a": {}}, id="dict:value:empty_dict"),
@@ -55,6 +56,13 @@ from tests import Group, Package, User
             {"c": 2},
             {"a": {"b": 1, "c": 2}},
             id="dict_value:merge",
+        ),
+        param(
+            {1: {"a": 1}},
+            "1",
+            {"b": 2},
+            {1: {"a": 1, "b": 2}},
+            id="dict_value:integer-key:merge",
         ),
         # list
         param({"a": [1, 2]}, "a", [2, 3], {"a": [2, 3]}, id="list:replace"),
@@ -191,6 +199,14 @@ def test_update_list_index_error() -> None:
         OmegaConf.update(c, "4", "abc")
 
     assert c == [1, 2, 3]
+
+
+def test_update_union_typed_integer_key() -> None:
+    cfg = DictConfig({1: 10}, element_type=Union[int, str])
+
+    OmegaConf.update(cfg, "1", 20)
+
+    assert cfg == {1: 20}
 
 
 def test_update_merge_by_default() -> None:


### PR DESCRIPTION
## Summary

- Allow integer interpolation segments and string key-path elements to select integer `DictConfig` keys.
- Preserve exact string-key precedence and reject ambiguous canonical pairs such as `1` and `"1"`.
- Keep the fallback integer-only: booleans, floats, and enums are not inferred from string path elements.
- Document the behavior and add a release fragment.

## Why

Integer keys are already valid dictionary keys, but interpolation and selection paths could not reach them. This also prevented nested interpolation patterns such as `${anchors.${dataset}.${resolution}.data}` when `resolution` identifies an integer key.

## Verification

- `.venv/bin/pytest tests/interpolation/test_interpolation.py tests/test_basic_ops_dict.py tests/test_select.py` — 814 passed
- `.venv/bin/pytest` — 8,552 passed, 362 skipped
- `.venv/bin/nox -s lint`
- `.venv/bin/nox -s docs` — HTML build and 481 doctests passed

Fixes #651