### PR TITLE
Make OmegaConf containers unhashable

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -309,6 +309,25 @@ Manipulation
     >>> conf.database = {'hostname': 'database01', 'port': 3306}
 
 
+Hashing
+^^^^^^^
+
+OmegaConf containers are unhashable because their values can change. They
+cannot be used as dictionary keys or set elements. If you currently use
+containers this way, migrate to an application-defined stable key. OmegaConf
+does not provide a hashable representation that preserves all config semantics.
+Read-only configs remain unhashable because the read-only flag is reversible
+and interpolations or resolvers can change their effective values.
+
+.. doctest::
+
+    >>> conf = OmegaConf.create({"key": "value"})
+    >>> hash(conf)
+    Traceback (most recent call last):
+    ...
+    TypeError: unhashable type: 'DictConfig'
+
+
 Serialization
 -------------
 OmegaConf objects can be saved and loaded with OmegaConf.save() and OmegaConf.load().

--- a/news/1333.api_change
+++ b/news/1333.api_change
@@ -1,0 +1,1 @@
+Make ``DictConfig`` and ``ListConfig`` unhashable, preventing their use as dictionary keys or set elements.

--- a/omegaconf/dictconfig.py
+++ b/omegaconf/dictconfig.py
@@ -70,6 +70,7 @@ def _make_key_suggestion(key: Any, available: Iterable) -> str:
 class DictConfig(BaseContainer, MutableMapping[Any, Any]):
     _metadata: ContainerMetadata
     _content: Union[Dict[DictKeyType, Node], None, str]
+    __hash__ = None  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -660,9 +661,6 @@ class DictConfig(BaseContainer, MutableMapping[Any, Any]):
         if x is not NotImplemented:
             return not x
         return NotImplemented
-
-    def __hash__(self) -> int:
-        return hash(str(self))
 
     def _promote(self, type_or_prototype: Optional[Type[Any]]) -> None:
         """

--- a/omegaconf/listconfig.py
+++ b/omegaconf/listconfig.py
@@ -47,6 +47,7 @@ from .errors import (
 
 class ListConfig(BaseContainer, MutableSequence[Any]):
     _content: Union[List[Node], None, str]
+    __hash__ = None  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -522,9 +523,6 @@ class ListConfig(BaseContainer, MutableSequence[Any]):
         if x is not NotImplemented:
             return not x
         return NotImplemented
-
-    def __hash__(self) -> int:
-        return hash(str(self))
 
     def __iter__(self) -> Iterator[Any]:
         return self._iter_ex(resolve=True)

--- a/tests/test_basic_ops_dict.py
+++ b/tests/test_basic_ops_dict.py
@@ -871,12 +871,13 @@ def test_dir(cfg: Any, key: Any, expected: Any) -> None:
         assert dir(c._get_node(key)) == expected
 
 
-def test_hash() -> None:
-    c1 = OmegaConf.create({"a": 10})
-    c2 = OmegaConf.create({"a": 10})
-    assert hash(c1) == hash(c2)
-    c2.a = 20
-    assert hash(c1) != hash(c2)
+def test_unhashable() -> None:
+    cfg = OmegaConf.create({"a": 10})
+    with raises(TypeError, match="unhashable"):
+        hash(cfg)
+    OmegaConf.set_readonly(cfg, True)
+    with raises(TypeError, match="unhashable"):
+        hash(cfg)
 
 
 @mark.parametrize("default", ["default", 0, None])

--- a/tests/test_basic_ops_list.py
+++ b/tests/test_basic_ops_list.py
@@ -858,12 +858,13 @@ def test_append_throws_not_changing_list() -> None:
     assert c == [iv]
 
 
-def test_hash() -> None:
-    c1 = OmegaConf.create([10])
-    c2 = OmegaConf.create([10])
-    assert hash(c1) == hash(c2)
-    c2[0] = 20
-    assert hash(c1) != hash(c2)
+def test_unhashable() -> None:
+    cfg = OmegaConf.create([10])
+    with raises(TypeError, match="unhashable"):
+        hash(cfg)
+    OmegaConf.set_readonly(cfg, True)
+    with raises(TypeError, match="unhashable"):
+        hash(cfg)
 
 
 @mark.parametrize(


### PR DESCRIPTION
## Summary

- make `DictConfig` and `ListConfig` unhashable, matching `TupleConfig`
- replace the old mutable value-based hashes with Python's standard `__hash__ = None` behavior
- document the behavior, including read-only configs
- update regression coverage and add the 2.4 API-change fragment

## Why

`DictConfig` and `ListConfig` used `hash(str(self))` despite being mutable and value-comparable. Mutation could change the hash of an existing dictionary key, and interpolation-aware equality could consider two configs equal while their unresolved string representations produced different hashes. Both behaviors violate Python's hashing contract.

OmegaConf 2.4 already contains significant compatibility changes, so this correctness fix is applied directly rather than going through a deprecation period.

## Impact

Calling `hash()`, using a config as a dictionary key, or inserting one into a set now raises `TypeError`. This also applies to read-only configs because the flag is reversible and effective values can change through interpolations or resolvers. Scalar node hashing is unchanged.

## Validation

- full test suite: 8,561 passed, 362 skipped
- documentation build and 483 doctests
- Pyrefly
- Ruff lint and formatting

Closes #1333